### PR TITLE
Fix Ewe Note sync auth route and add real vault import UI

### DIFF
--- a/packages/auth-server-hono/src/index.test.ts
+++ b/packages/auth-server-hono/src/index.test.ts
@@ -8,6 +8,7 @@ vi.mock('@hono/node-server', () => ({
 
 vi.mock('./env.js', () => ({
   env: {
+    AUTH_SERVER_URL: 'http://localhost:38101',
     AUTH_TRUSTED_ORIGINS: ['http://localhost:38101'],
     PORT: 38101,
     TRUST_PROXY: false,
@@ -45,6 +46,28 @@ vi.mock('./routes/files.js', async () => {
 const { app } = await import('./index.js');
 
 describe('app health routes', () => {
+  it('redirects root auth entry with redirect params to auth-pages sign-in', async () => {
+    const response = await app.fetch(
+      new Request('http://localhost/?redirect=http%3A%2F%2Flocalhost%3A4173%2F')
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe(
+      'http://localhost:38101/sign-in?redirect=http%3A%2F%2Flocalhost%3A4173%2F'
+    );
+  });
+
+  it('rewrites /auth/* browser routes onto auth-pages root routes', async () => {
+    const response = await app.fetch(
+      new Request('http://localhost/auth/sign-in?domain=note.eweser.com')
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe(
+      'http://localhost:38101/sign-in?domain=note.eweser.com'
+    );
+  });
+
   it('returns status payload for /health', async () => {
     const response = await app.fetch(new Request('http://localhost/health'));
 

--- a/packages/auth-server-hono/src/index.ts
+++ b/packages/auth-server-hono/src/index.ts
@@ -42,6 +42,19 @@ function redirectToAuthPages(path: string, search = '') {
   return new URL(`${path}${search}`, `${resolveAuthPagesOrigin()}/`).toString();
 }
 
+function normalizeAuthPagesPath(path: string) {
+  if (path === '/auth' || path === '/auth/') {
+    return '/';
+  }
+
+  if (path.startsWith('/auth/')) {
+    const stripped = path.slice('/auth'.length);
+    return stripped.startsWith('/') ? stripped : `/${stripped}`;
+  }
+
+  return path;
+}
+
 function isBrowserNavigation(method: string) {
   return method === 'GET' || method === 'HEAD';
 }
@@ -73,15 +86,17 @@ app.use('*', async (c, next) => {
   const requestUrl = new URL(c.req.url);
 
   if (c.req.path === '/' && requestUrl.searchParams.has('redirect')) {
-    return c.redirect(redirectToAuthPages('/auth/sign-in', requestUrl.search));
+    return c.redirect(redirectToAuthPages('/sign-in', requestUrl.search));
   }
 
   if (c.req.path === '/') {
-    return c.redirect(redirectToAuthPages('/auth/'));
+    return c.redirect(redirectToAuthPages('/'));
   }
 
   if (c.req.path === '/auth' || c.req.path.startsWith('/auth/')) {
-    return c.redirect(redirectToAuthPages(c.req.path, requestUrl.search));
+    return c.redirect(
+      redirectToAuthPages(normalizeAuthPagesPath(c.req.path), requestUrl.search)
+    );
   }
 
   await next();

--- a/packages/ewe-note/src/app/lib/browser-vault-import.ts
+++ b/packages/ewe-note/src/app/lib/browser-vault-import.ts
@@ -1,0 +1,657 @@
+import {
+  uploadFile,
+  type Database,
+  type FileAttachment,
+  type Note,
+  type Room,
+} from '@eweser/db';
+import {
+  buildRef,
+  extractTags,
+  extractWikiLinks,
+  parseFrontmatter,
+  type FolderBase,
+} from '@eweser/shared';
+import type { Doc } from 'yjs';
+
+const IGNORED_DIRS = new Set(['.obsidian', '.trash', '.git', 'node_modules']);
+const MARKDOWN_EXTENSION = '.md';
+const ATTACHMENT_MIME_TYPES: Record<string, string> = {
+  '.avif': 'image/avif',
+  '.base': 'text/yaml',
+  '.bmp': 'image/bmp',
+  '.canvas': 'application/json',
+  '.flac': 'audio/flac',
+  '.gif': 'image/gif',
+  '.jpeg': 'image/jpeg',
+  '.jpg': 'image/jpeg',
+  '.json': 'application/json',
+  '.m4a': 'audio/mp4',
+  '.mkv': 'video/x-matroska',
+  '.mov': 'video/quicktime',
+  '.mp3': 'audio/mpeg',
+  '.mp4': 'video/mp4',
+  '.ogg': 'audio/ogg',
+  '.ogv': 'video/ogg',
+  '.pdf': 'application/pdf',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.txt': 'text/plain',
+  '.wav': 'audio/wav',
+  '.webm': 'video/webm',
+  '.webp': 'image/webp',
+};
+
+type RemoteSyncReadyProvider = {
+  synced?: boolean;
+  on: (
+    event: 'synced' | 'authenticationFailed',
+    callback: (payload: { state?: boolean; reason?: string }) => void
+  ) => void;
+  off: (
+    event: 'synced' | 'authenticationFailed',
+    callback: (payload: { state?: boolean; reason?: string }) => void
+  ) => void;
+};
+
+type FolderMapDoc = Doc & {
+  getMap: (name: string) => {
+    set: (key: string, value: string) => void;
+  };
+  transact: (fn: () => void) => void;
+};
+
+type PreparedVaultNote = {
+  _id: string;
+  aliases: string[];
+  attachmentRefs: string[];
+  folderId: string | null;
+  frontmatter: Record<string, unknown>;
+  sourcePath: string;
+  sourceVault: string;
+  tags: string[];
+  text: string;
+};
+
+type PreparedVaultAttachment = {
+  file: File;
+  filename: string;
+  mimeType: string;
+  sourcePath: string;
+};
+
+type PreparedVaultImport = {
+  attachmentCount: number;
+  attachments: PreparedVaultAttachment[];
+  folderEntries: Array<{ id: string; path: string; record: FolderBase }>;
+  noteCount: number;
+  notes: PreparedVaultNote[];
+  skippedPaths: string[];
+  vaultName: string;
+};
+
+export type BrowserVaultImportPhase =
+  | 'parsing'
+  | 'connecting'
+  | 'uploading'
+  | 'writing'
+  | 'complete';
+
+export type BrowserVaultImportProgress = {
+  current: number;
+  message: string;
+  phase: BrowserVaultImportPhase;
+  total: number;
+};
+
+export type BrowserVaultImportResult = {
+  attachmentsRoomId: string;
+  attachmentsSkipped: number;
+  attachmentsUploaded: number;
+  noteRoomId: string;
+  notesImported: number;
+  remoteSyncEnabled: boolean;
+  skippedPaths: string[];
+  warnings: string[];
+};
+
+function normalizeSlashes(path: string) {
+  return path.replace(/\\/g, '/');
+}
+
+function getFileExtension(path: string) {
+  const normalized = normalizeSlashes(path);
+  const lastDot = normalized.lastIndexOf('.');
+  if (lastDot === -1) return '';
+  return normalized.slice(lastDot).toLowerCase();
+}
+
+function getFileName(path: string) {
+  const normalized = normalizeSlashes(path);
+  const segments = normalized.split('/').filter(Boolean);
+  return segments.at(-1) ?? normalized;
+}
+
+function getDirectoryPath(path: string) {
+  const normalized = normalizeSlashes(path);
+  const lastSlash = normalized.lastIndexOf('/');
+  if (lastSlash === -1) return '';
+  return normalized.slice(0, lastSlash);
+}
+
+function shouldIgnoreVaultPath(relativePath: string) {
+  const segments = normalizeSlashes(relativePath).split('/').filter(Boolean);
+  return segments.some((segment) => IGNORED_DIRS.has(segment));
+}
+
+function guessMimeType(file: File, sourcePath: string) {
+  if (file.type) {
+    return file.type;
+  }
+  return (
+    ATTACHMENT_MIME_TYPES[getFileExtension(sourcePath)] ??
+    'application/octet-stream'
+  );
+}
+
+function normalizeRelativePath(file: File) {
+  const relativePath = normalizeSlashes(file.webkitRelativePath || file.name);
+  const segments = relativePath.split('/').filter(Boolean);
+  const vaultName = segments[0] || 'Imported Vault';
+  const sourcePath = segments.slice(1).join('/') || file.name;
+  return { sourcePath, vaultName };
+}
+
+function buildFolderId(vaultName: string, folderPath: string) {
+  return `${vaultName}:${folderPath}`;
+}
+
+async function sha256Hex(value: string | ArrayBuffer) {
+  const bytes =
+    typeof value === 'string'
+      ? new TextEncoder().encode(value)
+      : new Uint8Array(value);
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+async function generateStableId(seed: string) {
+  return (await sha256Hex(seed)).slice(0, 16);
+}
+
+function collectAttachmentRefs(markdownContent: string) {
+  return extractWikiLinks(markdownContent)
+    .filter((link) => link.isEmbed && link.target)
+    .map((link) => normalizeSlashes(link.target));
+}
+
+function buildFolderEntries(vaultName: string, folderPaths: Set<string>) {
+  const sortedPaths = Array.from(folderPaths).sort((left, right) => {
+    const leftDepth = left.split('/').length;
+    const rightDepth = right.split('/').length;
+    return leftDepth - rightDepth || left.localeCompare(right);
+  });
+
+  return sortedPaths.map((path) => {
+    const parentPath = getDirectoryPath(path);
+    const record: FolderBase = {
+      name: getFileName(path),
+      ...(parentPath
+        ? { parentFolderId: buildFolderId(vaultName, parentPath) }
+        : {}),
+    };
+    return {
+      id: buildFolderId(vaultName, path),
+      path,
+      record,
+    };
+  });
+}
+
+export async function prepareVaultImport(
+  filesLike: FileList | File[],
+  onProgress?: (progress: BrowserVaultImportProgress) => void
+): Promise<PreparedVaultImport> {
+  const files = Array.from(filesLike);
+  if (files.length === 0) {
+    throw new Error('Choose an Obsidian vault folder with at least one file.');
+  }
+
+  const first = normalizeRelativePath(files[0]);
+  const notes: PreparedVaultNote[] = [];
+  const attachments: PreparedVaultAttachment[] = [];
+  const folderPaths = new Set<string>();
+  const skippedPaths: string[] = [];
+
+  let index = 0;
+  for (const file of files) {
+    index += 1;
+    const { sourcePath, vaultName } = normalizeRelativePath(file);
+    if (vaultName !== first.vaultName) {
+      throw new Error('Vault import must come from a single folder selection.');
+    }
+    if (!sourcePath || shouldIgnoreVaultPath(sourcePath)) {
+      skippedPaths.push(sourcePath || file.name);
+      continue;
+    }
+
+    onProgress?.({
+      current: index,
+      message: `Scanning ${sourcePath}`,
+      phase: 'parsing',
+      total: files.length,
+    });
+
+    const folderPath = getDirectoryPath(sourcePath);
+    if (folderPath) {
+      const parts = folderPath.split('/').filter(Boolean);
+      for (let partIndex = 0; partIndex < parts.length; partIndex += 1) {
+        folderPaths.add(parts.slice(0, partIndex + 1).join('/'));
+      }
+    }
+
+    if (getFileExtension(sourcePath) === MARKDOWN_EXTENSION) {
+      const rawContent = await file.text();
+      const { content, frontmatter } = parseFrontmatter(rawContent);
+      const tags = extractTags(content);
+      const frontmatterTags = frontmatter.tags;
+      if (Array.isArray(frontmatterTags)) {
+        for (const tag of frontmatterTags) {
+          if (typeof tag === 'string' && !tags.includes(tag)) {
+            tags.push(tag);
+          }
+        }
+      }
+
+      const aliases: string[] = [];
+      const frontmatterAliases = frontmatter.aliases;
+      if (Array.isArray(frontmatterAliases)) {
+        for (const alias of frontmatterAliases) {
+          if (typeof alias === 'string') {
+            aliases.push(alias);
+          }
+        }
+      }
+
+      notes.push({
+        _id: await generateStableId(`${first.vaultName}:${sourcePath}`),
+        aliases,
+        attachmentRefs: collectAttachmentRefs(content),
+        folderId: folderPath
+          ? buildFolderId(first.vaultName, folderPath)
+          : null,
+        frontmatter,
+        sourcePath,
+        sourceVault: first.vaultName,
+        tags,
+        text: content,
+      });
+      continue;
+    }
+
+    attachments.push({
+      file,
+      filename: file.name,
+      mimeType: guessMimeType(file, sourcePath),
+      sourcePath,
+    });
+  }
+
+  return {
+    attachmentCount: attachments.length,
+    attachments,
+    folderEntries: buildFolderEntries(first.vaultName, folderPaths),
+    noteCount: notes.length,
+    notes,
+    skippedPaths,
+    vaultName: first.vaultName,
+  };
+}
+
+async function waitForRemoteSyncProviderReady(
+  provider: RemoteSyncReadyProvider | null | undefined,
+  timeoutMs = 15000
+) {
+  if (!provider) {
+    throw new Error('Remote sync provider is missing.');
+  }
+
+  if (provider.synced) {
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const timeout = window.setTimeout(() => {
+      cleanup();
+      reject(new Error('Timed out waiting for remote sync provider.'));
+    }, timeoutMs);
+
+    const handleSynced = (payload: { state?: boolean }) => {
+      if (!payload.state) {
+        return;
+      }
+      cleanup();
+      resolve();
+    };
+
+    const handleAuthenticationFailed = (payload: { reason?: string }) => {
+      cleanup();
+      reject(
+        new Error(
+          `Remote sync provider authentication failed${payload.reason ? `: ${payload.reason}` : '.'}`
+        )
+      );
+    };
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      provider.off('synced', handleSynced);
+      provider.off('authenticationFailed', handleAuthenticationFailed);
+    };
+
+    provider.on('synced', handleSynced);
+    provider.on('authenticationFailed', handleAuthenticationFailed);
+  });
+}
+
+async function waitForRemoteRoomReady(room: {
+  syncProvider?: RemoteSyncReadyProvider | null;
+}) {
+  const startedAt = Date.now();
+  while (!room.syncProvider) {
+    if (Date.now() - startedAt >= 15000) {
+      throw new Error('Timed out waiting for remote sync provider.');
+    }
+    await new Promise((resolve) => window.setTimeout(resolve, 100));
+  }
+
+  await waitForRemoteSyncProviderReady(room.syncProvider, 15000);
+}
+
+async function resolveNotesRoom(
+  db: Database,
+  roomId: string,
+  collectionKey: 'notes' | 'fileAttachments',
+  remoteSyncEnabled: boolean
+) {
+  const localRoom =
+    collectionKey === 'notes'
+      ? db.getRoom<Note>('notes', roomId)
+      : db.getRoom<FileAttachment>('fileAttachments', roomId);
+
+  if (!localRoom) {
+    throw new Error(`Failed to create ${collectionKey} room.`);
+  }
+
+  if (!remoteSyncEnabled) {
+    await localRoom.load({ awaitLoadRemote: false, loadRemote: false });
+    return localRoom;
+  }
+
+  const synced = await db.syncRegistry();
+  if (!synced) {
+    throw new Error('Failed to sync registry before importing the vault.');
+  }
+
+  const serverRoom = db.registry.find(
+    (room) => room.id === roomId && room.collectionKey === collectionKey
+  );
+  if (!serverRoom) {
+    throw new Error(
+      `Remote ${collectionKey} room was not found after registry sync.`
+    );
+  }
+
+  const room = await db.loadRoom(serverRoom, {
+    awaitLoadRemote: true,
+    loadRemote: true,
+  });
+  await waitForRemoteRoomReady(room);
+  return room as Room<Note> | Room<FileAttachment>;
+}
+
+function writeFoldersToRoom(
+  room: Room<Note>,
+  folderEntries: PreparedVaultImport['folderEntries']
+) {
+  if (!room.ydoc || folderEntries.length === 0) {
+    return;
+  }
+
+  const doc = room.ydoc as unknown as FolderMapDoc;
+  const folderMap = doc.getMap('folders');
+  doc.transact(() => {
+    for (const folder of folderEntries) {
+      folderMap.set(folder.id, JSON.stringify(folder.record));
+    }
+  });
+}
+
+function buildAttachmentParentRefs(
+  db: Database,
+  noteRoomId: string,
+  notes: PreparedVaultNote[]
+) {
+  const refsByTarget = new Map<string, string[]>();
+
+  for (const note of notes) {
+    const noteRef = buildRef({
+      authServer: db.authServer,
+      collectionKey: 'notes',
+      documentId: note._id,
+      roomId: noteRoomId,
+    });
+
+    for (const attachmentRef of note.attachmentRefs) {
+      const normalized = normalizeSlashes(attachmentRef).toLowerCase();
+      const targets = refsByTarget.get(normalized) ?? [];
+      targets.push(noteRef);
+      refsByTarget.set(normalized, targets);
+    }
+  }
+
+  return refsByTarget;
+}
+
+export async function importVaultFromFiles(params: {
+  db: Database;
+  files: FileList | File[];
+  onProgress?: (progress: BrowserVaultImportProgress) => void;
+  remoteSyncEnabled: boolean;
+  setSelectedRoom?: (room: Room<Note> | null) => void;
+}) {
+  const prepared = await prepareVaultImport(params.files, params.onProgress);
+  if (prepared.noteCount === 0) {
+    throw new Error(
+      'No markdown notes were found in the selected vault folder.'
+    );
+  }
+
+  params.onProgress?.({
+    current: 0,
+    message: `Creating rooms for ${prepared.vaultName}`,
+    phase: 'connecting',
+    total: 1,
+  });
+
+  const noteRoomId = crypto.randomUUID();
+  const attachmentsRoomId = crypto.randomUUID();
+
+  params.db.newRoom<Note>({
+    collectionKey: 'notes',
+    id: noteRoomId,
+    name: prepared.vaultName,
+  });
+  params.db.newRoom<FileAttachment>({
+    collectionKey: 'fileAttachments',
+    id: attachmentsRoomId,
+    name: `${prepared.vaultName} Attachments`,
+  });
+
+  const noteRoom = (await resolveNotesRoom(
+    params.db,
+    noteRoomId,
+    'notes',
+    params.remoteSyncEnabled
+  )) as Room<Note>;
+  const attachmentsRoom = (await resolveNotesRoom(
+    params.db,
+    attachmentsRoomId,
+    'fileAttachments',
+    params.remoteSyncEnabled
+  )) as Room<FileAttachment>;
+
+  writeFoldersToRoom(noteRoom, prepared.folderEntries);
+
+  const Notes = noteRoom.getDocuments();
+  const warnings: string[] = [];
+  params.onProgress?.({
+    current: 0,
+    message: `Writing ${prepared.noteCount} notes`,
+    phase: 'writing',
+    total: prepared.noteCount,
+  });
+
+  let noteIndex = 0;
+  for (const note of prepared.notes) {
+    noteIndex += 1;
+    const now = Date.now();
+    Notes.set({
+      _created: now,
+      _id: note._id,
+      _ref: buildRef({
+        authServer: params.db.authServer,
+        collectionKey: 'notes',
+        documentId: note._id,
+        roomId: noteRoomId,
+      }),
+      _updated: now,
+      aliases: note.aliases,
+      ...(note.folderId ? { folderIds: [note.folderId] } : {}),
+      frontmatter: note.frontmatter,
+      sourcePath: note.sourcePath,
+      sourceVault: note.sourceVault,
+      tags: note.tags,
+      text: note.text,
+    });
+    params.onProgress?.({
+      current: noteIndex,
+      message: `Imported ${note.sourcePath}`,
+      phase: 'writing',
+      total: prepared.noteCount,
+    });
+  }
+
+  let attachmentsUploaded = 0;
+  let attachmentsSkipped = prepared.attachmentCount;
+  if (params.remoteSyncEnabled && prepared.attachments.length > 0) {
+    const parentRefsByTarget = buildAttachmentParentRefs(
+      params.db,
+      noteRoomId,
+      prepared.notes
+    );
+    const Attachments = attachmentsRoom.getDocuments();
+    attachmentsSkipped = 0;
+
+    let attachmentIndex = 0;
+    for (const attachment of prepared.attachments) {
+      attachmentIndex += 1;
+      params.onProgress?.({
+        current: attachmentIndex,
+        message: `Uploading ${attachment.sourcePath}`,
+        phase: 'uploading',
+        total: prepared.attachments.length,
+      });
+
+      try {
+        const bytes = await attachment.file.arrayBuffer();
+        const contentHash = await sha256Hex(bytes);
+        const normalizedTarget = normalizeSlashes(
+          attachment.sourcePath
+        ).toLowerCase();
+        const fileNameTarget = getFileName(normalizedTarget);
+        const parentNoteRefs = [
+          ...(parentRefsByTarget.get(normalizedTarget) ?? []),
+          ...(parentRefsByTarget.get(fileNameTarget) ?? []),
+        ];
+
+        const uploaded = await uploadFile({
+          db: params.db,
+          file: bytes,
+          metadata: {
+            baseId: noteRoomId,
+            filename: attachment.filename,
+            mimeType: attachment.mimeType,
+            ...(parentNoteRefs.length > 0 ? { parentNoteRefs } : {}),
+            size: attachment.file.size,
+            sourcePath: attachment.sourcePath,
+            sourceVault: prepared.vaultName,
+          },
+          roomId: attachmentsRoomId,
+        });
+
+        const attachmentId = await generateStableId(
+          `${noteRoomId}:${attachment.sourcePath}`
+        );
+        const now = Date.now();
+        Attachments.set({
+          ...uploaded,
+          _created: uploaded._created ?? now,
+          _id: attachmentId,
+          _ref: buildRef({
+            authServer: params.db.authServer,
+            collectionKey: 'fileAttachments',
+            documentId: attachmentId,
+            roomId: attachmentsRoomId,
+          }),
+          _updated: now,
+          baseId: noteRoomId,
+          contentHash,
+          filename: attachment.filename,
+          mimeType: attachment.mimeType,
+          ...(parentNoteRefs.length > 0 ? { parentNoteRefs } : {}),
+          size: attachment.file.size,
+          sourcePath: attachment.sourcePath,
+          sourceVault: prepared.vaultName,
+        });
+        attachmentsUploaded += 1;
+      } catch (error) {
+        attachmentsSkipped += 1;
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'Unknown attachment upload error.';
+        warnings.push(
+          `Attachment skipped: ${attachment.sourcePath} (${message})`
+        );
+      }
+    }
+  }
+
+  if (!params.remoteSyncEnabled && prepared.attachments.length > 0) {
+    warnings.push(
+      'Attachments were skipped because remote sync is not active. Sign in first to upload vault files.'
+    );
+  }
+
+  params.setSelectedRoom?.(noteRoom);
+  params.onProgress?.({
+    current: prepared.noteCount,
+    message: `Imported ${prepared.noteCount} notes`,
+    phase: 'complete',
+    total: prepared.noteCount,
+  });
+
+  return {
+    attachmentsRoomId,
+    attachmentsSkipped,
+    attachmentsUploaded,
+    noteRoomId,
+    notesImported: prepared.noteCount,
+    remoteSyncEnabled: params.remoteSyncEnabled,
+    skippedPaths: prepared.skippedPaths,
+    warnings,
+  } satisfies BrowserVaultImportResult;
+}

--- a/packages/ewe-note/src/app/pages/Settings.test.tsx
+++ b/packages/ewe-note/src/app/pages/Settings.test.tsx
@@ -11,6 +11,7 @@ import {
 } from '../components/workspace-interaction-settings';
 
 const mockNavigate = vi.fn();
+const mockSetSelectedRoom = vi.fn();
 
 vi.mock('react-router', () => ({
   useNavigate: () => mockNavigate,
@@ -21,10 +22,13 @@ vi.mock('../../db', () => ({
   useDb: () => ({
     allRooms: [],
     allRoomIds: [],
+    db: {},
     hasToken: false,
     loaded: true,
     loggedIn: false,
     loginUrl: 'http://localhost:38101/login',
+    selectedRoom: null,
+    setSelectedRoom: mockSetSelectedRoom,
     signOut: vi.fn(),
     syncStatus: 'signed-out',
     syncStatusDescription: 'Signed out',
@@ -67,6 +71,7 @@ describe('Settings', () => {
   beforeEach(() => {
     window.localStorage.clear();
     mockNavigate.mockClear();
+    mockSetSelectedRoom.mockClear();
   });
 
   afterEach(() => {
@@ -126,5 +131,18 @@ describe('Settings', () => {
     expect(
       screen.getAllByRole('button', { name: 'Create custom theme' }).length
     ).toBeGreaterThan(0);
+  });
+
+  it('shows the real vault import entry point in sync settings', () => {
+    render(<Settings />);
+
+    expect(
+      screen.getByRole('button', { name: 'Choose vault folder' })
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        'Choose an Obsidian vault folder to import markdown locally. Sign in first if you want attachments uploaded and synced across devices.'
+      )
+    ).toBeTruthy();
   });
 });

--- a/packages/ewe-note/src/app/pages/Settings.tsx
+++ b/packages/ewe-note/src/app/pages/Settings.tsx
@@ -24,6 +24,11 @@ import { AUTH_PAGES_SERVER, AUTH_SERVER, env, routerBase } from '../../config';
 import { useTheme } from '../components/ThemeProvider';
 import { Switch } from '../components/ui/switch';
 import { useWorkspaceInteractionPreferences } from '../components/workspace-interaction-settings';
+import {
+  importVaultFromFiles,
+  type BrowserVaultImportProgress,
+  type BrowserVaultImportResult,
+} from '../lib/browser-vault-import';
 
 const SETTINGS_SECTIONS = [
   { id: 'account', label: 'Account' },
@@ -41,22 +46,41 @@ export function Settings() {
   const contentRef = useRef<HTMLDivElement | null>(null);
   const [activeSection, setActiveSection] =
     useState<SettingsSectionId>('account');
+  const vaultInputRef = useRef<HTMLInputElement | null>(null);
+  const [vaultImportProgress, setVaultImportProgress] =
+    useState<BrowserVaultImportProgress | null>(null);
+  const [vaultImportResult, setVaultImportResult] =
+    useState<BrowserVaultImportResult | null>(null);
+  const [vaultImportError, setVaultImportError] = useState<string | null>(null);
   const { mode, theme, setMode } = useTheme();
   const { preferences, updatePreference } =
     useWorkspaceInteractionPreferences();
   const {
     allRooms,
     allRoomIds,
+    db,
     hasToken,
     loaded,
     loggedIn,
     loginUrl,
+    selectedRoom,
+    setSelectedRoom,
     signOut,
     syncStatus,
     syncStatusDescription,
     syncStatusLabel,
     user,
   } = useDb();
+
+  const importingVault = vaultImportProgress !== null;
+  const canSyncRemotely = loggedIn || hasToken;
+
+  useEffect(() => {
+    const input = vaultInputRef.current;
+    if (!input) return;
+    input.setAttribute('webkitdirectory', '');
+    input.setAttribute('directory', '');
+  }, []);
 
   useEffect(() => {
     const hash = location.hash.replace('#', '').trim();
@@ -118,6 +142,43 @@ export function Settings() {
     window.history.replaceState(null, '', `#${sectionId}`);
     target.scrollIntoView({ block: 'start', behavior: 'smooth' });
   };
+
+  const openVaultPicker = () => {
+    vaultInputRef.current?.click();
+  };
+
+  const handleVaultInputChange = async (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const files = event.currentTarget.files;
+    event.currentTarget.value = '';
+    if (!files || files.length === 0) return;
+
+    setVaultImportError(null);
+    setVaultImportResult(null);
+    try {
+      const result = await importVaultFromFiles({
+        db,
+        files,
+        onProgress: setVaultImportProgress,
+        remoteSyncEnabled: canSyncRemotely,
+        setSelectedRoom,
+      });
+      setVaultImportResult(result);
+    } catch (error) {
+      setVaultImportError(
+        error instanceof Error ? error.message : 'Vault import failed.'
+      );
+    } finally {
+      setVaultImportProgress(null);
+    }
+  };
+
+  const importedRoom =
+    vaultImportResult?.noteRoomId != null
+      ? (allRooms.find((room) => room.id === vaultImportResult.noteRoomId) ??
+        null)
+      : null;
 
   return (
     <div
@@ -318,6 +379,13 @@ export function Settings() {
               </h2>
               <SettingsPanel icon={Server} title="Local-first sync">
                 <div className="space-y-5">
+                  <input
+                    ref={vaultInputRef}
+                    className="hidden"
+                    multiple
+                    onChange={handleVaultInputChange}
+                    type="file"
+                  />
                   <div>
                     <p
                       data-cy="ewe-note-settings-sync-status"
@@ -345,8 +413,12 @@ export function Settings() {
                     />
                     <InfoBlock
                       icon={Download}
-                      title="Import and export"
-                      description="Markdown import and export live in the vault tools and editor source mode. UI-level vault import is still deferred."
+                      title="Obsidian vault import"
+                      description={
+                        canSyncRemotely
+                          ? 'Choose an Obsidian vault folder to create synced notes and attachment rooms from the browser.'
+                          : 'Choose an Obsidian vault folder to import markdown locally. Sign in first if you want attachments uploaded and synced across devices.'
+                      }
                     />
                     <div className="space-y-2 rounded-lg bg-accent/35 px-4 py-4">
                       <div className="text-sm font-medium text-foreground">
@@ -374,6 +446,113 @@ export function Settings() {
                         </div>
                       </dl>
                     </div>
+                  </div>
+
+                  <div className="space-y-4 rounded-lg border border-border/70 px-4 py-4">
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                      <div className="space-y-1">
+                        <div className="text-sm font-medium text-foreground">
+                          Import an Obsidian vault
+                        </div>
+                        <p className="text-sm text-muted-foreground">
+                          {canSyncRemotely
+                            ? 'This creates a notes room plus a paired attachment room, then uploads files through the auth API.'
+                            : 'This creates a local notes room immediately. Attachments stay out until sync is enabled.'}
+                        </p>
+                      </div>
+                      <button
+                        data-cy="ewe-note-settings-import-vault"
+                        disabled={importingVault}
+                        onClick={openVaultPicker}
+                        type="button"
+                        className="inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        <Download className="h-4 w-4" />
+                        {importingVault
+                          ? 'Importing vault...'
+                          : 'Choose vault folder'}
+                      </button>
+                    </div>
+
+                    {vaultImportProgress ? (
+                      <div
+                        data-cy="ewe-note-settings-import-progress"
+                        className="rounded-lg border border-border/70 bg-background/70 px-3 py-3 text-sm text-muted-foreground"
+                      >
+                        <div className="font-medium text-foreground">
+                          {vaultImportProgress.message}
+                        </div>
+                        <div className="mt-1">
+                          {vaultImportProgress.phase}{' '}
+                          {vaultImportProgress.current}
+                          {' / '}
+                          {vaultImportProgress.total}
+                        </div>
+                      </div>
+                    ) : null}
+
+                    {vaultImportError ? (
+                      <div
+                        data-cy="ewe-note-settings-import-error"
+                        className="rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-3 text-sm text-destructive"
+                      >
+                        {vaultImportError}
+                      </div>
+                    ) : null}
+
+                    {vaultImportResult ? (
+                      <div
+                        data-cy="ewe-note-settings-import-result"
+                        className="space-y-3 rounded-lg border border-border/70 bg-background/70 px-3 py-3 text-sm"
+                      >
+                        <div className="font-medium text-foreground">
+                          Vault imported
+                        </div>
+                        <div className="text-muted-foreground">
+                          {vaultImportResult.notesImported} notes imported into{' '}
+                          {importedRoom?.name ?? 'a new room'}.{' '}
+                          {vaultImportResult.remoteSyncEnabled
+                            ? `${vaultImportResult.attachmentsUploaded} attachments uploaded`
+                            : 'Attachment upload skipped until sync is active'}
+                          {vaultImportResult.attachmentsSkipped > 0
+                            ? `, ${vaultImportResult.attachmentsSkipped} skipped.`
+                            : '.'}
+                        </div>
+                        {vaultImportResult.warnings.length > 0 ? (
+                          <div className="space-y-1 text-muted-foreground">
+                            {vaultImportResult.warnings
+                              .slice(0, 3)
+                              .map((warning) => (
+                                <p key={warning}>{warning}</p>
+                              ))}
+                            {vaultImportResult.warnings.length > 3 ? (
+                              <p>
+                                {vaultImportResult.warnings.length - 3} more
+                                warning(s) hidden.
+                              </p>
+                            ) : null}
+                          </div>
+                        ) : null}
+                        <div className="flex flex-wrap gap-2">
+                          <button
+                            onClick={() => {
+                              if (!importedRoom) return;
+                              setSelectedRoom(importedRoom);
+                              navigate('/');
+                            }}
+                            type="button"
+                            className="rounded-lg border border-border px-3 py-2 text-sm text-foreground transition-colors hover:bg-accent/60"
+                          >
+                            Open imported room
+                          </button>
+                          {selectedRoom?.id === importedRoom?.id ? (
+                            <span className="inline-flex items-center rounded-lg bg-accent px-3 py-2 text-sm text-foreground">
+                              Active room
+                            </span>
+                          ) : null}
+                        </div>
+                      </div>
+                    ) : null}
                   </div>
                 </div>
               </SettingsPanel>

--- a/packages/ewe-note/src/db.tsx
+++ b/packages/ewe-note/src/db.tsx
@@ -86,7 +86,7 @@ const loginUrlParams = new URLSearchParams({
 });
 
 export const appLoginUrl = new URL(
-  `/auth/sign-in?${loginUrlParams.toString()}`,
+  `/sign-in?${loginUrlParams.toString()}`,
   config.AUTH_PAGES_SERVER
 ).toString();
 


### PR DESCRIPTION
## Summary
- fix auth-page redirects to the real auth-pages routes instead of the broken /auth/sign-in path
- add a browser-side Obsidian vault import flow in Ewe Note settings that creates note rooms and uploads attachments when sync is available
- cover the redirect behavior and the new sync settings entry point with tests

## Verification
- npm test --workspace @eweser/auth-server-hono -- src/index.test.ts
- npm test --workspace @eweser/ewe-note -- src/app/pages/Settings.test.tsx
- npm run type-check --workspace @eweser/ewe-note
- npm run build --workspace @eweser/ewe-note
- npm run build --workspace @eweser/auth-server-hono
