### PR TITLE
Fix default changeset script for ESM

### DIFF
--- a/scripts/create-default-changeset.js
+++ b/scripts/create-default-changeset.js
@@ -1,7 +1,8 @@
-const { execSync } = require('child_process');
-const fs = require('fs');
-const path = require('path');
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const changesetDir = path.resolve(__dirname, '../.changeset');
 if (!fs.existsSync(changesetDir)) {
   fs.mkdirSync(changesetDir);


### PR DESCRIPTION
## Summary
- convert the default changeset helper from CommonJS require to native ESM imports
- keeps the Release Workflow from failing under the root package "type": "module"

## Tests
- npm run default-changeset
- npx prettier --check scripts/create-default-changeset.js