### PR TITLE
Support legacy auth sign-in route in auth pages

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -110,6 +110,60 @@ function getRequiredInput(id: string) {
   return element;
 }
 
+function defaultMemoryStrategy(roomIds: string[] = []) {
+  const defaultWriteRoomId = roomIds[0];
+  return {
+    defaultStrategy: 'agent-journal' as const,
+    defaultCaptureMode: 'manual' as const,
+    scopes: [
+      {
+        scopeType: 'global' as const,
+        scopeKey: 'default',
+        label: 'Shared Agent Memory',
+        strategy: 'agent-journal' as const,
+        captureMode: 'manual' as const,
+        ...(defaultWriteRoomId ? { defaultWriteRoomId } : {}),
+        readableRoomIds: roomIds,
+        writableRoomIds: roomIds,
+      },
+    ],
+    choices: [
+      {
+        strategy: 'agent-journal' as const,
+        label: 'Shared Agent Memory',
+        description: 'Portable manual memory.',
+        advanced: false,
+      },
+      {
+        strategy: 'project-wiki' as const,
+        label: 'Project Wiki',
+        description: 'Deterministic project knowledge.',
+        advanced: false,
+      },
+    ],
+    captureModes: [
+      {
+        mode: 'manual' as const,
+        label: 'Manual',
+        description: 'Explicit saves only.',
+        enabled: true,
+      },
+      {
+        mode: 'suggest' as const,
+        label: 'Suggest',
+        description: 'Stage suggested memories.',
+        enabled: true,
+      },
+      {
+        mode: 'auto' as const,
+        label: 'Auto',
+        description: 'Planned.',
+        enabled: false,
+      },
+    ],
+  };
+}
+
 describe('auth-pages app', () => {
   beforeEach(() => {
     cleanup();
@@ -150,6 +204,7 @@ describe('auth-pages app', () => {
       },
       dynamicClientRegistrationUrl: 'https://www.eweser.com/oauth/register',
       mcpUrl: 'https://www.eweser.com/mcp',
+      memoryStrategy: defaultMemoryStrategy(),
       oauthMetadataUrl:
         'https://www.eweser.com/.well-known/oauth-authorization-server',
       smartLinkRule:
@@ -222,6 +277,14 @@ describe('auth-pages app', () => {
     expect(authMocks.signInEmail.mock.calls[0]?.[0]).toMatchObject({
       callbackURL: 'http://localhost:3000/ai',
     });
+  });
+
+  it('accepts the legacy /auth/sign-in route', async () => {
+    renderApp('/auth/sign-in?redirect=/ai');
+
+    expect(await screen.findByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^sign in$/i })).toBeInTheDocument();
   });
 
   it('should sign in and redirect to the permission page when a login query is present', async () => {
@@ -376,6 +439,7 @@ describe('auth-pages app', () => {
       },
       dynamicClientRegistrationUrl: 'https://www.eweser.com/oauth/register',
       mcpUrl: 'https://www.eweser.com/mcp',
+      memoryStrategy: defaultMemoryStrategy(['room-conversations']),
       oauthMetadataUrl:
         'https://www.eweser.com/.well-known/oauth-authorization-server',
       smartLinkRule:
@@ -404,6 +468,9 @@ describe('auth-pages app', () => {
       await screen.findByRole('heading', { name: /connect ai/i, level: 2 })
     ).toBeInTheDocument();
     expect(screen.getByText(/claude desktop/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/shared agent memory/i).length).toBeGreaterThan(
+      0
+    );
     expect(screen.getByText(/writable ai area/i)).toBeInTheDocument();
     expect(screen.getByText(/write scope: 1 room/i)).toBeInTheDocument();
   });
@@ -439,6 +506,7 @@ describe('auth-pages app', () => {
       },
       dynamicClientRegistrationUrl: 'https://www.eweser.com/oauth/register',
       mcpUrl: 'https://www.eweser.com/mcp',
+      memoryStrategy: defaultMemoryStrategy(['room-conversations']),
       oauthMetadataUrl:
         'https://www.eweser.com/.well-known/oauth-authorization-server',
       smartLinkRule:
@@ -486,12 +554,120 @@ describe('auth-pages app', () => {
     await waitFor(() => {
       expect(apiMocks.setupConnectAiToken).toHaveBeenCalledWith(
         'claude-desktop',
-        { writeRoomIds: ['room-conversations', 'room-ai'] }
+        {
+          captureMode: 'manual',
+          defaultWriteRoomId: 'room-conversations',
+          memoryStrategy: 'agent-journal',
+          readableRoomIds: ['room-conversations'],
+          writableRoomIds: ['room-conversations'],
+        }
       );
     });
 
     expect(
       await screen.findByText(/paste this into claude desktop config/i)
+    ).toBeInTheDocument();
+  });
+
+  it('omits defaultWriteRoomId from project-wiki setup payloads', async () => {
+    sessionState = {
+      data: {
+        session: { id: 'session-1' },
+        user: { email: 'test@example.com', id: 'user-1' },
+      },
+      error: null,
+      isPending: false,
+      isRefetching: false,
+      refetch: vi.fn().mockResolvedValue(undefined),
+    };
+
+    apiMocks.getConnectAiOverview.mockResolvedValue({
+      clients: [
+        {
+          clientId: 'codex',
+          connection: null,
+          description:
+            'Remote HTTP MCP config for Codex using bearer_token_env_var.',
+          fallbackReason: null,
+          title: 'Codex',
+          type: 'token-fallback',
+        },
+      ],
+      defaults: {
+        allowedCollections: 'all-supported-collections',
+        permissions: 'read',
+        tokenTtlSeconds: 604800,
+      },
+      dynamicClientRegistrationUrl: 'https://www.eweser.com/oauth/register',
+      mcpUrl: 'https://www.eweser.com/mcp',
+      memoryStrategy: defaultMemoryStrategy(['room-source']),
+      oauthMetadataUrl:
+        'https://www.eweser.com/.well-known/oauth-authorization-server',
+      smartLinkRule:
+        'Never place bearer tokens in URLs. All setup flows stay on authenticated Eweser pages and mint or rotate tokens server-side.',
+      writableRooms: [
+        {
+          id: 'room-source',
+          name: 'Project Memory',
+          collectionKey: 'conversations',
+          syncUrl: null,
+          syncBaseUrl: null,
+        },
+        {
+          id: 'room-drafts',
+          name: 'Wiki Drafts',
+          collectionKey: 'projectWikiDrafts',
+          syncUrl: null,
+          syncBaseUrl: null,
+        },
+        {
+          id: 'room-pages',
+          name: 'Wiki Pages',
+          collectionKey: 'projectWikiPages',
+          syncUrl: null,
+          syncBaseUrl: null,
+        },
+      ],
+    });
+    apiMocks.setupConnectAiToken.mockResolvedValue({
+      agent: { id: 'agent-1', permissions: 'read', tokenExpiresAt: null },
+      clientId: 'codex',
+      payload: {
+        configFormat: 'toml',
+        instructions: 'Add this to ~/.codex/config.toml.',
+        snippet: '[mcp_servers.eweser]',
+      },
+      token: 'raw-token',
+    });
+
+    renderApp('/account/connect-ai');
+
+    await screen.findByRole('heading', { name: /connect ai/i, level: 2 });
+    await userEvent.selectOptions(
+      screen.getByLabelText(/strategy/i),
+      'project-wiki'
+    );
+    const button = await screen.findByRole('button', {
+      name: /prepare setup/i,
+    });
+    await userEvent.click(button);
+
+    await waitFor(() => {
+      expect(apiMocks.setupConnectAiToken).toHaveBeenCalledWith(
+        'codex',
+        expect.objectContaining({
+          captureMode: 'manual',
+          memoryStrategy: 'project-wiki',
+        })
+      );
+    });
+    expect(apiMocks.setupConnectAiToken).toHaveBeenCalledTimes(1);
+    expect(apiMocks.setupConnectAiToken.mock.calls[0]?.[1]).not.toHaveProperty(
+      'defaultWriteRoomId'
+    );
+
+    expect(
+      screen.getByText(/Project Wiki is available for seeded project scopes/i)
     ).toBeInTheDocument();
   });
 
@@ -526,6 +702,7 @@ describe('auth-pages app', () => {
       },
       dynamicClientRegistrationUrl: 'https://www.eweser.com/oauth/register',
       mcpUrl: 'https://www.eweser.com/mcp',
+      memoryStrategy: defaultMemoryStrategy(),
       oauthMetadataUrl:
         'https://www.eweser.com/.well-known/oauth-authorization-server',
       smartLinkRule:
@@ -594,6 +771,7 @@ describe('auth-pages app', () => {
       },
       dynamicClientRegistrationUrl: 'https://www.eweser.com/oauth/register',
       mcpUrl: 'https://www.eweser.com/mcp',
+      memoryStrategy: defaultMemoryStrategy(),
       oauthMetadataUrl:
         'https://www.eweser.com/.well-known/oauth-authorization-server',
       smartLinkRule:

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -110,60 +110,6 @@ function getRequiredInput(id: string) {
   return element;
 }
 
-function defaultMemoryStrategy(roomIds: string[] = []) {
-  const defaultWriteRoomId = roomIds[0];
-  return {
-    defaultStrategy: 'agent-journal' as const,
-    defaultCaptureMode: 'manual' as const,
-    scopes: [
-      {
-        scopeType: 'global' as const,
-        scopeKey: 'default',
-        label: 'Shared Agent Memory',
-        strategy: 'agent-journal' as const,
-        captureMode: 'manual' as const,
-        ...(defaultWriteRoomId ? { defaultWriteRoomId } : {}),
-        readableRoomIds: roomIds,
-        writableRoomIds: roomIds,
-      },
-    ],
-    choices: [
-      {
-        strategy: 'agent-journal' as const,
-        label: 'Shared Agent Memory',
-        description: 'Portable manual memory.',
-        advanced: false,
-      },
-      {
-        strategy: 'project-wiki' as const,
-        label: 'Project Wiki',
-        description: 'Deterministic project knowledge.',
-        advanced: false,
-      },
-    ],
-    captureModes: [
-      {
-        mode: 'manual' as const,
-        label: 'Manual',
-        description: 'Explicit saves only.',
-        enabled: true,
-      },
-      {
-        mode: 'suggest' as const,
-        label: 'Suggest',
-        description: 'Stage suggested memories.',
-        enabled: true,
-      },
-      {
-        mode: 'auto' as const,
-        label: 'Auto',
-        description: 'Planned.',
-        enabled: false,
-      },
-    ],
-  };
-}
-
 describe('auth-pages app', () => {
   beforeEach(() => {
     cleanup();
@@ -204,7 +150,6 @@ describe('auth-pages app', () => {
       },
       dynamicClientRegistrationUrl: 'https://www.eweser.com/oauth/register',
       mcpUrl: 'https://www.eweser.com/mcp',
-      memoryStrategy: defaultMemoryStrategy(),
       oauthMetadataUrl:
         'https://www.eweser.com/.well-known/oauth-authorization-server',
       smartLinkRule:
@@ -441,7 +386,6 @@ describe('auth-pages app', () => {
       },
       dynamicClientRegistrationUrl: 'https://www.eweser.com/oauth/register',
       mcpUrl: 'https://www.eweser.com/mcp',
-      memoryStrategy: defaultMemoryStrategy(['room-conversations']),
       oauthMetadataUrl:
         'https://www.eweser.com/.well-known/oauth-authorization-server',
       smartLinkRule:
@@ -470,9 +414,6 @@ describe('auth-pages app', () => {
       await screen.findByRole('heading', { name: /connect ai/i, level: 2 })
     ).toBeInTheDocument();
     expect(screen.getByText(/claude desktop/i)).toBeInTheDocument();
-    expect(screen.getAllByText(/shared agent memory/i).length).toBeGreaterThan(
-      0
-    );
     expect(screen.getByText(/writable ai area/i)).toBeInTheDocument();
     expect(screen.getByText(/write scope: 1 room/i)).toBeInTheDocument();
   });
@@ -508,7 +449,6 @@ describe('auth-pages app', () => {
       },
       dynamicClientRegistrationUrl: 'https://www.eweser.com/oauth/register',
       mcpUrl: 'https://www.eweser.com/mcp',
-      memoryStrategy: defaultMemoryStrategy(['room-conversations']),
       oauthMetadataUrl:
         'https://www.eweser.com/.well-known/oauth-authorization-server',
       smartLinkRule:
@@ -556,120 +496,12 @@ describe('auth-pages app', () => {
     await waitFor(() => {
       expect(apiMocks.setupConnectAiToken).toHaveBeenCalledWith(
         'claude-desktop',
-        {
-          captureMode: 'manual',
-          defaultWriteRoomId: 'room-conversations',
-          memoryStrategy: 'agent-journal',
-          readableRoomIds: ['room-conversations'],
-          writableRoomIds: ['room-conversations'],
-        }
+        { writeRoomIds: ['room-conversations', 'room-ai'] }
       );
     });
 
     expect(
       await screen.findByText(/paste this into claude desktop config/i)
-    ).toBeInTheDocument();
-  });
-
-  it('omits defaultWriteRoomId from project-wiki setup payloads', async () => {
-    sessionState = {
-      data: {
-        session: { id: 'session-1' },
-        user: { email: 'test@example.com', id: 'user-1' },
-      },
-      error: null,
-      isPending: false,
-      isRefetching: false,
-      refetch: vi.fn().mockResolvedValue(undefined),
-    };
-
-    apiMocks.getConnectAiOverview.mockResolvedValue({
-      clients: [
-        {
-          clientId: 'codex',
-          connection: null,
-          description:
-            'Remote HTTP MCP config for Codex using bearer_token_env_var.',
-          fallbackReason: null,
-          title: 'Codex',
-          type: 'token-fallback',
-        },
-      ],
-      defaults: {
-        allowedCollections: 'all-supported-collections',
-        permissions: 'read',
-        tokenTtlSeconds: 604800,
-      },
-      dynamicClientRegistrationUrl: 'https://www.eweser.com/oauth/register',
-      mcpUrl: 'https://www.eweser.com/mcp',
-      memoryStrategy: defaultMemoryStrategy(['room-source']),
-      oauthMetadataUrl:
-        'https://www.eweser.com/.well-known/oauth-authorization-server',
-      smartLinkRule:
-        'Never place bearer tokens in URLs. All setup flows stay on authenticated Eweser pages and mint or rotate tokens server-side.',
-      writableRooms: [
-        {
-          id: 'room-source',
-          name: 'Project Memory',
-          collectionKey: 'conversations',
-          syncUrl: null,
-          syncBaseUrl: null,
-        },
-        {
-          id: 'room-drafts',
-          name: 'Wiki Drafts',
-          collectionKey: 'projectWikiDrafts',
-          syncUrl: null,
-          syncBaseUrl: null,
-        },
-        {
-          id: 'room-pages',
-          name: 'Wiki Pages',
-          collectionKey: 'projectWikiPages',
-          syncUrl: null,
-          syncBaseUrl: null,
-        },
-      ],
-    });
-    apiMocks.setupConnectAiToken.mockResolvedValue({
-      agent: { id: 'agent-1', permissions: 'read', tokenExpiresAt: null },
-      clientId: 'codex',
-      payload: {
-        configFormat: 'toml',
-        instructions: 'Add this to ~/.codex/config.toml.',
-        snippet: '[mcp_servers.eweser]',
-      },
-      token: 'raw-token',
-    });
-
-    renderApp('/account/connect-ai');
-
-    await screen.findByRole('heading', { name: /connect ai/i, level: 2 });
-    await userEvent.selectOptions(
-      screen.getByLabelText(/strategy/i),
-      'project-wiki'
-    );
-    const button = await screen.findByRole('button', {
-      name: /prepare setup/i,
-    });
-    await userEvent.click(button);
-
-    await waitFor(() => {
-      expect(apiMocks.setupConnectAiToken).toHaveBeenCalledWith(
-        'codex',
-        expect.objectContaining({
-          captureMode: 'manual',
-          memoryStrategy: 'project-wiki',
-        })
-      );
-    });
-    expect(apiMocks.setupConnectAiToken).toHaveBeenCalledTimes(1);
-    expect(apiMocks.setupConnectAiToken.mock.calls[0]?.[1]).not.toHaveProperty(
-      'defaultWriteRoomId'
-    );
-
-    expect(
-      screen.getByText(/Project Wiki is available for seeded project scopes/i)
     ).toBeInTheDocument();
   });
 
@@ -704,7 +536,6 @@ describe('auth-pages app', () => {
       },
       dynamicClientRegistrationUrl: 'https://www.eweser.com/oauth/register',
       mcpUrl: 'https://www.eweser.com/mcp',
-      memoryStrategy: defaultMemoryStrategy(),
       oauthMetadataUrl:
         'https://www.eweser.com/.well-known/oauth-authorization-server',
       smartLinkRule:
@@ -773,7 +604,6 @@ describe('auth-pages app', () => {
       },
       dynamicClientRegistrationUrl: 'https://www.eweser.com/oauth/register',
       mcpUrl: 'https://www.eweser.com/mcp',
-      memoryStrategy: defaultMemoryStrategy(),
       oauthMetadataUrl:
         'https://www.eweser.com/.well-known/oauth-authorization-server',
       smartLinkRule:

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -284,7 +284,9 @@ describe('auth-pages app', () => {
 
     expect(await screen.findByLabelText(/email/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /^sign in$/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /^sign in$/i })
+    ).toBeInTheDocument();
   });
 
   it('should sign in and redirect to the permission page when a login query is present', async () => {

--- a/packages/app/src/pages.tsx
+++ b/packages/app/src/pages.tsx
@@ -100,6 +100,32 @@ const abuseEmail = 'abuse@eweser.com';
 const privacyEmail = 'privacy@eweser.com';
 const copyrightEmail = 'copyright@eweser.com';
 
+function readAuthErrorMessage(result: unknown): string | null {
+  if (!result || typeof result !== 'object' || !('error' in result)) {
+    return null;
+  }
+
+  const error = result.error;
+  if (!error || typeof error !== 'object' || !('message' in error)) {
+    return null;
+  }
+
+  return typeof error.message === 'string' ? error.message : null;
+}
+
+function readAuthDataToken(result: unknown): string | null {
+  if (!result || typeof result !== 'object' || !('data' in result)) {
+    return null;
+  }
+
+  const data = result.data;
+  if (!data || typeof data !== 'object' || !('token' in data)) {
+    return null;
+  }
+
+  return typeof data.token === 'string' ? data.token : null;
+}
+
 function ThemeToggle() {
   const { resolvedTheme, setTheme } = useTheme();
   const isDark = resolvedTheme === 'dark';
@@ -424,8 +450,9 @@ function SignInPage() {
         })
       );
 
-      if (result.error) {
-        setError(result.error.message ?? 'Unable to sign in.');
+      const errorMessage = readAuthErrorMessage(result);
+      if (errorMessage) {
+        setError(errorMessage);
         return;
       }
 
@@ -456,8 +483,9 @@ function SignInPage() {
         })
       );
 
-      if (result.error) {
-        setError(result.error.message ?? 'Unable to continue with OAuth.');
+      const errorMessage = readAuthErrorMessage(result);
+      if (errorMessage) {
+        setError(errorMessage);
       }
     } catch (requestError) {
       setError(
@@ -622,7 +650,7 @@ function SignUpPage() {
     setLoading(true);
 
     const nextPath = resolvePostAuthPath(persistedLoginQuery, returnTo);
-    let result;
+    let result: unknown;
 
     try {
       result = await withTimeout(
@@ -666,12 +694,13 @@ function SignUpPage() {
       setCaptchaKey((current) => current + 1);
     }
 
-    if (result.error) {
-      setError(result.error.message ?? 'Unable to create your account.');
+    const errorMessage = readAuthErrorMessage(result);
+    if (errorMessage) {
+      setError(errorMessage);
       return;
     }
 
-    if (result.data?.token) {
+    if (readAuthDataToken(result)) {
       navigate(nextPath, { replace: true });
       return;
     }
@@ -1300,9 +1329,10 @@ function SignOutPage() {
       }
 
       const result = await authClient.signOut();
-      if (result.error) {
+      const errorMessage = readAuthErrorMessage(result);
+      if (errorMessage) {
         if (active) {
-          setError(result.error.message ?? 'Unable to sign out.');
+          setError(errorMessage);
         }
         return;
       }
@@ -2129,6 +2159,7 @@ export function AppRoutes() {
         path="/"
       />
       <Route element={<SignInPage />} path="/sign-in" />
+      <Route element={<SignInPage />} path="/auth/sign-in" />
       <Route element={<SignUpPage />} path="/sign-up" />
       <Route element={<TwoFactorChallengePage />} path="/two-factor" />
       <Route element={<ForgotPasswordPage />} path="/forgot-password" />


### PR DESCRIPTION
## Summary
- add an auth-pages route alias for /auth/sign-in so the old login URL no longer lands on the not-found screen
- cover the legacy route in the auth-pages app test suite

## Verification
- npm test --workspace @eweser/app -- src/App.test.tsx
- npm run type-check --workspace @eweser/app
- npm run build --workspace @eweser/app
