### PR TITLE
Add Eweser glossary grill workflow

### DIFF
--- a/.codex/skills/eweser-coder/SKILL.md
+++ b/.codex/skills/eweser-coder/SKILL.md
@@ -21,14 +21,15 @@ Planner -> Coder workflow.
 
 1. Check `git status --short --branch` and avoid reverting unrelated user changes.
 2. Read the plan file. The user should provide a path such as `docs/ai/plans/YYYY-MM-DD-feature.md`.
-3. Read `AGENTS.md`, `ARCHITECTURE.md`, `.github/copilot-instructions.md`, and `docs/ai/workflows/codex-planner-coder.md`.
-4. Read the nearest `INDEX.md` before broad `rg` or `find` exploration. For symbol/import/export questions, prefer `npm run code-map:query -- --symbol <name>`, `--file <path>`, or `--package <name>` before dumping source into context.
-5. Read the relevant package `AGENTS.md` for the run scope.
-6. Read existing tests around the affected code before changing behavior.
-7. Identify which run to start from. Default to Run 1 and implement all runs sequentially.
-8. Confirm the plan's approval boundary covers the requested work. If not, stop and ask for approval.
-9. Before running tests, starting services, Cypress, or browser flows, run `~/.codex/skills/eweser-runtime-orientation/scripts/eweser-runtime-orientation.sh status`; run `refresh` if endpoints are unknown or stale.
-10. Do not edit `node_modules/`, `dist/`, or generated files unless the plan explicitly requires generated output.
+3. Read `AGENTS.md`, `ARCHITECTURE.md`, `.github/copilot-instructions.md`, `GLOSSARY-MAP.md`, and `docs/ai/workflows/codex-planner-coder.md`.
+4. Read the nearest `INDEX.md` before broad `rg` or `find` exploration. For symbol/import/export questions, prefer `npm run code-map:query -- --symbol <name>`, `--file <path>`, or `--package <name>` before dumping source into the prompt.
+5. Read relevant mapped `GLOSSARY.md` files for the run scope, especially when the plan's Domain Language section names them.
+6. Read the relevant package `AGENTS.md` for the run scope.
+7. Read existing tests around the affected code before changing behavior.
+8. Identify which run to start from. Default to Run 1 and implement all runs sequentially.
+9. Confirm the plan's approval boundary covers the requested work. If not, stop and ask for approval.
+10. Before running tests, starting services, Cypress, or browser flows, run `~/.codex/skills/eweser-runtime-orientation/scripts/eweser-runtime-orientation.sh status`; run `refresh` if endpoints are unknown or stale.
+11. Do not edit `node_modules/`, `dist/`, or generated files unless the plan explicitly requires generated output.
 
 Read long docs in targeted chunks. Do not concatenate multiple large docs or
 full source files into one command when an index, heading search, or `code-map`
@@ -50,6 +51,7 @@ query can narrow the next file to inspect.
 
 - The approved plan is the approval boundary. Stay inside it.
 - Minimal diff: extend existing patterns before adding new abstractions.
+- Preserve canonical domain terms from the relevant `GLOSSARY.md` files. If implementation reveals a terminology correction inside the approval boundary, update the glossary and plan summary.
 - TypeScript strict mode: no `any` unless unavoidable and documented.
 - Yjs writes: always through CRDT helpers such as `docs.set()`, `docs.new()`, or `yDoc.transact()`.
 - Never directly mutate Yjs-observed objects.
@@ -72,6 +74,8 @@ Use sidecars to keep implementation moving, not to obscure ownership.
 
 ## Test strategy
 
+Use tracer-bullet slices where practical: write one failing behavior test,
+implement the smallest useful path, then refactor while keeping tests green.
 Write tests before or alongside implementation:
 
 - Unit tests: Vitest in `packages/*/src/**/*.test.ts`.

--- a/.codex/skills/eweser-grill-with-docs/SKILL.md
+++ b/.codex/skills/eweser-grill-with-docs/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: eweser-grill-with-docs
+description: >
+  Use this skill in the EweserDB repo when the user wants to stress-test a
+  feature, plan, product decision, or naming choice against EweserDB domain
+  language before implementation. It uses GLOSSARY-MAP.md, package GLOSSARY.md
+  glossaries, INDEX.md navigation, AGENTS.md, and ADRs to challenge fuzzy terms,
+  resolve DDD-style language, update glossary docs, and identify sparse ADR
+  candidates. It ends with self-reflection and skill-improvement suggestions
+  when the session reveals workflow gaps. Planner-style only: do not edit
+  product code.
+---
+
+# Role: EweserDB Grill With Docs
+
+You interview the user and the repo until a plan's terminology and decision
+boundaries are precise enough for Planner or Coder to use.
+
+## Startup
+
+1. Read `AGENTS.md`, the nearest `INDEX.md`, and `GLOSSARY-MAP.md`.
+2. Read only the relevant `GLOSSARY.md` files from the glossary map.
+3. Read `docs/ai/adr/README.md` and only the ADRs directly related to the
+   question.
+4. If there is an existing plan, read that plan and `docs/ai/plans/_template.md`.
+5. If the user asks for smoke-test prompts for this skill, read
+   `references/test-prompts.md`.
+
+## Grilling Loop
+
+- If the answer can be found in code or docs, inspect the repo instead of
+  asking the user to restate it.
+- Ask one unresolved question at a time and wait for the user's answer before
+  resolving that term, updating docs for that term, or moving to the next
+  unresolved question.
+- Use Codex's built-in question UI whenever it is available:
+  - Call `request_user_input` with exactly one question.
+  - Provide two or three mutually exclusive options only when the question has
+    clear choices.
+  - Put the repo-recommended option first and suffix its label with
+    `(Recommended)` when a recommendation exists, but do not treat that option
+    as accepted until the user chooses it.
+  - Include a concise free-form path by relying on the client's built-in
+    `Other` option; do not add your own `Other` option.
+- If `request_user_input` is unavailable, ask one concise question in chat and
+  stop the turn immediately. Do not include a final summary, continue the grill,
+  or answer the question yourself.
+- Never self-answer a question after asking it. A recommendation is only a
+  recommendation, not approval to proceed.
+- Challenge glossary conflicts immediately. Example: "The glossary uses
+  `access grant`, but this plan says `permission`. Do you mean grant, room ACL,
+  or token scope?"
+- Stress-test relationships with concrete scenarios, especially around rooms,
+  collections, grants, sync, public aggregation, E2EE, backups, and MCP access.
+- Keep terms aligned with user-owned/local-first product language.
+- Notice friction while grilling: repeated ambiguity, missing glossary terms,
+  stale docs, weak examples, or questions that could have been answered from
+  repo docs.
+
+## Updating Docs
+
+- When a term is resolved, update the relevant `GLOSSARY.md` during the session.
+- Keep `GLOSSARY.md` files as glossaries only. Do not put implementation steps,
+  TODOs, acceptance criteria, or speculative design notes there.
+- Add or update a plan's `Domain Language` section when a plan exists.
+- Offer an ADR only when the decision is hard to reverse, broad in impact, and
+  surprising without background.
+- If the session reveals a possible improvement to this skill, record it in the
+  final self-reflection. Do not edit the skill itself unless the user's request
+  explicitly includes skill updates.
+
+## Output
+
+End with:
+
+- resolved canonical terms;
+- open terminology questions, if any;
+- `GLOSSARY.md` files changed;
+- ADR candidates, if any;
+- the next planner/coder handoff.
+- self-reflection: what the grilling clarified, what remained hard, and whether
+  the repo docs made the right answer discoverable;
+- skill adjustment suggestions: concrete updates to this skill, its prompt
+  examples, or glossary workflow, or `None`.
+
+Do not write product code in this skill.

