### PR TITLE
Preserve MCP write scopes in HTTP route

### DIFF
--- a/packages/auth-server-hono/src/routes/mcp.test.ts
+++ b/packages/auth-server-hono/src/routes/mcp.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
+import type { AgentConfig as DbAgentConfig } from '../db/schema/agents.js';
 
 vi.mock('../env.js', () => ({
   env: {
@@ -34,7 +35,8 @@ vi.mock('../model/security-events.js', () => ({
   logSecurityEvent: vi.fn(),
 }));
 
-const { mcpRouter } = await import('./mcp.js');
+const { mcpRouter, filterRoomsForAgentConfig, mapDbAgentConfigForMcp } =
+  await import('./mcp.js');
 
 function makeApp() {
   const app = new Hono();
@@ -45,6 +47,98 @@ function makeApp() {
 describe('mcpRouter', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('preserves split read and write scopes when mapping DB agent configs', () => {
+    const tokenExpiresAt = new Date('2026-05-01T00:00:00.000Z');
+    const dbAgent: DbAgentConfig = {
+      id: 'agent-1',
+      userId: 'user-1',
+      name: 'Codex',
+      type: 'mcp',
+      endpoint: null,
+      allowedCollections: [],
+      allowedRooms: [],
+      readAllowedCollections: ['notes', 'conversations'],
+      readAllowedRooms: ['room-readable'],
+      writeAllowedCollections: ['conversations'],
+      writeAllowedRooms: ['room-conversations'],
+      writeAllowedFolderIds: ['folder-ai'],
+      writeAllowedPathPrefixes: ['AI/'],
+      permissions: 'read',
+      isActive: true,
+      tokenHash: 'token-hash',
+      tokenExpiresAt,
+      lastAccessAt: null,
+      createdAt: new Date('2026-04-28T00:00:00.000Z'),
+      updatedAt: null,
+    };
+
+    expect(mapDbAgentConfigForMcp(dbAgent)).toMatchObject({
+      id: 'agent-1',
+      userId: 'user-1',
+      name: 'Codex',
+      type: 'mcp',
+      allowedCollections: [],
+      allowedRooms: [],
+      readAllowedCollections: ['notes', 'conversations'],
+      readAllowedRooms: ['room-readable'],
+      writeAllowedCollections: ['conversations'],
+      writeAllowedRooms: ['room-conversations'],
+      writeAllowedFolderIds: ['folder-ai'],
+      writeAllowedPathPrefixes: ['AI/'],
+      permissions: 'read',
+      isActive: true,
+      tokenExpiresAt: tokenExpiresAt.toISOString(),
+    });
+  });
+
+  it('filters MCP session rooms with explicit read scope before legacy scope', () => {
+    const agentConfig = {
+      id: 'agent-1',
+      userId: 'user-1',
+      name: 'Codex',
+      type: 'mcp' as const,
+      allowedCollections: [],
+      allowedRooms: [],
+      readAllowedCollections: ['conversations'],
+      readAllowedRooms: ['room-conversations'],
+      writeAllowedCollections: ['conversations'],
+      writeAllowedRooms: ['room-conversations'],
+      permissions: 'read' as const,
+      isActive: true,
+      tokenExpiresAt: null,
+    };
+
+    const rooms = filterRoomsForAgentConfig(
+      [
+        {
+          id: 'room-notes',
+          name: 'Notes',
+          collectionKey: 'notes',
+          syncUrl: null,
+          syncBaseUrl: null,
+        },
+        {
+          id: 'room-conversations',
+          name: 'Conversations',
+          collectionKey: 'conversations',
+          syncUrl: null,
+          syncBaseUrl: null,
+        },
+      ],
+      agentConfig
+    );
+
+    expect(rooms).toEqual([
+      {
+        id: 'room-conversations',
+        name: 'Conversations',
+        collectionKey: 'conversations',
+        syncUrl: null,
+        syncBaseUrl: null,
+      },
+    ]);
   });
 
   it('returns 401 for unauthenticated MCP request', async () => {

--- a/packages/auth-server-hono/src/routes/mcp.ts
+++ b/packages/auth-server-hono/src/routes/mcp.ts
@@ -15,6 +15,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
 import { DataLayer, registerTools } from '@eweser/mcp';
 import type { AgentConfig, AgentRoom } from '@eweser/mcp';
+import type { AgentConfig as DbAgentConfig } from '../db/schema/agents.js';
 import { createRateLimit, getClientIp } from '../middleware/rate-limit.js';
 import {
   getValidOAuthAccessToken,
@@ -68,6 +69,62 @@ setInterval(
   },
   5 * 60 * 1000
 );
+
+function compactScope(values: string[] | undefined): string[] {
+  return Array.from(new Set((values ?? []).filter(Boolean)));
+}
+
+function effectiveScope(
+  nextScope: string[] | undefined,
+  legacyScope: string[] | undefined
+): string[] {
+  const next = compactScope(nextScope);
+  return next.length > 0 ? next : compactScope(legacyScope);
+}
+
+function scopeIncludes(scope: string[], value: string): boolean {
+  return scope.length === 0 || scope.includes(value);
+}
+
+export function mapDbAgentConfigForMcp(agent: DbAgentConfig): AgentConfig {
+  return {
+    id: agent.id,
+    userId: agent.userId,
+    name: agent.name,
+    type: agent.type,
+    allowedCollections: agent.allowedCollections,
+    allowedRooms: agent.allowedRooms,
+    permissions: agent.permissions,
+    readAllowedCollections: agent.readAllowedCollections,
+    readAllowedRooms: agent.readAllowedRooms,
+    writeAllowedCollections: agent.writeAllowedCollections,
+    writeAllowedRooms: agent.writeAllowedRooms,
+    writeAllowedFolderIds: agent.writeAllowedFolderIds,
+    writeAllowedPathPrefixes: agent.writeAllowedPathPrefixes,
+    isActive: agent.isActive,
+    tokenExpiresAt: agent.tokenExpiresAt?.toISOString() ?? null,
+  };
+}
+
+export function filterRoomsForAgentConfig(
+  rooms: AgentRoom[],
+  agentConfig: AgentConfig
+): AgentRoom[] {
+  const readAllowedCollections = effectiveScope(
+    agentConfig.readAllowedCollections,
+    agentConfig.allowedCollections
+  );
+  const readAllowedRooms = effectiveScope(
+    agentConfig.readAllowedRooms,
+    agentConfig.allowedRooms
+  );
+
+  return rooms.filter(
+    (room) =>
+      scopeIncludes(readAllowedCollections, room.collectionKey) &&
+      scopeIncludes(readAllowedRooms, room.id)
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Auth resolution — try OAuth token first, then legacy agent token
@@ -125,18 +182,7 @@ async function resolveAuth(
     return {
       userId: agent.userId,
       permissions: agent.permissions,
-      // Map DB AgentConfig to mcp-server AgentConfig (tokenExpiresAt is Date | null in DB, string | null in mcp)
-      agentConfig: {
-        id: agent.id,
-        userId: agent.userId,
-        name: agent.name,
-        type: agent.type,
-        allowedCollections: agent.allowedCollections,
-        allowedRooms: agent.allowedRooms,
-        permissions: agent.permissions,
-        isActive: agent.isActive,
-        tokenExpiresAt: agent.tokenExpiresAt?.toISOString() ?? null,
-      },
+      agentConfig: mapDbAgentConfigForMcp(agent),
       agentToken: token,
     };
   }
@@ -259,12 +305,7 @@ mcpRouter.all('/', async (c) => {
         auth.userId,
         auth.permissions
       );
-      // Filter to allowedRooms if configured
-      const allowedRooms = auth.agentConfig.allowedRooms;
-      agentRooms =
-        allowedRooms.length > 0
-          ? ar.filter((r) => allowedRooms.includes(r.id))
-          : ar;
+      agentRooms = filterRoomsForAgentConfig(ar, agentConfig);
     } else {
       // OAuth token path
       const built = await buildAgentConfigForUser(


### PR DESCRIPTION
## Summary
- preserve split read/write agent scope fields when mapping DB agent configs into the HTTP MCP DataLayer
- filter HTTP MCP session rooms using explicit read scope before falling back to legacy allowed room fields
- add regression coverage for the split-scope mapping and room filtering

## Tests
- npm run test --workspace @eweser/auth-server-hono -- --run src/routes/mcp.test.ts src/routes/agents.test.ts src/routes/connect-ai.test.ts
- npm run type-check --workspace @eweser/auth-server-hono
- npm run lint --workspace @eweser/auth-server-hono