### PR TITLE
Matrix crdt sync issues

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": true,
   "useWorkspaces": true,
-  "version": "1.4.6"
+  "version": "1.4.7"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15069,7 +15069,7 @@
     },
     "packages/db": {
       "name": "@eweser/db",
-      "version": "1.4.6",
+      "version": "1.4.7",
       "license": "MIT",
       "dependencies": {
         "@matrix-org/olm": "^3.2.14",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eweser/db",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "eweser-db core database",
   "keywords": [
     "user-owned",

--- a/packages/db/src/utils/connection/connectMatrixProvider.ts
+++ b/packages/db/src/utils/connection/connectMatrixProvider.ts
@@ -41,20 +41,19 @@ export function connectMatrixProvider(
       }
 
       if (!room?.ydoc) throw new Error('room.ydoc not found');
-      const doc = room.ydoc;
 
-      logger('start connectMatrixProvider', { room, doc });
+      logger('start connectMatrixProvider', { room, doc: room.ydoc });
       // quit early if already connected
       if (
-        doc.isLoaded &&
+        room.ydoc.isLoaded &&
         room.matrixProvider?.canWrite &&
         // @ts-expect-error
         !room.matrixProvider.disposed
       ) {
         logger('matrix provider already connected', {
-          doc,
+          doc: room.ydoc,
           room,
-          isLoaded: doc.isLoaded,
+          isLoaded: room.ydoc.isLoaded,
           canWrite: room.matrixProvider?.canWrite,
         });
         room.connectStatus = 'ok';
@@ -68,7 +67,7 @@ export function connectMatrixProvider(
 
       room.matrixProvider = newMatrixProvider(
         _db.matrixClient,
-        doc,
+        room.ydoc,
         room.roomId
           ? { type: 'id', id: room.roomId }
           : { type: 'alias', alias: room.roomAlias },
@@ -77,13 +76,13 @@ export function connectMatrixProvider(
 
       room.matrixProvider.onDocumentAvailable((e) => {
         room.connectStatus = 'ok';
-        logger('onDocumentAvailable', { room, doc, e });
+        logger('onDocumentAvailable', { room, doc: room.ydoc, e });
         return resolve(true);
       });
 
       room.matrixProvider.onDocumentUnavailable((e) => {
         room.connectStatus = 'disconnected';
-        logger('onDocumentUnavailable', { room, doc, e });
+        logger('onDocumentUnavailable', { room, doc: room.ydoc, e });
         reject('onDocumentUnavailable');
       });
 

--- a/packages/db/src/utils/connection/initializeDoc.ts
+++ b/packages/db/src/utils/connection/initializeDoc.ts
@@ -4,9 +4,10 @@ import { Doc } from 'yjs';
 import type { Document, YDoc } from '../../types';
 
 export const initializeDocAndLocalProvider = async <T extends Document>(
-  aliasSeed: string
+  aliasSeed: string,
+  existingDoc?: YDoc<T>
 ): Promise<{ ydoc: YDoc<T>; localProvider: IndexeddbPersistence }> => {
-  const ydoc = new Doc() as YDoc<T>;
+  const ydoc = existingDoc || (new Doc() as YDoc<T>);
   if (!ydoc) throw new Error('could not create doc');
 
   const localProvider = new IndexeddbPersistence(aliasSeed, ydoc as Doc);

--- a/packages/db/src/utils/connection/newMatrixProvider.ts
+++ b/packages/db/src/utils/connection/newMatrixProvider.ts
@@ -22,6 +22,12 @@ export const newMatrixProvider = (
   // This is the main code that sets up the connection between
   // yjs and Matrix. It creates a new MatrixProvider and
   // registers it to the `doc`.
+  const optionsToSet = {...options, writer: {...options?.writer}};
+if (!options?.writer?.flushInterval){
+// default is 500. setting this to a bit longer seems to help deliverability, otherwise the matrix server will throttle requests if it gets too many at once and never gets any through. This is especially a problem in react dev mode when events can often double-trigger
+  optionsToSet.writer.flushInterval = 1000
+}
+
   const newMatrixProvider = new MatrixProvider(
     doc as Doc,
     matrixClient,

--- a/packages/example-basic/src/AppBasic.tsx
+++ b/packages/example-basic/src/AppBasic.tsx
@@ -80,13 +80,13 @@ const NotesInternal = ({ notesRoom }: { notesRoom: Room<Note> }) => {
     Notes.sortByRecent(Notes.getUndeleted())
   );
 
-  const [selectedNote, setSelectedNote] = useState(notes[0]?._id);
+  const [selectedNote, setSelectedNote] = useState(Object.keys(Notes.sortByRecent(Notes.getUndeleted()))[0]);
 
   // listen for changes to the ydoc and update the state
   Notes.onChange((_event) => {
     const unDeleted = Notes.sortByRecent(Notes.getUndeleted());
     setNotes(unDeleted);
-    if (!notes[selectedNote] || notes[selectedNote]._deleted) {
+    if (!unDeleted[selectedNote]) {
       setSelectedNote(Object.keys(unDeleted)[0]);
     }
   });


### PR DESCRIPTION
The Matrix server was not handling 'send update' events, especially in development. It seems that development requests were triggering a throttle. Increasing the throttle from 500 to 100 ms ensured that updates were delivered eventually even with WebRTC off. With WebRTC on, the updates came in sooner. but this change makes sure updates are recorded to Matrix as well.