--- a/.codex/skills/eweser-grill-with-docs/references/test-prompts.md
+++ b/.codex/skills/eweser-grill-with-docs/references/test-prompts.md
@@ -1,0 +1,32 @@
+# EweserDB Grill-With-Docs Test Prompts
+
+Use these prompts to smoke-test the skill against real EweserDB docs. Each
+prompt should keep the skill in planner/docs mode: glossary and plan edits are
+allowed, product code edits are not. Each prompt should end with
+self-reflection and skill adjustment suggestions, even when the suggestion is
+`None`, unless the skill is waiting for the user's answer to a built-in
+question.
+
+1. `$eweser-grill-with-docs on docs/ai/plans/2026-05-16-db-readme-todo-backlog.md run 4. Stress-test server identity, peer server, federation request, and federated principal language before implementation. Use Codex's built-in question UI for the first unresolved question, wait for my answer, update GLOSSARY.md files only when a term is resolved, and finish with self-reflection plus skill adjustment suggestions.`
+
+2. `$eweser-grill-with-docs on docs/ai/plans/2026-05-16-db-readme-todo-backlog.md run 5. Challenge every use of "permission", "access", "identity", and "relay" against the glossary map. Resolve terms from repo evidence where possible, but ask one built-in question and stop when user input is required.`
+
+3. `$eweser-grill-with-docs on docs/ai/plans/2026-05-16-db-readme-todo-backlog.md run 6. Distinguish user snapshot, operator backup, backup listener, sync relay persistence, and federation-as-backup. Update glossary docs if the distinctions are stable.`
+
+4. `$eweser-grill-with-docs on docs/ai/plans/2026-05-16-db-readme-todo-backlog.md run 7. Grill the encrypted-room decision against privacy, public aggregation, MCP access, collaboration, account recovery, passkeys, and authenticator apps. End with ADR candidates, open terminology questions, self-reflection, and skill adjustment suggestions.`
+
+5. `$eweser-grill-with-docs on docs/ai/plans/2026-05-16-db-readme-todo-backlog.md run 9. Refine schema/API versioning language so it separates SDK API, shared collection schema, auth API, sync protocol, aggregator API, and storage provider profile compatibility.`
+
+6. `$eweser-grill-with-docs on docs/ai/plans/2026-05-16-db-readme-todo-backlog.md run 11. Decide whether "permission page" is acceptable user-facing copy or whether this plan should use access approval, access grant, grant satisfaction, and app capability instead.`
+
+7. `$eweser-grill-with-docs over packages/db/README.md, ARCHITECTURE.md, and GLOSSARY-MAP.md. Find stale or ambiguous terms left from the old README TODO list, especially around public data, backups, federation, E2EE, and migrations. Make docs-only glossary or plan edits.`
+
+8. `$eweser-grill-with-docs over packages/aggregator/README.md and packages/aggregator/GLOSSARY.md. Check whether public search, public room, publication state, indexability, and de-indexing are consistently named and do not imply private synced data is searchable.`
+
+9. `$eweser-grill-with-docs over packages/mcp-server/README.md, packages/mcp-server/GLOSSARY.md, and the active AI memory plans. Separate Agent Journal, project wiki, memory scope, readable room scope, and writable room scope.`
+
+10. `$eweser-grill-with-docs on a new feature idea: "let agents read all my notes and make a backup." Force precise EweserDB language for agent tokens, readable room scope, user snapshots, encrypted rooms, and public aggregation before any implementation plan is written.`
+
+11. `$eweser-grill-with-docs on docs/ai/plans/2026-05-16-db-readme-todo-backlog.md run 13. After resolving hosted sync usage language, evaluate whether the skill asked questions that were answerable from docs, whether any glossary docs were missing terms, and whether the skill itself needs a new prompt example or rule.`
+
+12. `$eweser-grill-with-docs over GLOSSARY-MAP.md, GLOSSARY.md, README.md, and ARCHITECTURE.md. Test whether the current product description has stable domain language for rooms, collections, grants, sync, public aggregation, encrypted rooms, backups, and MCP access. Use Codex's built-in question UI for any unresolved term, do not answer your own question, and do not continue until I answer.`

--- a/.codex/skills/eweser-planner/SKILL.md
+++ b/.codex/skills/eweser-planner/SKILL.md
@@ -24,20 +24,22 @@ Read:
 1. `AGENTS.md`
 2. `ARCHITECTURE.md`
 3. `.github/copilot-instructions.md`
