### PR TITLE
fix: use root-relative Dockerfile paths for Railway services

### DIFF
--- a/packages/aggregator/railway.toml
+++ b/packages/aggregator/railway.toml
@@ -1,5 +1,5 @@
 [build]
-dockerfilePath = "Dockerfile"
+dockerfilePath = "packages/aggregator/Dockerfile"
 buildCommand = ""
 
 [deploy]

--- a/packages/auth-pages/railway.toml
+++ b/packages/auth-pages/railway.toml
@@ -1,5 +1,5 @@
 [build]
-dockerfilePath = "Dockerfile"
+dockerfilePath = "packages/auth-pages/Dockerfile"
 buildCommand = ""
 
 [deploy]

--- a/packages/auth-server-hono/railway.toml
+++ b/packages/auth-server-hono/railway.toml
@@ -1,5 +1,5 @@
 [build]
-dockerfilePath = "Dockerfile"
+dockerfilePath = "packages/auth-server-hono/Dockerfile"
 buildCommand = ""
 
 [deploy]

--- a/packages/ewe-note/railway.toml
+++ b/packages/ewe-note/railway.toml
@@ -1,5 +1,5 @@
 [build]
-dockerfilePath = "Dockerfile"
+dockerfilePath = "packages/ewe-note/Dockerfile"
 buildCommand = ""
 
 [deploy]

--- a/packages/sync-server/railway.toml
+++ b/packages/sync-server/railway.toml
@@ -1,6 +1,8 @@
 [build]
-dockerfilePath = "Dockerfile"
+dockerfilePath = "packages/sync-server/Dockerfile"
 buildCommand = ""
 
 [deploy]
+healthcheckPath = "/"
+healthcheckTimeout = 30
 restartPolicyMaxRetries = 3

--- a/scripts/railway.mjs
+++ b/scripts/railway.mjs
@@ -19,6 +19,7 @@ const SERVICES = {
 const CONFIG_FILES = {
   'ewe-note': 'packages/ewe-note/railway.toml',
   aggregator: 'packages/aggregator/railway.toml',
+  'auth-api': 'packages/auth-server-hono/railway.toml',
   'sync-server': 'packages/sync-server/railway.toml',
   'auth-pages': 'packages/auth-pages/railway.toml',
 };


### PR DESCRIPTION
## Summary
Fix Railway monorepo service config so each service resolves its Dockerfile from repo root instead of looking for `/Dockerfile`.

## Changes
- Update per-service `railway.toml` files to use root-relative `dockerfilePath`:
  - `packages/auth-server-hono/Dockerfile`
  - `packages/sync-server/Dockerfile`
  - `packages/aggregator/Dockerfile`
  - `packages/auth-pages/Dockerfile`
  - `packages/ewe-note/Dockerfile`
- Add `auth-api` mapping in `scripts/railway.mjs` so redeploy helper binds the auth service to `packages/auth-server-hono/railway.toml` too.
- Add sync-server healthcheck defaults in `packages/sync-server/railway.toml` (`/`, timeout 30).

## Why
Railway service config is resolved from repository root; using `dockerfilePath = "Dockerfile"` caused all services to fail with `Dockerfile /Dockerfile does not exist` and could lead to fallback/wrong service build behavior.
