### PR TITLE
Ignore vault sync dotfiles in inventory

### DIFF
--- a/packages/ewe-note/src/cli/import-vault.test.ts
+++ b/packages/ewe-note/src/cli/import-vault.test.ts
@@ -95,6 +95,12 @@ async function createSecretFixtureVault(): Promise<string> {
     'utf-8'
   );
 
+  await writeFile(
+    join(vaultDir, '.eweser-local-state.json'),
+    JSON.stringify({ token: 'tooling-secret-value' }, null, 2),
+    'utf-8'
+  );
+
   await writeFile(join(vaultDir, '.obsidian', 'config'), 'ignored', 'utf-8');
 
   return vaultDir;
@@ -438,6 +444,12 @@ describe('inventoryVault', () => {
       expect(serialized).not.toContain('super-secret-value');
       expect(serialized).not.toContain(SECRET_FIXTURE_OPENAI_KEY);
       expect(serialized).not.toContain('canvas-secret');
+      expect(report.secretFindings).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ path: '.eweser-local-state.json' }),
+        ])
+      );
+      expect(report.skippedPaths).toContain('.eweser-local-state.json');
 
       const noteFinding = report.secretFindings.find(
         (finding) =>

--- a/packages/ewe-note/src/cli/import-vault.ts
+++ b/packages/ewe-note/src/cli/import-vault.ts
@@ -422,7 +422,7 @@ async function scanDirectory(
       const fullPath = join(currentDir, entry);
       const relPath = toVaultRelativePath(vaultRoot, fullPath);
 
-      if (IGNORED_DIRS.has(entry)) {
+      if (IGNORED_DIRS.has(entry) || entry.startsWith('.')) {
         skippedPaths.push(relPath);
         continue;
       }


### PR DESCRIPTION
## Summary
- ignore hidden dotfiles during vault inventory scans to match the live sync watcher behavior
- keep  out of secret findings while still reporting it as a skipped path
- add test coverage for hidden tooling files in inventory mode

## Verification
- npm test --workspace @eweser/ewe-note -- import-vault.test.ts
- npm test --workspace @eweser/ewe-note
- npm run lint --workspace @eweser/ewe-note -- --max-warnings=0
- npm run build --workspace @eweser/ewe-note
- EWE_NOTE_BASE_URL=http://127.0.0.1:5181/ ELECTRON_RUN_AS_NODE= npx cypress run --config baseUrl=http://127.0.0.1:5181,video=false --spec e2e/cypress/tests/ewe-note.cy.ts
- node_modules/.bin/tsx packages/ewe-note/src/cli/vault-sync.ts --vault /Users/jacob/Documents/Work-eweser-scrubbed-with-attachments-2026-05-04 --inventory-only --name Work-Scrubbed-With-Attachments
- node_modules/.bin/tsx --eval "import { EweserRoomVaultSyncEngine } from './packages/ewe-note/src/cli/vault-sync.ts'; void (async () => { const engine = new EweserRoomVaultSyncEngine({ vaultPath: '/Users/jacob/Documents/Work-eweser-scrubbed-with-attachments-2026-05-04', vaultName: 'Work-Scrubbed-With-Attachments', roomId: 'work-scrubbed-overnight', attachmentsRoomId: 'work-scrubbed-overnight-attachments', remoteSync: false, debounceMs: 50 }); await engine.start(); console.log(JSON.stringify({ notes: engine.getNotes().length, attachments: engine.getAttachments().length }, null, 2)); await engine.stop(); })();"

## Notes
- Railway deploy access from this machine is currently blocked by an unauthorized local token, so this PR captures the verified code path while deploy auth is sorted separately.