-4. `docs/ai/workflows/codex-planner-coder.md`
-5. `docs/ai/plans/_template.md`
-6. Relevant package `AGENTS.md`, for example `packages/db/AGENTS.md`
-7. Any existing plan in `docs/ai/plans/` related to the feature
+4. `GLOSSARY-MAP.md` and relevant mapped `GLOSSARY.md` files
+5. `docs/ai/workflows/codex-planner-coder.md`
+6. `docs/ai/plans/_template.md`
+7. Relevant package `AGENTS.md`, for example `packages/db/AGENTS.md`
+8. Any existing plan in `docs/ai/plans/` related to the feature
 
 ## Workflow
 
 1. Ask only blocking clarifying questions first if the goal, scope, or acceptance criteria are unclear. If uncertainty is non-blocking, record it as an assumption in the plan and keep going.
 2. Research the codebase to understand current state.
-3. Run small feasibility experiments only when allowed by the user and useful for planning.
-4. Review architecture boundaries, migration impact, cascading type changes, and changeset requirements.
-5. For substantial work, save a draft plan to `docs/ai/plans/YYYY-MM-DD-<slug>.md`.
-6. For small, clear work, produce a concise implementation outline instead of a plan file.
-7. Present the plan or outline for approval and stop. Do not begin implementation.
+3. Challenge fuzzy or conflicting domain terms against the relevant `GLOSSARY.md` files. If a term is resolved, update the glossary immediately.
+4. Run small feasibility experiments only when allowed by the user and useful for planning.
+5. Review architecture boundaries, migration impact, cascading type changes, ADR candidates, and changeset requirements.
+6. For substantial work, save a draft plan to `docs/ai/plans/YYYY-MM-DD-<slug>.md`.
+7. For small, clear work, produce a concise implementation outline instead of a plan file.
+8. Present the plan or outline for approval and stop. Do not begin implementation.
 
 ## Research rules
 
@@ -53,7 +55,7 @@ Use sidecars only for separable research questions.
 
 - Use `scripts/codex/mini-worker.sh code "..."` for local code exploration.
 - Use `scripts/codex/mini-worker.sh web "..."` for current external documentation checks.
-- Use `scripts/codex/mini-worker.sh research "..."` when the question needs both local and external context.
+- Use `scripts/codex/mini-worker.sh research "..."` when the question needs both local and external research.
 - Use Codex app subagents only when the user explicitly asks for subagents, delegation, or parallel work.
 
 ## Questions to ask first
@@ -62,6 +64,7 @@ Use sidecars only for separable research questions.
 - Packages: which workspaces are in scope?
 - Constraints: published API, migration, offline-first, auth/security, or release constraints?
 - Acceptance criteria: how do we know the work is done?
+- Domain language: which terms should be canonical, and which terms are ambiguous?
 
 ## Architecture review
 
@@ -93,6 +96,13 @@ Use `docs/ai/plans/_template.md`. Save to
 
 - Assumption: ...
 - Open question: ...
+
+## Domain Language
+
+- Glossary docs: ...
+- New terms: ...
+- Changed terms: ...
+- ADR candidates: ...
 
 ## Runs
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -80,6 +80,10 @@ If you are creating, updating, or reviewing index files or source headers,
 also read [`docs/ai/code-indexing.md`](../docs/ai/code-indexing.md) and apply
 its contract in the same change.
 
+Use [`GLOSSARY-MAP.md`](../GLOSSARY-MAP.md) and the mapped `GLOSSARY.md` files for
+canonical EweserDB domain language. Treat those files as glossaries only; plans
+belong in `docs/ai/plans/` and architectural decisions belong in ADRs.
+
 Use the three-phase workflow for substantial or ambiguous work:
 
 1. `01-planner` / `planner` - research and write a scoped plan

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ EweserDB is a local-first, user-owned database SDK built on Yjs CRDTs. Users own
 - Read `README.md` for product philosophy and API overview.
 - Read `ARCHITECTURE.md` for current system design.
 - Read `LOCAL_DEVELOPMENT.md` for setup and local service details.
-- Treat `docs/ai/` and `docs/ai/adr/` as historical context unless a file explicitly says it is current guidance.
+- Treat `docs/ai/` and `docs/ai/adr/` as historical background unless a file explicitly says it is current guidance.
 - Product/user configuration that must interoperate across apps should live in
   EweserDB rooms or shared schemas. PostgreSQL in `packages/auth-server-hono`
   should be reserved for auth, grants, sessions, OAuth, operational tokens, and
@@ -139,6 +139,17 @@ after the index narrows the search space to the right package, source root, or
 boundary file.
 If you are creating, updating, or reviewing index files or source headers,
 also read `docs/ai/code-indexing.md` and apply its contract in the same change.
+
+## Domain Language
+
+Use `GLOSSARY-MAP.md` and the mapped `GLOSSARY.md` files to keep planning,
+implementation, docs, and user-facing copy aligned with EweserDB domain
+language. These files are glossaries only: do not put implementation plans,
+acceptance criteria, TODOs, or temporary design notes in them.
+
+For substantial or ambiguous work, resolve fuzzy terms during planning. Update
+the relevant `GLOSSARY.md` when a canonical term is decided. Create or update an
+ADR only for hard-to-reverse decisions that would be surprising without background.
 
 For substantial or ambiguous work, use the Planner -> Coder workflow:
 

