### PR TITLE
fix: remove root Railway build/deploy overrides in monorepo

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -1,12 +1,3 @@
 {
-  "$schema": "https://railway.app/railway.schema.json",
-  "build": {
-    "builder": "DOCKERFILE",
-    "dockerfilePath": "Dockerfile"
-  },
-  "deploy": {
-    "healthcheckPath": "/health",
-    "restartPolicyType": "ON_FAILURE",
-    "restartPolicyMaxRetries": 3
-  }
+  "$schema": "https://railway.app/railway.schema.json"
 }

--- a/railway.toml
+++ b/railway.toml
@@ -1,32 +1,10 @@
 # Railway configuration — EweserDB monorepo root
-# This file configures the default service (auth-api) when deploying from the root.
-# For a full multi-service deployment, add each package as a separate Railway service
-# pointing to the same repo with its own config file:
 #
-#   packages/auth-server-hono/railway.toml   → auth-api
-#   packages/sync-server/railway.toml        → sync-server
-#   packages/aggregator/railway.toml         → aggregator
-#   packages/auth-pages/railway.toml         → auth-pages
-#   packages/ewe-note/railway.toml           → ewe-note
+# Intentionally left without [build]/[deploy] overrides.
 #
-# Required environment variables (set in Railway dashboard):
-#   DATABASE_URL         — from Railway PostgreSQL plugin
-#   SERVER_SECRET        — openssl rand -hex 32
-#   BETTER_AUTH_SECRET   — openssl rand -hex 32
-#   SYNC_AUTH_SECRET     — openssl rand -hex 32
-#   WEBHOOK_SECRET       — openssl rand -hex 32
-#   BETTER_AUTH_BASE_URL — https://<your-railway-domain>
-#   AUTH_SERVER_DOMAIN   — <your-railway-domain>
-#   AUTH_SERVER_URL      — https://<your-railway-domain>
-#   SYNC_SERVER_URL      — wss://<your-railway-domain>/sync
-#   SYNC_PUBLIC_URL      — wss://<your-railway-domain>/sync
-
-[build]
-dockerfilePath = "packages/auth-server-hono/Dockerfile"
-buildCommand = ""
-
-[deploy]
-healthcheckPath = "/health"
-healthcheckTimeout = 120
-restartPolicyType = "ON_FAILURE"
-restartPolicyMaxRetries = 3
+# Why: this repository is deployed as multiple Railway services from one repo.
+# Per-service settings (or each service's own railway.toml via railwayConfigFile)
+# must decide Dockerfile path, health checks, and start behavior.
+#
+# If root-level build/deploy is hardcoded here, all services can accidentally
+# inherit auth-api settings (wrong Dockerfile, healthcheck path, predeploy command).


### PR DESCRIPTION
## Summary
Remove hardcoded root-level Railway build/deploy config that caused multi-service template deployments to inherit auth-api settings.

## Problem
When services were not explicitly bound to per-service `railway.toml` files, Railway read root config and could apply auth-api Dockerfile/healthcheck behavior to other services (e.g. sync-server building auth-server image).

## Changes
- `railway.toml`
  - Remove root `[build]` and `[deploy]` hardcoded values.
  - Keep only explanatory comments.
- `railway.json`
  - Remove root `build` and `deploy` blocks.
  - Keep only schema key.

## Why this is safe
Per-service config should live in each service's own settings (`RAILWAY_DOCKERFILE_PATH`, healthcheck, start command) or explicit per-service `railwayConfigFile` mapping. Root overrides are incorrect for this monorepo template model.
