### PR TITLE
Fix app auth proxy for production login

### DIFF
--- a/packages/app/Dockerfile
+++ b/packages/app/Dockerfile
@@ -38,5 +38,6 @@ COPY --from=builder /workspace/packages/app/dist /usr/share/nginx/html
 EXPOSE 80
 
 ENV PORT=80
+ENV AUTH_API_PROXY_URL=https://auth.eweser.com
 
-CMD ["sh", "-c", "envsubst '${PORT}' < /etc/nginx/templates/default.conf.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"]
+CMD ["sh", "-c", "envsubst '${PORT} ${AUTH_API_PROXY_URL}' < /etc/nginx/templates/default.conf.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"]

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -37,6 +37,8 @@ npm run dev
 | Variable                  | Description                                               |
 | ------------------------- | --------------------------------------------------------- |
 | `VITE_AUTH_SERVER_URL`    | URL of the auth API server                                |
+| `VITE_AUTH_API_URL`       | Auth client base URL. Defaults to same-origin `/api/auth` |
+| `AUTH_API_PROXY_URL`      | Runtime nginx proxy target for same-origin auth paths     |
 | `VITE_TURNSTILE_SITE_KEY` | Optional Cloudflare Turnstile site key for signup captcha |
 
 ## Docker

--- a/packages/app/nginx.conf
+++ b/packages/app/nginx.conf
@@ -11,6 +11,63 @@ server {
     add_header Content-Type text/plain;
   }
 
+  # Keep auth and MCP endpoints reachable when the SPA is built with the
+  # same-origin default VITE_AUTH_API_URL=/api/auth.
+  location = /mcp {
+    proxy_pass ${AUTH_API_PROXY_URL};
+    proxy_http_version 1.1;
+    proxy_set_header Host $proxy_host;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_ssl_server_name on;
+  }
+
+  location /mcp/ {
+    proxy_pass ${AUTH_API_PROXY_URL};
+    proxy_http_version 1.1;
+    proxy_set_header Host $proxy_host;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_ssl_server_name on;
+  }
+
+  location /oauth/ {
+    proxy_pass ${AUTH_API_PROXY_URL};
+    proxy_http_version 1.1;
+    proxy_set_header Host $proxy_host;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_ssl_server_name on;
+  }
+
+  location /.well-known/ {
+    proxy_pass ${AUTH_API_PROXY_URL};
+    proxy_http_version 1.1;
+    proxy_set_header Host $proxy_host;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_ssl_server_name on;
+  }
+
+  location /api/ {
+    proxy_pass ${AUTH_API_PROXY_URL};
+    proxy_http_version 1.1;
+    proxy_set_header Host $proxy_host;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_ssl_server_name on;
+  }
+
   location / {
     try_files $uri $uri/ /index.html;
   }

--- a/packages/app/nginx.conf.test.ts
+++ b/packages/app/nginx.conf.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const packageRoot = process.cwd();
+const nginxConfig = readFileSync(join(packageRoot, 'nginx.conf'), {
+  encoding: 'utf8',
+});
+
+describe('app nginx proxy config', () => {
+  it('proxies same-origin auth API requests to the auth service', () => {
+    expect(nginxConfig).toContain('location /api/ {');
+    expect(nginxConfig).toContain('proxy_pass ${AUTH_API_PROXY_URL};');
+  });
+
+  it('keeps app-shell fallback behind explicit auth route proxies', () => {
+    expect(nginxConfig.indexOf('location /api/ {')).toBeLessThan(
+      nginxConfig.indexOf('location / {')
+    );
+    expect(nginxConfig).not.toContain('location /auth/ {');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds nginx proxy routes for same-origin auth, MCP, OAuth, and well-known endpoints in the app container
- Wires `AUTH_API_PROXY_URL` through the app Docker image so production can target the auth service at runtime
- Documents the new app auth proxy env vars and adds a focused nginx config regression test

## Validation
- npm test --workspace @eweser/app -- nginx.conf.test.ts
- git diff --check origin/main...HEAD

## Notes
- This is the production login/auth proxy fix branch that had been pushed without a PR.