--- a/GLOSSARY-MAP.md
+++ b/GLOSSARY-MAP.md
@@ -1,0 +1,33 @@
+# EweserDB Glossary Map
+
+This file maps the DDD-style language areas that agents should use when
+stress-testing plans and naming changes. `GLOSSARY.md` files are glossaries only:
+they define shared language, not implementation plans, specs, or scratch notes.
+
+## How To Use
+
+- Read the root `GLOSSARY.md` before substantial product, SDK, auth, sync, app,
+  or agent-access work.
+- Read the package glossary below when work touches that language area.
+- When a term is resolved during planning, update the relevant `GLOSSARY.md`
+  immediately with the canonical wording.
+- If a decision is hard to reverse and surprising without background, consider an
+  ADR under `docs/ai/adr/`; do not use ADRs for ordinary implementation notes.
+
+## Glossaries
+
+| Language area             | Glossary                                                                           | Use when                                                                                                                           |
+| ------------------------- | ---------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Shared product language   | [`GLOSSARY.md`](./GLOSSARY.md)                                                     | Naming product concepts that span packages, docs, plans, and user-facing copy.                                                     |
+| SDK rooms and documents   | [`packages/db/GLOSSARY.md`](./packages/db/GLOSSARY.md)                             | Changing `@eweser/db`, room/document helpers, local persistence, sync client behavior, or public SDK APIs.                         |
+| Auth and grants           | [`packages/auth-server-hono/GLOSSARY.md`](./packages/auth-server-hono/GLOSSARY.md) | Changing sessions, OAuth, room access grants, sync tokens, agent tokens, or auth-server PostgreSQL boundaries.                     |
+| Sync relay                | [`packages/sync-server/GLOSSARY.md`](./packages/sync-server/GLOSSARY.md)           | Changing Hocuspocus room sync, token authentication, persistence, or webhook forwarding.                                           |
+| Public aggregation        | [`packages/aggregator/GLOSSARY.md`](./packages/aggregator/GLOSSARY.md)             | Changing public indexing, webhook ingestion, search, or de-indexing behavior.                                                      |
+| Ewe Note bases and vaults | [`packages/ewe-note/GLOSSARY.md`](./packages/ewe-note/GLOSSARY.md)                 | Changing notes, bases, vault import/export, editor behavior, or Obsidian compatibility.                                            |
+| MCP and agent memory      | [`packages/mcp-server/GLOSSARY.md`](./packages/mcp-server/GLOSSARY.md)             | Changing MCP tools, local stdio or remote HTTP MCP setup, agent room access, memory capture, project scopes, or tool output rules. |
+
+## ADR Policy
+
+`docs/ai/adr/README.md` is the current index for accepted EweserDB ADRs. Treat
+individual ADRs with `Accepted` or `Implemented` status as current decision
+records unless a newer ADR or active plan explicitly supersedes them.

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -1,0 +1,95 @@
+# EweserDB Shared Language
+
+This file is a glossary for product language that crosses packages. Keep it
+free of implementation steps, TODOs, and temporary design notes.
+
+## Terms
+
+- **EweserDB**: The local-first, user-owned database product and SDK ecosystem.
+- **User-owned data**: Data controlled by the user and portable across apps,
+  agents, and self-hosted deployments.
+- **Room**: A Yjs-backed container with a collection key, shared schema, and
+  room access control. Rooms are the main authorization and remote-sync
+  boundary; folders and bases may organize room content but do not replace room
+  collection boundaries.
+- **Collection**: A named set of documents with a shared shape, such as `notes`
+  or `fileAttachments`.
+- **Shared schema**: A TypeScript and runtime contract that lets independent
+  apps understand the same collection data.
+- **Document**: One item inside a room collection. Documents are changed through
+  EweserDB/Yjs helpers, not by directly mutating observed Yjs data.
+- **Reference**: A cross-document `_ref` built from auth server, collection,
+  room, and document identifiers.
+- **App**: A client that requests access to user-owned rooms through the auth
+  flow, then uses the SDK locally.
+- **Access grant**: An auditable authorization that lets an app or agent read or
+  write selected rooms.
+- **Room ACL**: The room-level owner, admin, read, and write state used to
+  enforce access. A room ACL is not the same thing as an app access grant,
+  OAuth authorization, sync token, or MCP room scope.
+- **Remote sync**: Optional Hocuspocus/Yjs synchronization through the sync
+  relay. Remote sync does not make a room public.
+- **Sync relay**: The Hocuspocus service that relays Yjs updates for
+  authenticated room connections and may forward publication metadata to the
+  aggregator. It is not a backup system or public-search service.
+- **Sync token**: A short-lived token that lets a client connect to the sync
+  relay for a scoped room.
+- **Public room**: A room intentionally published for public aggregation or
+  search. Public is explicit; private rooms must not be indexed.
+- **Publication state**: The explicit public/private room state used to decide
+  whether the aggregator may index room data.
+- **Public search**: Search over indexed rows from explicitly public rooms.
+  Public search must not imply access to private, merely synced, shared, or
+  MCP-readable rooms.
+- **User snapshot**: A portable backup bundle created for a user's selected
+  rooms. A user snapshot is not a sync replica, operator database backup, or
+  federation backup listener.
+- **Encrypted room**: An opt-in room whose content is protected by client-held
+  keys. Current docs must not imply ordinary hosted rooms are end-to-end
+  encrypted; encrypted rooms must describe reduced search, public aggregation,
+  recovery, collaboration, and MCP access honestly.
+- **Federated principal**: A user or service identity from another EweserDB
+  auth server, usually displayed as a server-qualified identity.
+- **Server identity**: A stable public identity for an EweserDB auth server,
+  used to verify federation requests and peer trust.
+- **Peer server**: Another EweserDB auth server that participates in
+  federation, relay sync, or backup-listener flows.
+- **Backup listener**: A trusted peer-server role that follows selected room
+  updates for recovery. It is not a human collaborator and not an operator
+  backup.
+- **Capability**: A bounded action an app, token, or agent may perform, such as
+  reading rooms, writing rooms, or requesting sync.
+- **Compatibility policy**: The repo's rules for how SDK APIs, shared schemas,
+  server APIs, sync protocol, and persisted room data may change over time.
+- **Base**: The user-facing workspace unit for vault-style data. A base groups
+  rooms without replacing room collection boundaries.
+- **Vault**: The Obsidian-compatible filesystem/workspace concept represented by
+  a base in Ewe Note.
+- **Agent Journal**: The default Eweser-native memory strategy for coding
+  continuity, decisions, preferences, and project session history.
+- **Project scope**: The boundary agents use for repo or project-specific memory
+  and room access.
+- **MCP-readable room**: A room included in an agent's readable room scope.
+  MCP-readable is not the same thing as public-searchable.
+
+## Ambiguous Terms
+
+- **Database**: Use `EweserDB` for the product, `Database` for the SDK class,
+  and `PostgreSQL` only for auth-server operational storage.
+- **Permission**: Prefer the precise term: access grant, room ACL, token scope,
+  or app capability.
+- **Access**: Clarify whether this means app access grant, room ACL, sync token
+  scope, readable room scope, writable room scope, or public-search
+  indexability.
+- **Sync**: Clarify whether this means local persistence, remote sync through
+  the sync relay, sync relay persistence, federation relay, backup-listener
+  relay, or filesystem/vault sync.
+- **Public data**: Do not use as shorthand for "shareable" or "synced". Use
+  `public room` only when indexing/search is explicitly enabled.
+- **Backup**: Clarify whether this means a user snapshot, operator database
+  backup, sync relay persistence, or federation backup listener.
+- **Encrypted/E2EE**: Use `encrypted room` only for an explicit opt-in room
+  encryption feature. Do not use it for TLS, disk encryption, provider storage
+  encryption, or ordinary hosted sync.
+- **Memory**: Clarify whether this means Agent Journal records, project wiki
+  source material, derived processor output, or ordinary note content.

--- a/INDEX.md
+++ b/INDEX.md
@@ -20,6 +20,8 @@ shared schemas, auth grants, sync, and interoperable apps.
 - [`LOCAL_DEVELOPMENT.md`](./LOCAL_DEVELOPMENT.md): Local service setup and
   ports.
 - [`AGENTS.md`](./AGENTS.md): Repo-wide agent policy.
+- [`GLOSSARY-MAP.md`](./GLOSSARY-MAP.md): Domain-language glossary map for
+  planning and AI agents.
 - [`docs/ai/code-indexing.md`](./docs/ai/code-indexing.md): Index format and
   checker contract.
 - [`packages/INDEX.md`](./packages/): Workspace package map.
@@ -46,11 +48,14 @@ shared schemas, auth grants, sync, and interoperable apps.
 - Public package API changes to `@eweser/db`, `@eweser/shared`, or
   `@eweser/examples-components` require a changeset.
 - Never delete migrations or commit secrets.
+- `GLOSSARY.md` files are glossaries only. Put implementation plans in
+  `docs/ai/plans/` and architectural decisions in ADRs.
 
 ## Update Triggers
 
 - Update when the monorepo layout, package relationships, root commands,
-  architecture docs, agent workflow, or top-level quality gates change.
+  architecture docs, domain-language map, agent workflow, or top-level quality
+  gates change.
 - Update nearby child indexes when ownership, public entry points, auth/security
   behavior, Yjs behavior, or test commands change.
 

--- a/docs/ai/adr/README.md
+++ b/docs/ai/adr/README.md
@@ -2,6 +2,11 @@
 
 Short, permanent records of significant architectural decisions made during EweserDB development.
 
+> Status: active decision index. ADRs with `Accepted` or `Implemented` status
+> are current decision records unless a newer ADR or active plan explicitly
+> supersedes them. Treat ordinary `docs/ai/plans/` files as historical unless
+> marked current in the plans index.
+
 ## Index
 
 | ID                                              | Title                                         | Status      | Date       |

--- a/docs/ai/plans/README.md
+++ b/docs/ai/plans/README.md
@@ -15,12 +15,22 @@ Every new plan must include:
 - Goal
 - Scope
 - Assumptions / open questions
+- Domain language and relevant `GLOSSARY.md` files when the work introduces or
+  changes product terms
 - Runs with id, title, files, steps, tests, verification, dependencies, model
   tier, and risk level
 - Stop conditions
 - Approval boundary
 - Execution summary
 - Self-reflection / instruction improvements
+
+For terminology-heavy plans or runs, especially federation, encrypted rooms,
+public aggregation, MCP/agent access, backups, and compatibility policy, run
+`eweser-grill-with-docs` before implementation approval. It should resolve
+canonical terms into `GLOSSARY.md` and the plan's Domain Language section without
+editing product code. Each grilling session should end with a brief
+self-reflection and concrete skill-adjustment suggestions when the workflow
+itself needs improvement.
 
 Use `eweser-coder` for coding runs in plan metadata and examples.
 
@@ -77,13 +87,13 @@ plan. Standalone QA is reserved for independent re-QA or audit work.
 
 ### Deferred Backlog
 
-| Plan                                                                           | Status      | Notes                                                            |
-| ------------------------------------------------------------------------------ | ----------- | ---------------------------------------------------------------- |
-| [2026-05-16-db-readme-todo-backlog.md](./2026-05-16-db-readme-todo-backlog.md) | Proposed    | Consolidates remaining DB README TODOs into implementation runs. |
-| [2026-04-02-phase-4-deploy.md](./2026-04-02-phase-4-deploy.md)                 | Mostly done | Keep only for remaining production polish/cleanup notes.         |
-| [2026-04-02-phase-5-mobile.md](./2026-04-02-phase-5-mobile.md)                 | Deferred    | PWA exists; Capacitor/native app work is not launch-path.        |
-| [2026-04-03-file-storage.md](./2026-04-03-file-storage.md)                     | Deferred    | Object storage, file APIs, and BYO storage provider work.        |
-| [2026-04-05-auto-knowledge-graph.md](./2026-04-05-auto-knowledge-graph.md)     | Deferred    | Later graph/search layer concept.                                |
+| Plan                                                                           | Status      | Notes                                                                                                                      |
+| ------------------------------------------------------------------------------ | ----------- | -------------------------------------------------------------------------------------------------------------------------- |
+| [2026-05-16-db-readme-todo-backlog.md](./2026-05-16-db-readme-todo-backlog.md) | Proposed    | Consolidates remaining DB README TODOs; terminology-heavy runs should pass through `eweser-grill-with-docs` before coding. |
+| [2026-04-02-phase-4-deploy.md](./2026-04-02-phase-4-deploy.md)                 | Mostly done | Keep only for remaining production polish/cleanup notes.                                                                   |
+| [2026-04-02-phase-5-mobile.md](./2026-04-02-phase-5-mobile.md)                 | Deferred    | PWA exists; Capacitor/native app work is not launch-path.                                                                  |
+| [2026-04-03-file-storage.md](./2026-04-03-file-storage.md)                     | Deferred    | Object storage, file APIs, and BYO storage provider work.                                                                  |
+| [2026-04-05-auto-knowledge-graph.md](./2026-04-05-auto-knowledge-graph.md)     | Deferred    | Later graph/search layer concept.                                                                                          |
 
 ## Completed Plans
 

--- a/docs/ai/plans/_template.md
+++ b/docs/ai/plans/_template.md
@@ -14,6 +14,13 @@
 - Assumption: <Known fact or working assumption.>
 - Open question: <Question that must be answered before or during implementation.>
 
+## Domain Language
+
+- Glossary docs: <Relevant GLOSSARY.md files, or "None needed".>
+- New terms: <Canonical term and definition, or "None".>
+- Changed terms: <Existing term whose meaning/naming changes, or "None".>
+- ADR candidates: <Hard-to-reverse decisions that may need ADRs, or "None".>
+
 ## Runs
 
 ## Run Order And Manual Test Handoffs

--- a/docs/ai/workflows/codex-planner-coder.md
+++ b/docs/ai/workflows/codex-planner-coder.md
@@ -24,6 +24,8 @@ Planner may:
 - Ask clarifying questions when goal, scope, or acceptance criteria are unclear.
 - Run read-only inspection and small feasibility checks when useful.
 - Create or update plan documents in `docs/ai/plans/`.
+- Create or update `GLOSSARY.md` glossary entries when domain language is
+  resolved during planning.
 
 Planner must not:
 
@@ -69,6 +71,8 @@ include:
 - Goal
 - Scope
 - Assumptions / open questions
+- Domain language: relevant `GLOSSARY.md` files, new or changed terms, and ADR
+  candidates
 - Runs with id, title, files, steps, tests, verification, dependencies, model
   tier, and risk level
 - For orchestrated UI runs, explicit `ui: true | false` classification and the

--- a/packages/aggregator/GLOSSARY.md
+++ b/packages/aggregator/GLOSSARY.md
@@ -1,0 +1,33 @@
+# Public Aggregation Language
+
+This file is a glossary for `@eweser/aggregator`. Keep it free of
+implementation steps, TODOs, and temporary design notes.
+
+## Terms
+
+- **Aggregator**: The server-side service that indexes explicitly public room
+  data for search.
+- **Indexed row**: A database row derived from public room data for search or
+  discovery.
+- **Webhook event**: A signed or trusted update received from the sync relay for
+  possible indexing.
+- **Publication state**: The explicit room state that says whether room data may
+  be considered for indexing.
+- **Indexability**: The policy decision that determines whether a room or
+  collection may be indexed.
+- **Indexable room**: A room whose publication state and policy checks allow
+  aggregator indexing.
+- **De-indexing**: Removing or hiding indexed rows when a room becomes private,
+  a document is deleted, or publication state is missing.
+- **Public search**: Search over indexed public rows only. Public search must
+  not imply access to private synced data.
+- **Search payload**: The limited document data returned by public search.
+
+## Ambiguous Terms
+
+- **Shared**: Do not use `shared` to mean public. A room can be shared with
+  collaborators without being publicly indexed.
+- **Visible**: Clarify whether visibility is app-local, collaborator-readable,
+  public-searchable, or MCP-readable.
+- **Permission gate**: Prefer `publication state` or `indexability` when
+  discussing public search. Use access-grant language only for auth decisions.

--- a/packages/aggregator/INDEX.md
+++ b/packages/aggregator/INDEX.md
@@ -14,6 +14,7 @@ room data.
 ## Start Here
 
 - [`README.md`](./README.md): Service overview, environment variables, and API.
+- [`GLOSSARY.md`](./GLOSSARY.md): Public aggregation glossary.
 - [`package.json`](./package.json): Workspace scripts and dependencies.
 - [`src/INDEX.md`](./src/): Source navigation map.
 - [`src/index.ts`](./src/index.ts): Hono app entry point and route wiring.

--- a/packages/auth-server-hono/GLOSSARY.md
+++ b/packages/auth-server-hono/GLOSSARY.md
@@ -1,0 +1,48 @@
+# Auth And Grants Language
+
+This file is a glossary for `@eweser/auth-server-hono`. Keep it free of
+implementation steps, TODOs, and temporary design notes.
+
+## Terms
+
+- **Auth server**: The Hono service that owns users, sessions, OAuth, app
+  clients, room grants, sync-token issuance, and security/audit metadata.
+- **Session**: A signed-in browser or API identity for an EweserDB user.
+- **App client**: A registered app identity that requests room access.
+- **Access request**: The app-to-auth-server request describing desired
+  collections, rooms, redirect target, and capabilities.
+- **Access grant**: The persisted approval that authorizes an app or agent for
+  selected rooms and capabilities.
+- **Room ACL**: The room-level access-control state used to determine owner,
+  admin, read, and write rights.
+- **Sync token**: The short-lived token minted by the auth server for a specific
+  sync connection scope.
+- **Grant satisfaction**: The server-side check that an existing access grant
+  covers a new app access request.
+- **Agent token**: A token for MCP or other AI agent access. Agent tokens must
+  stay bounded by readable and writable room scopes.
+- **Remote MCP endpoint**: The auth-server HTTP `/mcp` route that accepts OAuth
+  bearer tokens or agent tokens and exposes MCP tools over scoped room access.
+- **Server identity**: The auth server's stable federation identity, including
+  public verification material and service URLs.
+- **Peer server**: A remote EweserDB auth server registered for federation or
+  backup-listener flows.
+- **Federated principal**: A user or service identity that belongs to a peer
+  server and may appear in room ACL or relay authorization decisions.
+- **Federation request**: A signed server-to-server request with replay
+  protection and explicit peer trust checks.
+- **Backup listener**: A peer-server role authorized to receive selected room
+  updates for recovery, separate from collaborator grants.
+- **Operational mirror**: Auth-server PostgreSQL data that helps enforce auth or
+  audit behavior but is not the canonical product data store.
+- **Provider profile**: Non-secret storage-provider metadata visible to users or
+  operators. Provider secrets remain server-side.
+
+## Ambiguous Terms
+
+- **Grant**: Clarify whether it is an app access grant, room ACL entry, OAuth
+  authorization, or sync token claim.
+- **Identity**: Clarify whether it is a local user, app client, agent token,
+  server identity, peer server, or federated principal.
+- **User data**: Product/user configuration that must interoperate belongs in
+  EweserDB rooms or shared schemas, not only in auth-server PostgreSQL.

--- a/packages/auth-server-hono/INDEX.md
+++ b/packages/auth-server-hono/INDEX.md
@@ -14,6 +14,7 @@ sync tokens, OAuth, agent tokens, and remote MCP endpoints.
 ## Start Here
 
 - [`AGENTS.md`](./AGENTS.md): Package-specific auth and database rules.
+- [`GLOSSARY.md`](./GLOSSARY.md): Auth/grant glossary.
 - [`README.md`](./README.md): Service overview, routes, and environment
   variables.
 - [`package.json`](./package.json): Workspace scripts and DB commands.

--- a/packages/db/GLOSSARY.md
+++ b/packages/db/GLOSSARY.md
@@ -1,0 +1,37 @@
+# SDK Rooms And Documents Language
+
+This file is a glossary for `@eweser/db`. Keep it free of implementation steps,
+TODOs, and temporary design notes.
+
+## Terms
+
+- **Database client**: The SDK object an app creates to load local rooms,
+  manage auth state, and coordinate sync.
+- **Room client**: The SDK representation of one room. It owns document helpers,
+  local state, and optional sync connection state for that room.
+- **Initial room**: A room definition the SDK should ensure exists for the app
+  during startup.
+- **Loaded room**: A room whose local Yjs state is available to the app.
+- **Document helper**: The public wrapper for creating, setting, deleting, and
+  listing documents in a CRDT-safe way.
+- **Soft delete**: A document state where `_deleted` is true and cleanup may
+  later purge the item after its TTL.
+- **Local persistence**: Browser IndexedDB-backed Yjs state that keeps the app
+  useful offline.
+- **Remote sync**: Optional Hocuspocus synchronization using a scoped sync token.
+- **Seed data**: First-run documents inserted idempotently by the SDK or app.
+  Seed data is not a migration.
+- **User snapshot**: A portable backup bundle for selected rooms. A user
+  snapshot is not a live sync replica, operator database backup, or federation
+  backup listener.
+- **Restore dry-run**: A restore preview that reports rooms, documents,
+  conflicts, and irreversible actions before CRDT writes happen.
+- **Compatibility migration**: A CRDT-safe change that moves local room data
+  from an older shared schema or SDK expectation to a newer one.
+
+## Ambiguous Terms
+
+- **Room registry**: Use only for the SDK-visible list of rooms; do not confuse
+  it with auth-server grant storage.
+- **Migration**: Clarify whether this means a local room data migration, a
+  shared schema compatibility migration, or a PostgreSQL migration.

--- a/packages/db/INDEX.md
+++ b/packages/db/INDEX.md
@@ -14,6 +14,7 @@ IndexedDB persistence, and optional WebRTC/Hocuspocus sync.
 ## Start Here
 
 - [`AGENTS.md`](./AGENTS.md): SDK and shared package rules.
+- [`GLOSSARY.md`](./GLOSSARY.md): SDK room/document glossary.
 - [`README.md`](./README.md): SDK philosophy and usage examples.
 - [`package.json`](./package.json): Workspace scripts.
 - [`src/INDEX.md`](./src/): Source navigation map.

--- a/packages/ewe-note/GLOSSARY.md
+++ b/packages/ewe-note/GLOSSARY.md
@@ -1,0 +1,26 @@
+# Ewe Note Bases And Vaults Language
+
+This file is a glossary for `@eweser/ewe-note`. Keep it free of implementation
+steps, TODOs, and temporary design notes.
+
+## Terms
+
+- **Ewe Note**: The offline-first note-taking app built on EweserDB rooms.
+- **Base**: The user-facing workspace unit for vault-style data.
+- **Vault**: The Obsidian-compatible filesystem/workspace concept represented
+  by a base.
+- **Note room**: A room in the `notes` collection that stores note documents for
+  a base or vault.
+- **Note**: A document representing user-authored note content and metadata.
+- **Source path**: Device-local or imported path metadata used for
+  Obsidian-compatible sync and round trips.
+- **Attachment**: File metadata associated with note content. Attachment bytes
+  may live in object storage or local cache depending on configuration.
+- **Workspace mode**: The current pane/layout mode of the app shell.
+
+## Ambiguous Terms
+
+- **Folder**: Use only for filesystem or note hierarchy concepts; do not use it
+  as a synonym for base, vault, room, or collection.
+- **Sync**: Clarify whether this means EweserDB room sync, Obsidian filesystem
+  import/export, or attachment transfer.

--- a/packages/ewe-note/INDEX.md
+++ b/packages/ewe-note/INDEX.md
@@ -13,6 +13,7 @@ Tailwind, TipTap, and `@eweser/db`.
 ## Start Here
 
 - [`AGENTS.md`](./AGENTS.md): Frontend/app rules.
+- [`GLOSSARY.md`](./GLOSSARY.md): Ewe Note base/vault glossary.
 - [`README.md`](./README.md): App overview and development setup.
 - [`package.json`](./package.json): Workspace scripts.
 - [`src/INDEX.md`](./src/): Source navigation map.

--- a/packages/mcp-server/GLOSSARY.md
+++ b/packages/mcp-server/GLOSSARY.md
@@ -1,0 +1,41 @@
+# MCP And Agent Memory Language
+
+This file is a glossary for `@eweser/mcp`. Keep it free of implementation
+steps, TODOs, and temporary design notes.
+
+## Terms
+
+- **MCP server**: The EweserDB MCP surface that exposes authorized rooms to AI
+  clients through tools. It can run as the local stdio `@eweser/mcp` package or
+  through the auth server's remote HTTP `/mcp` endpoint, depending on the
+  client setup path.
+- **Remote MCP endpoint**: The auth-server HTTP MCP route used by OAuth-capable
+  clients and token-backed remote MCP fallbacks.
+- **Agent**: An AI client or workflow acting through an approved agent token.
+- **Agent token**: A bearer token issued by the auth server for MCP or other AI
+  access. Agent tokens must be scoped by readable and writable room scopes.
+- **Readable room scope**: The set of rooms an agent may list, search, or read.
+- **Writable room scope**: The set of rooms an agent may create or update
+  documents in.
+- **MCP-readable room**: A room included in an agent's readable room scope.
+  MCP-readable does not mean public-searchable.
+- **Default write room**: The room selected for ordinary agent writes such as
+  saving session memory.
+- **Agent Journal**: The default Eweser-native memory strategy for session
+  notes, preferences, decisions, and project continuity.
+- **Memory scope**: The boundary for a memory item, such as global, project,
+  workspace, or agent-specific.
+- **Project wiki**: A source-backed project knowledge layer. It is distinct from
+  Agent Journal session memory.
+- **Tool output**: Data returned by MCP tools. Tool output must respect room
+  access and redact secret-like content.
+
+## Ambiguous Terms
+
+- **Memory**: Clarify Agent Journal, project wiki, derived graph, or note
+  content before changing schema or UX.
+- **Access**: Prefer `readable room scope` or `writable room scope` when
+  discussing MCP permissions.
+- **Encrypted room access**: Clarify whether the agent receives plaintext from a
+  user-unlocked client workflow or no MCP access at all. Do not imply server-side
+  MCP can read client-held encrypted content.

--- a/packages/mcp-server/INDEX.md
+++ b/packages/mcp-server/INDEX.md
@@ -14,6 +14,7 @@ authorized EweserDB rooms through agent tokens.
 ## Start Here
 
 - [`README.md`](./README.md): Supported clients, configuration, and tools.
+- [`GLOSSARY.md`](./GLOSSARY.md): MCP and agent-memory glossary.
 - [`package.json`](./package.json): Workspace scripts.
 - [`src/INDEX.md`](./src/): Source navigation map.
 - [`src/index.ts`](./src/index.ts): Stdio MCP server entry point.

--- a/packages/sync-server/GLOSSARY.md
+++ b/packages/sync-server/GLOSSARY.md
@@ -1,0 +1,36 @@
+# Sync Relay Language
+
+This file is a glossary for `@eweser/sync-server`. Keep it free of
+implementation steps, TODOs, and temporary design notes.
+
+## Terms
+
+- **Sync relay**: The Hocuspocus WebSocket service that relays Yjs updates for
+  authenticated room connections.
+- **Room connection**: One authenticated client connection to a scoped room.
+- **Persistence store**: Server-side storage of Yjs updates for relay recovery.
+- **Sync token claim**: A signed token field used to authorize a room
+  connection, including room ID, collection key, user identity, and capabilities.
+- **Webhook forwarding**: The sync relay's optional notification path to the
+  aggregator after room updates.
+- **Publication metadata**: The public/private room state attached to update
+  forwarding so the aggregator can enforce indexing boundaries.
+- **Federation relay**: A server-side relay connection that carries authorized
+  room updates between EweserDB auth servers.
+- **Origin server**: The server that owns the room's authoritative grants and
+  federation policy.
+- **Home server**: The server a federated user signs in through when accessing a
+  remote room.
+- **Backup-listener relay**: A read-only or standby federation relay used for
+  recovery, not collaboration.
+- **Usage event**: Metadata about a sync session such as duration or room ID.
+  Usage events must not contain document content.
+
+## Ambiguous Terms
+
+- **Server copy**: Use `persistence store` for relay recovery and `backup` for
+  user-visible backup behavior.
+- **Public update**: Use only when a room's explicit publication state permits
+  indexing; synced updates are not public by default.
+- **Relay**: Clarify whether this means a normal sync relay, federation relay,
+  or backup-listener relay.

--- a/packages/sync-server/INDEX.md
+++ b/packages/sync-server/INDEX.md
@@ -15,6 +15,7 @@ token authentication and SQLite persistence.
 ## Start Here
 
 - [`README.md`](./README.md): Service overview and authentication flow.
+- [`GLOSSARY.md`](./GLOSSARY.md): Sync relay glossary.
 - [`package.json`](./package.json): Workspace scripts.
 - [`src/INDEX.md`](./src/): Source navigation map.
 - [`src/index.ts`](./src/index.ts): Hocuspocus server configuration.


### PR DESCRIPTION
## What

Splits the Eweser glossary/grill workflow out into a focused docs-only PR so the repo gets the `eweser-grill-with-docs` skill and canonical glossary map without waiting on the broader DB README backlog PR.

## Changes

- `.codex/skills/eweser-grill-with-docs` - adds the repo-local grilling skill and smoke prompts for terminology-heavy planning.
- `GLOSSARY-MAP.md`, `GLOSSARY.md`, `packages/*/GLOSSARY.md` - add the root and package-level canonical domain-language glossaries.
- `AGENTS.md`, `INDEX.md`, package indexes, and Copilot instructions - route agents to the glossary map before broad exploration.
- `.codex/skills/eweser-planner`, `.codex/skills/eweser-coder`, and planner docs - wire glossary/domain-language checks into future plan and coding runs.

## Testing

- [x] `npm run code-index:check`
- [x] Targeted `npx prettier --check` for changed docs/skill files
- [x] Skill frontmatter validation for `eweser-grill-with-docs`, `eweser-planner`, and `eweser-coder`
- [x] Pre-commit secret scan and lint-staged checks
- [x] Pre-push secret scan and targeted formatting verify

## Checklist

- [x] Docs/agent-workflow only; no product code changed
- [x] No changeset needed because no published package API changed
- [x] No secrets committed
- [x] No database migrations changed
