### PR TITLE
Render imported Obsidian image attachments

### DIFF
--- a/packages/ewe-note/src/app/lib/browser-attachment-cache.test.ts
+++ b/packages/ewe-note/src/app/lib/browser-attachment-cache.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it } from 'vitest';
+import { indexedDB } from 'fake-indexeddb';
+import {
+  clearBrowserAttachmentCacheForTests,
+  getCachedBrowserAttachmentBlob,
+  putBrowserAttachmentCache,
+} from './browser-attachment-cache';
+
+beforeEach(async () => {
+  Object.defineProperty(globalThis, 'indexedDB', {
+    configurable: true,
+    value: indexedDB,
+  });
+  await clearBrowserAttachmentCacheForTests();
+});
+
+describe('browser attachment cache', () => {
+  it('stores imported attachment bytes by note room, source path, and content hash', async () => {
+    await putBrowserAttachmentCache({
+      baseId: 'notes-room-1',
+      blob: new Blob([new Uint8Array([1, 2, 3])], { type: 'image/png' }),
+      contentHash: 'sha256-cover',
+      filename: 'cover.png',
+      mimeType: 'image/png',
+      sourcePath: 'Assets/cover.png',
+    });
+
+    const cached = await getCachedBrowserAttachmentBlob({
+      baseId: 'notes-room-1',
+      contentHash: 'sha256-cover',
+      sourcePath: 'Assets/cover.png',
+    });
+
+    expect(cached?.type).toBe('image/png');
+    if (!cached) {
+      throw new Error('Expected cached attachment blob to be available.');
+    }
+    expect(Array.from(new Uint8Array(await cached.arrayBuffer()))).toEqual([
+      1, 2, 3,
+    ]);
+  });
+});

--- a/packages/ewe-note/src/app/lib/browser-attachment-cache.ts
+++ b/packages/ewe-note/src/app/lib/browser-attachment-cache.ts
@@ -1,0 +1,168 @@
+import type { FileAttachmentBase } from '@eweser/shared';
+
+const DB_NAME = 'ewe-note-browser-attachment-cache';
+const DB_VERSION = 1;
+const STORE_NAME = 'attachments';
+
+type BrowserAttachmentCacheReference = Pick<
+  FileAttachmentBase,
+  'baseId' | 'contentHash' | 'sourcePath'
+>;
+
+export type BrowserAttachmentCacheEntry = BrowserAttachmentCacheReference &
+  Pick<FileAttachmentBase, 'filename' | 'mimeType'> & {
+    blob: Blob;
+  };
+
+type StoredBrowserAttachment = BrowserAttachmentCacheEntry & {
+  createdAt: number;
+  key: string;
+};
+
+function normalizeSourcePath(sourcePath: string): string {
+  return sourcePath
+    .replace(/\\/g, '/')
+    .replace(/^\.\//, '')
+    .replace(/\/+/g, '/');
+}
+
+export function getBrowserAttachmentCacheKey({
+  baseId,
+  contentHash,
+  sourcePath,
+}: BrowserAttachmentCacheReference): string {
+  return [
+    baseId,
+    contentHash,
+    normalizeSourcePath(sourcePath).toLowerCase(),
+  ].join('\u0000');
+}
+
+function hasIndexedDb(): boolean {
+  return typeof indexedDB !== 'undefined';
+}
+
+function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () =>
+      reject(request.error ?? new Error('IndexedDB request failed'));
+  });
+}
+
+function transactionDone(transaction: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () =>
+      reject(transaction.error ?? new Error('IndexedDB transaction failed'));
+    transaction.onabort = () =>
+      reject(transaction.error ?? new Error('IndexedDB transaction aborted'));
+  });
+}
+
+async function openAttachmentCacheDb(): Promise<IDBDatabase | null> {
+  if (!hasIndexedDb()) return null;
+
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: 'key' });
+      }
+    };
+
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () =>
+      reject(request.error ?? new Error('IndexedDB open failed'));
+  });
+}
+
+export async function putBrowserAttachmentCache(
+  entry: BrowserAttachmentCacheEntry
+): Promise<boolean> {
+  const db = await openAttachmentCacheDb();
+  if (!db) return false;
+
+  try {
+    const transaction = db.transaction(STORE_NAME, 'readwrite');
+    const store = transaction.objectStore(STORE_NAME);
+    const stored: StoredBrowserAttachment = {
+      ...entry,
+      key: getBrowserAttachmentCacheKey(entry),
+      sourcePath: normalizeSourcePath(entry.sourcePath),
+      createdAt: Date.now(),
+    };
+
+    store.put(stored);
+    await transactionDone(transaction);
+    return true;
+  } finally {
+    db.close();
+  }
+}
+
+export async function getCachedBrowserAttachmentBlob(
+  reference: BrowserAttachmentCacheReference
+): Promise<Blob | null> {
+  const db = await openAttachmentCacheDb();
+  if (!db) return null;
+
+  try {
+    const transaction = db.transaction(STORE_NAME, 'readonly');
+    const store = transaction.objectStore(STORE_NAME);
+    const stored = await requestToPromise<StoredBrowserAttachment | undefined>(
+      store.get(getBrowserAttachmentCacheKey(reference))
+    );
+    await transactionDone(transaction);
+    return stored?.blob ?? null;
+  } finally {
+    db.close();
+  }
+}
+
+export async function getCachedBrowserAttachmentUrls(
+  attachments: readonly FileAttachmentBase[]
+): Promise<Record<string, string>> {
+  if (
+    typeof URL === 'undefined' ||
+    typeof URL.createObjectURL !== 'function' ||
+    attachments.length === 0
+  ) {
+    return {};
+  }
+
+  const urls: Record<string, string> = {};
+  for (const attachment of attachments) {
+    const blob = await getCachedBrowserAttachmentBlob(attachment);
+    if (!blob) continue;
+    urls[attachment.sourcePath] = URL.createObjectURL(blob);
+  }
+  return urls;
+}
+
+export function revokeCachedBrowserAttachmentUrls(
+  attachmentUrls: Readonly<Record<string, string>>
+): void {
+  if (typeof URL === 'undefined' || typeof URL.revokeObjectURL !== 'function') {
+    return;
+  }
+
+  for (const url of Object.values(attachmentUrls)) {
+    if (url.startsWith('blob:')) URL.revokeObjectURL(url);
+  }
+}
+
+export async function clearBrowserAttachmentCacheForTests(): Promise<void> {
+  const db = await openAttachmentCacheDb();
+  if (!db) return;
+
+  try {
+    const transaction = db.transaction(STORE_NAME, 'readwrite');
+    transaction.objectStore(STORE_NAME).clear();
+    await transactionDone(transaction);
+  } finally {
+    db.close();
+  }
+}

--- a/packages/ewe-note/src/app/lib/browser-vault-import.test.ts
+++ b/packages/ewe-note/src/app/lib/browser-vault-import.test.ts
@@ -1,0 +1,192 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { indexedDB } from 'fake-indexeddb';
+import {
+  clearBrowserAttachmentCacheForTests,
+  getCachedBrowserAttachmentBlob,
+} from './browser-attachment-cache';
+
+vi.mock('@eweser/db', () => ({
+  uploadFile: vi.fn(),
+}));
+
+beforeEach(async () => {
+  Object.defineProperty(globalThis, 'indexedDB', {
+    configurable: true,
+    value: indexedDB,
+  });
+  await clearBrowserAttachmentCacheForTests();
+});
+
+type StoredDocument = Record<string, unknown>;
+type CollectionKey = 'notes' | 'fileAttachments';
+type TestRoom = {
+  getDocuments: () => { set(document: StoredDocument): void };
+  load: () => Promise<void>;
+};
+type TestDatabase = {
+  authServer: string;
+  getRoom: (collectionKey: CollectionKey, roomId: string) => TestRoom | null;
+  newRoom: (options: { collectionKey: CollectionKey; id: string }) => void;
+};
+
+function fileWithPath(
+  path: string,
+  contents: string | Uint8Array,
+  options: FilePropertyBag = {}
+) {
+  const file = new File([contents], path.split('/').pop() ?? path, options);
+  Object.defineProperty(file, 'webkitRelativePath', {
+    configurable: true,
+    value: path,
+  });
+  return file;
+}
+
+function createDocumentStore() {
+  const docs: StoredDocument[] = [];
+  return {
+    docs,
+    api: {
+      set(document: StoredDocument) {
+        docs.push(document);
+      },
+    },
+  };
+}
+
+function createRoom(documentsApi: { set(document: StoredDocument): void }) {
+  return {
+    getDocuments: () => documentsApi,
+    load: async () => undefined,
+  } satisfies TestRoom;
+}
+
+function createImportHarness() {
+  const notes = createDocumentStore();
+  const attachments = createDocumentStore();
+  const rooms = new Map<string, TestRoom>();
+
+  const db = {
+    authServer: 'http://auth.test',
+    getRoom(collectionKey: CollectionKey, roomId: string) {
+      return rooms.get(`${collectionKey}:${roomId}`) ?? null;
+    },
+    newRoom({
+      collectionKey,
+      id,
+    }: {
+      collectionKey: CollectionKey;
+      id: string;
+    }) {
+      rooms.set(
+        `${collectionKey}:${id}`,
+        collectionKey === 'notes'
+          ? createRoom(notes.api)
+          : createRoom(attachments.api)
+      );
+    },
+  } satisfies TestDatabase;
+
+  return { attachments: attachments.docs, db, notes: notes.docs };
+}
+
+describe('importVaultFromFiles', () => {
+  it('preserves local attachment metadata when browser vault import runs without remote sync', async () => {
+    const { attachments, db, notes } = createImportHarness();
+    const { importVaultFromFiles } = await import('./browser-vault-import');
+    const result = await importVaultFromFiles({
+      db: db as never,
+      files: [
+        fileWithPath(
+          'Test Vault/Notes/Imported.md',
+          '![cover](ignored)\n![[Assets/cover.png]]',
+          {
+            type: 'text/markdown',
+          }
+        ),
+        fileWithPath('Test Vault/Assets/cover.png', new Uint8Array([1, 2, 3]), {
+          type: 'image/png',
+        }),
+      ],
+      remoteSyncEnabled: false,
+    });
+
+    const expectedCoverContentHash = [
+      '039058c6f2c0cb49',
+      '2c533b0a4d14ef77',
+      'cc0f78abccced528',
+      '7d84a1a2011cfb81',
+    ].join('');
+
+    expect(notes).toHaveLength(1);
+    expect(result.attachmentsUploaded).toBe(0);
+    expect(result.attachmentsSkipped).toBe(0);
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0]).toEqual(
+      expect.objectContaining({
+        baseId: result.noteRoomId,
+        contentHash: expectedCoverContentHash,
+        filename: 'cover.png',
+        localAvailability: 'available',
+        mimeType: 'image/png',
+        size: 3,
+        sourcePath: 'Assets/cover.png',
+        sourceVault: 'Test Vault',
+      })
+    );
+    expect(attachments[0]?.parentNoteRefs).toEqual([
+      `http://auth.test|notes|${result.noteRoomId}|${notes[0]?._id}`,
+    ]);
+
+    const cachedBlob = await getCachedBrowserAttachmentBlob({
+      baseId: result.noteRoomId,
+      contentHash: String(attachments[0]?.contentHash),
+      sourcePath: 'Assets/cover.png',
+    });
+    expect(cachedBlob?.type).toBe('image/png');
+    if (!cachedBlob) {
+      throw new Error(
+        'Expected cached imported attachment blob to be available.'
+      );
+    }
+    expect(Array.from(new Uint8Array(await cachedBlob.arrayBuffer()))).toEqual([
+      1, 2, 3,
+    ]);
+  });
+
+  it('skips local-only attachment metadata when bytes cannot be read', async () => {
+    const { attachments, db, notes } = createImportHarness();
+    const brokenAttachment = fileWithPath(
+      'Test Vault/Assets/broken.png',
+      new Uint8Array([1]),
+      { type: 'image/png' }
+    );
+    Object.defineProperty(brokenAttachment, 'arrayBuffer', {
+      configurable: true,
+      value: vi.fn(async () => {
+        throw new Error('read failed');
+      }),
+    });
+
+    const { importVaultFromFiles } = await import('./browser-vault-import');
+    const result = await importVaultFromFiles({
+      db: db as never,
+      files: [
+        fileWithPath('Test Vault/Notes/Imported.md', '![[Assets/broken.png]]', {
+          type: 'text/markdown',
+        }),
+        brokenAttachment,
+      ],
+      remoteSyncEnabled: false,
+    });
+
+    expect(notes).toHaveLength(1);
+    expect(attachments).toHaveLength(0);
+    expect(result.attachmentsUploaded).toBe(0);
+    expect(result.attachmentsSkipped).toBe(1);
+    expect(result.warnings).toEqual([
+      'Attachment skipped: Assets/broken.png (read failed)',
+    ]);
+  });
+});

--- a/packages/ewe-note/src/app/lib/browser-vault-import.ts
+++ b/packages/ewe-note/src/app/lib/browser-vault-import.ts
@@ -13,6 +13,7 @@ import {
   type FolderBase,
 } from '@eweser/shared';
 import type { Doc } from 'yjs';
+import { putBrowserAttachmentCache } from './browser-attachment-cache';
 
 const IGNORED_DIRS = new Set(['.obsidian', '.trash', '.git', 'node_modules']);
 const MARKDOWN_EXTENSION = '.md';
@@ -455,6 +456,58 @@ function buildAttachmentParentRefs(
   return refsByTarget;
 }
 
+function findAttachmentParentNoteRefs(
+  refsByTarget: Map<string, string[]>,
+  sourcePath: string
+) {
+  const normalizedTarget = normalizeSlashes(sourcePath).toLowerCase();
+  const fileNameTarget = getFileName(normalizedTarget);
+  return Array.from(
+    new Set([
+      ...(refsByTarget.get(normalizedTarget) ?? []),
+      ...(refsByTarget.get(fileNameTarget) ?? []),
+    ])
+  );
+}
+
+async function cacheBrowserAttachmentBytes({
+  attachment,
+  baseId,
+  bytes,
+  contentHash,
+  warnings,
+}: {
+  attachment: PreparedVaultAttachment;
+  baseId: string;
+  bytes: ArrayBuffer;
+  contentHash: string;
+  warnings: string[];
+}): Promise<'available' | 'unknown'> {
+  try {
+    const cached = await putBrowserAttachmentCache({
+      baseId,
+      blob: new Blob([bytes], { type: attachment.mimeType }),
+      contentHash,
+      filename: attachment.filename,
+      mimeType: attachment.mimeType,
+      sourcePath: attachment.sourcePath,
+    });
+
+    if (cached) return 'available';
+    warnings.push(
+      `Attachment bytes not cached locally: ${attachment.sourcePath} (browser cache unavailable)`
+    );
+    return 'unknown';
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Unknown browser cache error.';
+    warnings.push(
+      `Attachment bytes not cached locally: ${attachment.sourcePath} (${message})`
+    );
+    return 'unknown';
+  }
+}
+
 export async function importVaultFromFiles(params: {
   db: Database;
   files: FileList | File[];
@@ -544,17 +597,16 @@ export async function importVaultFromFiles(params: {
     });
   }
 
-  let attachmentsUploaded = 0;
-  let attachmentsSkipped = prepared.attachmentCount;
-  if (params.remoteSyncEnabled && prepared.attachments.length > 0) {
-    const parentRefsByTarget = buildAttachmentParentRefs(
-      params.db,
-      noteRoomId,
-      prepared.notes
-    );
-    const Attachments = attachmentsRoom.getDocuments();
-    attachmentsSkipped = 0;
+  const parentRefsByTarget = buildAttachmentParentRefs(
+    params.db,
+    noteRoomId,
+    prepared.notes
+  );
+  const Attachments = attachmentsRoom.getDocuments();
 
+  let attachmentsUploaded = 0;
+  let attachmentsSkipped = 0;
+  if (params.remoteSyncEnabled && prepared.attachments.length > 0) {
     let attachmentIndex = 0;
     for (const attachment of prepared.attachments) {
       attachmentIndex += 1;
@@ -568,14 +620,17 @@ export async function importVaultFromFiles(params: {
       try {
         const bytes = await attachment.file.arrayBuffer();
         const contentHash = await sha256Hex(bytes);
-        const normalizedTarget = normalizeSlashes(
+        const localAvailability = await cacheBrowserAttachmentBytes({
+          attachment,
+          baseId: noteRoomId,
+          bytes,
+          contentHash,
+          warnings,
+        });
+        const parentNoteRefs = findAttachmentParentNoteRefs(
+          parentRefsByTarget,
           attachment.sourcePath
-        ).toLowerCase();
-        const fileNameTarget = getFileName(normalizedTarget);
-        const parentNoteRefs = [
-          ...(parentRefsByTarget.get(normalizedTarget) ?? []),
-          ...(parentRefsByTarget.get(fileNameTarget) ?? []),
-        ];
+        );
 
         const uploaded = await uploadFile({
           db: params.db,
@@ -584,7 +639,7 @@ export async function importVaultFromFiles(params: {
             baseId: noteRoomId,
             filename: attachment.filename,
             mimeType: attachment.mimeType,
-            ...(parentNoteRefs.length > 0 ? { parentNoteRefs } : {}),
+            parentNoteRefs,
             size: attachment.file.size,
             sourcePath: attachment.sourcePath,
             sourceVault: prepared.vaultName,
@@ -610,6 +665,7 @@ export async function importVaultFromFiles(params: {
           baseId: noteRoomId,
           contentHash,
           filename: attachment.filename,
+          localAvailability,
           mimeType: attachment.mimeType,
           ...(parentNoteRefs.length > 0 ? { parentNoteRefs } : {}),
           size: attachment.file.size,
@@ -631,9 +687,65 @@ export async function importVaultFromFiles(params: {
   }
 
   if (!params.remoteSyncEnabled && prepared.attachments.length > 0) {
-    warnings.push(
-      'Attachments were skipped because remote sync is not active. Sign in first to upload vault files.'
-    );
+    let attachmentIndex = 0;
+    for (const attachment of prepared.attachments) {
+      attachmentIndex += 1;
+      params.onProgress?.({
+        current: attachmentIndex,
+        message: `Recording local attachment metadata for ${attachment.sourcePath}`,
+        phase: 'writing',
+        total: prepared.attachments.length,
+      });
+
+      try {
+        const bytes = await attachment.file.arrayBuffer();
+        const contentHash = await sha256Hex(bytes);
+        const localAvailability = await cacheBrowserAttachmentBytes({
+          attachment,
+          baseId: noteRoomId,
+          bytes,
+          contentHash,
+          warnings,
+        });
+        const parentNoteRefs = findAttachmentParentNoteRefs(
+          parentRefsByTarget,
+          attachment.sourcePath
+        );
+        const attachmentId = await generateStableId(
+          `${noteRoomId}:${attachment.sourcePath}`
+        );
+        const now = Date.now();
+        Attachments.set({
+          _created: now,
+          _id: attachmentId,
+          _ref: buildRef({
+            authServer: params.db.authServer,
+            collectionKey: 'fileAttachments',
+            documentId: attachmentId,
+            roomId: attachmentsRoomId,
+          }),
+          _updated: now,
+          baseId: noteRoomId,
+          contentHash,
+          filename: attachment.filename,
+          localAvailability,
+          mimeType: attachment.mimeType,
+          ...(parentNoteRefs.length > 0 ? { parentNoteRefs } : {}),
+          size: attachment.file.size,
+          sourcePath: attachment.sourcePath,
+          sourceVault: prepared.vaultName,
+        });
+      } catch (error) {
+        attachmentsSkipped += 1;
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'Unknown attachment metadata error.';
+        warnings.push(
+          `Attachment skipped: ${attachment.sourcePath} (${message})`
+        );
+      }
+    }
   }
 
   params.setSelectedRoom?.(noteRoom);

--- a/packages/ewe-note/src/components/editor-attachments.test.ts
+++ b/packages/ewe-note/src/components/editor-attachments.test.ts
@@ -41,6 +41,14 @@ function roomWithAttachments(attachments: AttachmentDocument[]) {
   };
 }
 
+function unloadedRoom() {
+  return {
+    getDocuments() {
+      throw new Error('attachment ydoc is still loading');
+    },
+  };
+}
+
 describe('editor attachment context helpers', () => {
   it('collects only file attachments belonging to the selected note room', () => {
     const attachments = collectNoteRoomAttachments(
@@ -51,6 +59,17 @@ describe('editor attachment context helpers', () => {
           attachment('Assets/deleted.png', { _deleted: true }),
         ]),
       ],
+      'notes-room-1'
+    );
+
+    expect(attachments.map((entry) => entry.sourcePath)).toEqual([
+      'Assets/cover.png',
+    ]);
+  });
+
+  it('skips unloaded attachment rooms while collecting selected note attachments', () => {
+    const attachments = collectNoteRoomAttachments(
+      [unloadedRoom(), roomWithAttachments([attachment('Assets/cover.png')])],
       'notes-room-1'
     );
 

--- a/packages/ewe-note/src/components/editor-attachments.test.ts
+++ b/packages/ewe-note/src/components/editor-attachments.test.ts
@@ -1,0 +1,76 @@
+import type { FileAttachmentBase } from '@eweser/shared';
+import { describe, expect, it } from 'vitest';
+import {
+  buildEditorAttachmentContext,
+  collectNoteRoomAttachments,
+} from './editor-attachments';
+
+type AttachmentDocument = FileAttachmentBase & {
+  _id: string;
+  _deleted?: boolean;
+};
+
+function attachment(
+  sourcePath: string,
+  overrides: Partial<AttachmentDocument> = {}
+): AttachmentDocument {
+  const filename = sourcePath.split('/').pop() ?? sourcePath;
+  return {
+    _id: `attachment:${sourcePath}`,
+    baseId: 'notes-room-1',
+    contentHash: `hash:${sourcePath}`,
+    filename,
+    localAvailability: 'available',
+    mimeType: 'image/png',
+    size: 3,
+    sourcePath,
+    sourceVault: 'Test Vault',
+    ...overrides,
+  };
+}
+
+function roomWithAttachments(attachments: AttachmentDocument[]) {
+  return {
+    getDocuments() {
+      return {
+        getUndeleted() {
+          return attachments.filter((entry) => !entry._deleted);
+        },
+      };
+    },
+  };
+}
+
+describe('editor attachment context helpers', () => {
+  it('collects only file attachments belonging to the selected note room', () => {
+    const attachments = collectNoteRoomAttachments(
+      [
+        roomWithAttachments([
+          attachment('Assets/cover.png'),
+          attachment('Assets/other-room.png', { baseId: 'other-room' }),
+          attachment('Assets/deleted.png', { _deleted: true }),
+        ]),
+      ],
+      'notes-room-1'
+    );
+
+    expect(attachments.map((entry) => entry.sourcePath)).toEqual([
+      'Assets/cover.png',
+    ]);
+  });
+
+  it('builds markdown attachment context with note source path and materialized URLs', () => {
+    const attachments = [attachment('Assets/cover.png')];
+    const context = buildEditorAttachmentContext({
+      attachmentUrls: { 'Assets/cover.png': 'blob:cover' },
+      attachments,
+      note: { sourcePath: 'Notes/Imported.md' },
+    });
+
+    expect(context).toEqual({
+      attachmentUrls: { 'Assets/cover.png': 'blob:cover' },
+      attachments,
+      noteSourcePath: 'Notes/Imported.md',
+    });
+  });
+});

--- a/packages/ewe-note/src/components/editor-attachments.ts
+++ b/packages/ewe-note/src/components/editor-attachments.ts
@@ -25,6 +25,16 @@ export type AttachmentRoomSource = {
   getDocuments: () => AttachmentDocuments;
 };
 
+function getLoadedAttachmentDocuments(
+  room: AttachmentRoomSource
+): AttachmentDocuments | undefined {
+  try {
+    return room.getDocuments();
+  } catch {
+    return undefined;
+  }
+}
+
 function attachmentDocumentsToArray(
   documents:
     | readonly AttachmentRecord[]
@@ -37,11 +47,14 @@ export function collectNoteRoomAttachments(
   attachmentRooms: readonly AttachmentRoomSource[],
   noteRoomId: string
 ): FileAttachmentBase[] {
-  return attachmentRooms.flatMap((room) =>
-    attachmentDocumentsToArray(room.getDocuments().getUndeleted()).filter(
+  return attachmentRooms.flatMap((room) => {
+    const documents = getLoadedAttachmentDocuments(room);
+    if (!documents) return [];
+
+    return attachmentDocumentsToArray(documents.getUndeleted()).filter(
       (attachment) => !attachment._deleted && attachment.baseId === noteRoomId
-    )
-  );
+    );
+  });
 }
 
 export function buildEditorAttachmentContext({
@@ -93,7 +106,10 @@ export function useEditorAttachmentContext({
   );
 
   useEffect(() => {
-    const documents = attachmentRooms.map((room) => room.getDocuments());
+    const documents = attachmentRooms.flatMap((room) => {
+      const attachmentDocuments = getLoadedAttachmentDocuments(room);
+      return attachmentDocuments ? [attachmentDocuments] : [];
+    });
     const refreshAttachments = () => {
       setAttachments(collectNoteRoomAttachments(attachmentRooms, noteRoomId));
     };

--- a/packages/ewe-note/src/components/editor-attachments.ts
+++ b/packages/ewe-note/src/components/editor-attachments.ts
@@ -1,0 +1,147 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { Database, Note } from '@eweser/db';
+import type { FileAttachmentBase } from '@eweser/shared';
+import {
+  getCachedBrowserAttachmentUrls,
+  revokeCachedBrowserAttachmentUrls,
+} from '@/app/lib/browser-attachment-cache';
+import type { AttachmentResolverContext } from '@/utils/attachment-resolver';
+
+type AttachmentRecord = FileAttachmentBase & {
+  _deleted?: boolean;
+};
+
+type AttachmentDocuments = {
+  getUndeleted: () =>
+    | readonly AttachmentRecord[]
+    | Readonly<Record<string, AttachmentRecord>>;
+  onChange?: (listener: () => void) => void;
+  documents?: {
+    unobserve: (listener: () => void) => void;
+  };
+};
+
+export type AttachmentRoomSource = {
+  getDocuments: () => AttachmentDocuments;
+};
+
+function attachmentDocumentsToArray(
+  documents:
+    | readonly AttachmentRecord[]
+    | Readonly<Record<string, AttachmentRecord>>
+): AttachmentRecord[] {
+  return Array.isArray(documents) ? [...documents] : Object.values(documents);
+}
+
+export function collectNoteRoomAttachments(
+  attachmentRooms: readonly AttachmentRoomSource[],
+  noteRoomId: string
+): FileAttachmentBase[] {
+  return attachmentRooms.flatMap((room) =>
+    attachmentDocumentsToArray(room.getDocuments().getUndeleted()).filter(
+      (attachment) => !attachment._deleted && attachment.baseId === noteRoomId
+    )
+  );
+}
+
+export function buildEditorAttachmentContext({
+  attachmentUrls,
+  attachments,
+  note,
+}: {
+  attachmentUrls: Readonly<Record<string, string>>;
+  attachments: readonly FileAttachmentBase[];
+  note: Pick<Note, 'sourcePath'> | { sourcePath?: string };
+}): AttachmentResolverContext {
+  return {
+    attachments,
+    attachmentUrls,
+    ...(note.sourcePath ? { noteSourcePath: note.sourcePath } : {}),
+  };
+}
+
+function shouldResolveAttachments(
+  note: Pick<Note, 'sourcePath'> | { sourcePath?: string },
+  attachments: readonly FileAttachmentBase[],
+  attachmentUrls: Readonly<Record<string, string>>
+): boolean {
+  return Boolean(
+    note.sourcePath ||
+    attachments.length > 0 ||
+    Object.keys(attachmentUrls).length > 0
+  );
+}
+
+export function useEditorAttachmentContext({
+  db,
+  note,
+  noteRoomId,
+}: {
+  db: Database;
+  note: Note;
+  noteRoomId: string;
+}): AttachmentResolverContext | undefined {
+  const attachmentRooms = useMemo<AttachmentRoomSource[]>(
+    () => db.getRooms('fileAttachments') as unknown as AttachmentRoomSource[],
+    [db]
+  );
+  const [attachments, setAttachments] = useState<FileAttachmentBase[]>(() =>
+    collectNoteRoomAttachments(attachmentRooms, noteRoomId)
+  );
+  const [attachmentUrls, setAttachmentUrls] = useState<Record<string, string>>(
+    {}
+  );
+
+  useEffect(() => {
+    const documents = attachmentRooms.map((room) => room.getDocuments());
+    const refreshAttachments = () => {
+      setAttachments(collectNoteRoomAttachments(attachmentRooms, noteRoomId));
+    };
+
+    refreshAttachments();
+    for (const attachmentDocuments of documents) {
+      attachmentDocuments.onChange?.(refreshAttachments);
+    }
+
+    return () => {
+      for (const attachmentDocuments of documents) {
+        attachmentDocuments.documents?.unobserve(refreshAttachments);
+      }
+    };
+  }, [attachmentRooms, noteRoomId]);
+
+  useEffect(() => {
+    let active = true;
+
+    getCachedBrowserAttachmentUrls(attachments)
+      .then((nextUrls) => {
+        if (!active) {
+          revokeCachedBrowserAttachmentUrls(nextUrls);
+          return;
+        }
+        setAttachmentUrls(nextUrls);
+      })
+      .catch(() => {
+        if (active) setAttachmentUrls({});
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [attachments]);
+
+  useEffect(
+    () => () => revokeCachedBrowserAttachmentUrls(attachmentUrls),
+    [attachmentUrls]
+  );
+
+  if (!shouldResolveAttachments(note, attachments, attachmentUrls)) {
+    return undefined;
+  }
+
+  return buildEditorAttachmentContext({
+    attachmentUrls,
+    attachments,
+    note,
+  });
+}

--- a/packages/ewe-note/src/components/editor.tsx
+++ b/packages/ewe-note/src/components/editor.tsx
@@ -11,6 +11,7 @@ import { useNotesRoom } from '@/notes-room';
 import { Icons } from '@/lib/icons';
 import FrontmatterEditor from '@/components/frontmatter-editor';
 import { TiptapEditor } from '@/components/tiptap-editor';
+import { useEditorAttachmentContext } from '@/components/editor-attachments';
 import type { Editor as TiptapEditorInstance } from '@tiptap/react';
 
 const darkModeCursorColors = [
@@ -83,6 +84,7 @@ export default function Editor({
       updateNoteText={updateNoteText}
       updateNoteFrontmatter={updateNoteFrontmatter}
       note={note}
+      noteRoomId={selectedRoom.id}
       showFrontmatterEditor={showFrontmatterEditor}
       onEditorReady={onEditorReady}
       onEditorFocusChange={onEditorFocusChange}
@@ -100,6 +102,7 @@ function EditorInternal({
   updateNoteText,
   updateNoteFrontmatter,
   note,
+  noteRoomId,
   showFrontmatterEditor,
   onEditorReady,
   onEditorFocusChange,
@@ -116,6 +119,7 @@ function EditorInternal({
     note?: Note
   ) => void;
   note: Note;
+  noteRoomId: string;
   showFrontmatterEditor: boolean;
   onEditorReady?: (editor: TiptapEditorInstance | null) => void;
   onEditorFocusChange?: (focused: boolean) => void;
@@ -123,8 +127,13 @@ function EditorInternal({
   sourceMode?: boolean;
   onSourceModeChange?: (sourceMode: boolean) => void;
 }) {
-  const { user } = useDb();
+  const { db, user } = useDb();
   const { resolvedMode } = useTheme();
+  const attachmentContext = useEditorAttachmentContext({
+    db,
+    note,
+    noteRoomId,
+  });
   const usedTheme = resolvedMode;
   const cursorColors =
     usedTheme === 'dark' ? darkModeCursorColors : lightModeCursorColors;
@@ -153,6 +162,7 @@ function EditorInternal({
           onNavigateWikiLink={onNavigateWikiLink}
           sourceMode={sourceMode}
           onSourceModeChange={onSourceModeChange}
+          attachmentContext={attachmentContext}
         />
       </div>
     </div>

--- a/packages/ewe-note/src/components/tiptap-editor-refresh.test.ts
+++ b/packages/ewe-note/src/components/tiptap-editor-refresh.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { shouldRefreshLocalEditorContent } from './tiptap-editor';
+
+describe('shouldRefreshLocalEditorContent', () => {
+  it('blocks non-collaborative refreshes while local editor markdown has not reached the note', () => {
+    expect(
+      shouldRefreshLocalEditorContent({
+        collaborationReady: false,
+        focused: false,
+        hasEditor: true,
+        noteText: 'saved markdown',
+        pendingEditorMarkdown: 'unsaved local markdown',
+        sourceMode: false,
+      })
+    ).toBe(false);
+  });
+
+  it('allows non-collaborative refreshes once the pending local markdown matches the note', () => {
+    expect(
+      shouldRefreshLocalEditorContent({
+        collaborationReady: false,
+        focused: false,
+        hasEditor: true,
+        noteText: 'saved markdown',
+        pendingEditorMarkdown: 'saved markdown',
+        sourceMode: false,
+      })
+    ).toBe(true);
+  });
+
+  it('allows non-collaborative refreshes when no local edit is pending', () => {
+    expect(
+      shouldRefreshLocalEditorContent({
+        collaborationReady: false,
+        focused: false,
+        hasEditor: true,
+        noteText: 'saved markdown',
+        pendingEditorMarkdown: null,
+        sourceMode: false,
+      })
+    ).toBe(true);
+  });
+
+  it('blocks refreshes while focused, source mode, collaboration, or missing editor already own content', () => {
+    const readyToRefresh = {
+      collaborationReady: false,
+      focused: false,
+      hasEditor: true,
+      noteText: 'saved markdown',
+      pendingEditorMarkdown: null,
+      sourceMode: false,
+    };
+
+    expect(
+      shouldRefreshLocalEditorContent({ ...readyToRefresh, focused: true })
+    ).toBe(false);
+    expect(
+      shouldRefreshLocalEditorContent({ ...readyToRefresh, sourceMode: true })
+    ).toBe(false);
+    expect(
+      shouldRefreshLocalEditorContent({
+        ...readyToRefresh,
+        collaborationReady: true,
+      })
+    ).toBe(false);
+    expect(
+      shouldRefreshLocalEditorContent({ ...readyToRefresh, hasEditor: false })
+    ).toBe(false);
+  });
+});

--- a/packages/ewe-note/src/components/tiptap-editor.tsx
+++ b/packages/ewe-note/src/components/tiptap-editor.tsx
@@ -21,6 +21,7 @@ import type { SlashMenuState } from '@/editor/slash-commands';
 import { resolveSlashMenuState } from '@/editor/slash-commands';
 import type { XmlFragment } from 'yjs';
 import type { Note, Room } from '@eweser/db';
+import type { AttachmentResolverContext } from '@/utils/attachment-resolver';
 import {
   editorJsonToMarkdown,
   markdownToEditorHtml,
@@ -75,12 +76,22 @@ interface TiptapEditorProps {
   onEditorFocusChange?: (focused: boolean) => void;
   sourceMode?: boolean;
   onSourceModeChange?: (sourceMode: boolean) => void;
+  attachmentContext?: AttachmentResolverContext;
 }
 
 interface LinkDialogState {
   open: boolean;
   kind: 'link' | 'external-link';
   href: string;
+}
+
+interface ShouldRefreshLocalEditorContentOptions {
+  collaborationReady: boolean;
+  focused: boolean;
+  hasEditor: boolean;
+  noteText: string;
+  pendingEditorMarkdown: string | null;
+  sourceMode: boolean;
 }
 
 function debounce(func: (markdown: string, note: Note) => void, wait: number) {
@@ -142,6 +153,23 @@ const ImageNode = Node.create({
       height: {
         default: null,
         parseHTML: (element) => element.getAttribute('height'),
+      },
+      sourcePath: {
+        default: null,
+        parseHTML: (element) =>
+          element.getAttribute('data-ewe-attachment-source'),
+        renderHTML: (attributes) =>
+          attributes.sourcePath
+            ? { 'data-ewe-attachment-source': attributes.sourcePath }
+            : {},
+      },
+      originalSource: {
+        default: null,
+        parseHTML: (element) => element.getAttribute('data-ewe-ofm-source'),
+        renderHTML: (attributes) =>
+          attributes.originalSource
+            ? { 'data-ewe-ofm-source': attributes.originalSource }
+            : {},
       },
     };
   },
@@ -224,6 +252,18 @@ function saveEditor(
   save(editorJsonToMarkdown(editor.getJSON() as JSONContent), note);
 }
 
+export function shouldRefreshLocalEditorContent({
+  collaborationReady,
+  focused,
+  hasEditor,
+  noteText,
+  pendingEditorMarkdown,
+  sourceMode,
+}: ShouldRefreshLocalEditorContentOptions): boolean {
+  if (!hasEditor || collaborationReady || sourceMode || focused) return false;
+  return pendingEditorMarkdown === null || pendingEditorMarkdown === noteText;
+}
+
 export function TiptapEditor({
   note,
   doc,
@@ -237,6 +277,7 @@ export function TiptapEditor({
   onEditorFocusChange,
   sourceMode = false,
   onSourceModeChange,
+  attachmentContext,
 }: TiptapEditorProps) {
   const noteRef = useRef(note);
   const fragment = useMemo(
@@ -245,10 +286,11 @@ export function TiptapEditor({
   );
   const collaborationReady = isCollaborationReady(fragment, provider);
   const initialHtml = useMemo(
-    () => markdownToEditorHtml(note.text),
-    [note.text]
+    () => markdownToEditorHtml(note.text, attachmentContext),
+    [attachmentContext, note.text]
   );
   const debouncedSaveRef = useRef<ReturnType<typeof debounce> | null>(null);
+  const pendingEditorMarkdownRef = useRef<string | null>(null);
   const suppressEditorSaveRef = useRef(false);
   const [slashMenuState, setSlashMenuState] = useState<SlashMenuState | null>(
     null
@@ -267,6 +309,9 @@ export function TiptapEditor({
 
   useEffect(() => {
     noteRef.current = note;
+    if (pendingEditorMarkdownRef.current === note.text) {
+      pendingEditorMarkdownRef.current = null;
+    }
     if (!sourceMode) {
       setSourceValue(note.text);
     }
@@ -326,10 +371,9 @@ export function TiptapEditor({
           setSlashMenuState(null);
         }
 
-        debouncedSaveRef.current?.(
-          editorJsonToMarkdown(editor.getJSON() as JSONContent),
-          noteRef.current
-        );
+        const markdown = editorJsonToMarkdown(editor.getJSON() as JSONContent);
+        pendingEditorMarkdownRef.current = markdown;
+        debouncedSaveRef.current?.(markdown, noteRef.current);
       },
       onDestroy() {
         onEditorReady?.(null);
@@ -346,6 +390,29 @@ export function TiptapEditor({
     },
     [selectedNoteId, doc, provider?.awareness]
   );
+
+  useEffect(() => {
+    const activeEditor = editor;
+    if (
+      !activeEditor ||
+      !shouldRefreshLocalEditorContent({
+        collaborationReady,
+        focused,
+        hasEditor: true,
+        noteText: note.text,
+        pendingEditorMarkdown: pendingEditorMarkdownRef.current,
+        sourceMode,
+      })
+    ) {
+      return;
+    }
+
+    suppressEditorSaveRef.current = true;
+    activeEditor.commands.setContent(initialHtml, false);
+    window.setTimeout(() => {
+      suppressEditorSaveRef.current = false;
+    }, 500);
+  }, [collaborationReady, editor, focused, initialHtml, note.text, sourceMode]);
 
   const closeSlashMenu = useCallback(() => setSlashMenuState(null), []);
   const toggleSourceMode = useCallback(() => {
@@ -431,12 +498,21 @@ export function TiptapEditor({
     debouncedSaveRef.current?.flush();
     onSaveMarkdown(sourceValue, noteRef.current);
     suppressEditorSaveRef.current = true;
-    editor?.commands.setContent(markdownToEditorHtml(sourceValue), false);
+    editor?.commands.setContent(
+      markdownToEditorHtml(sourceValue, attachmentContext),
+      false
+    );
     window.setTimeout(() => {
       suppressEditorSaveRef.current = false;
     }, 500);
     onSourceModeChange?.(false);
-  }, [editor, onSaveMarkdown, onSourceModeChange, sourceValue]);
+  }, [
+    attachmentContext,
+    editor,
+    onSaveMarkdown,
+    onSourceModeChange,
+    sourceValue,
+  ]);
 
   useEffect(() => {
     if (!onSourceModeChange) return;

--- a/packages/ewe-note/src/editor/markdown.test.ts
+++ b/packages/ewe-note/src/editor/markdown.test.ts
@@ -345,6 +345,29 @@ describe('TipTap markdown bridge', () => {
     expect(resolved.originalSource).toBe('![[image.png]]');
   });
 
+  it.each(['image.png?raw=1', 'image.png#preview'])(
+    'resolves image embed target %s after stripping query or fragment metadata',
+    (target) => {
+      const resolved = resolveAttachmentEmbed(target, {
+        attachments: [attachment('Attachments/image.png')],
+        attachmentUrls: {
+          'Attachments/image.png': 'blob:resolved-image',
+        },
+        noteSourcePath: 'Notes/Imported Note.md',
+      });
+
+      expect(resolved.status).toBe('resolved');
+      if (resolved.status !== 'resolved') {
+        throw new Error(
+          `Expected ${target} to resolve to the attachment record.`
+        );
+      }
+      expect(resolved.sourcePath).toBe('Attachments/image.png');
+      expect(resolved.url).toBe('blob:resolved-image');
+      expect(resolved.originalSource).toBe(`![[${target}]]`);
+    }
+  );
+
   it.each(['../secret.png', '..\\secret.png', '%2e%2e/secret.png'])(
     'keeps unsafe vault image embed target %s source-visible instead of constructing local URLs',
     (target) => {

--- a/packages/ewe-note/src/editor/markdown.test.ts
+++ b/packages/ewe-note/src/editor/markdown.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import type { FileAttachmentBase } from '@eweser/shared';
 import {
   editorJsonToMarkdown,
   markdownToEditorHtml,
@@ -9,6 +10,7 @@ import {
 } from './markdown';
 import { markdownToOfm, ofmToMarkdown } from '../extensions/ofm-serializer';
 import { parseCalloutHeader } from '../extensions/callout';
+import { resolveAttachmentEmbed } from '../utils/attachment-resolver';
 import {
   FEATURE_VAULT_MATRIX,
   readFeatureVaultFixture,
@@ -51,6 +53,24 @@ function normalizeOfmText(value: string): string {
     .replace(/[ \t]+\n/g, '\n')
     .replace(/\n{3,}/g, '\n\n')
     .trim();
+}
+
+function attachment(
+  sourcePath: string,
+  overrides: Partial<FileAttachmentBase> = {}
+): FileAttachmentBase {
+  const filename = sourcePath.split('/').pop() ?? sourcePath;
+  return {
+    baseId: 'notes-room-1',
+    contentHash: `hash:${sourcePath}`,
+    filename,
+    localAvailability: 'available',
+    mimeType: 'image/png',
+    size: 12,
+    sourcePath,
+    sourceVault: 'test-vault',
+    ...overrides,
+  };
 }
 
 describe('TipTap markdown bridge', () => {
@@ -229,15 +249,64 @@ describe('TipTap markdown bridge', () => {
     expect(back).toContain('![[Notes/Session 1#Topic Heading]]');
   });
 
-  it('preserves media embeds as source-visible OFM until a media node owns them', () => {
+  it('keeps image embeds source-visible when no attachment context is available', () => {
     const source = '![[Attachments/test-image.png|640x480]]';
     const toEditor = ofmToMarkdown(source);
-    const back = markdownToOfm(toEditor);
     const html = markdownToEditorHtml(source);
 
-    expect(toEditor).toContain('![[Attachments/test-image.png|640x480]]');
-    expect(back).toContain('![[Attachments/test-image.png|640x480]]');
+    expect(toEditor).toBe(source);
     expect(html).toContain('![[Attachments/test-image.png|640x480]]');
+    expect(html).not.toContain('data-ewe-broken-attachment="true"');
+  });
+
+  it('renders available Obsidian image embeds as image HTML with resolver metadata', () => {
+    const source = [
+      '![[image.png]]',
+      '![[Assets/diagram.png|300]]',
+      '![[wide.png|640x480]]',
+    ].join('\n');
+    const html = markdownToEditorHtml(source, {
+      attachments: [
+        attachment('Attachments/image.png'),
+        attachment('Assets/diagram.png'),
+        attachment('Media/wide.png', { filename: 'wide.png' }),
+      ],
+      attachmentUrls: {
+        'Attachments/image.png': 'blob:available-cover',
+        'Assets/diagram.png': 'blob:available-diagram',
+        'Media/wide.png': 'blob:available-wide',
+      },
+      noteSourcePath: 'Notes/Imported Note.md',
+    });
+
+    expect(html).toContain('<img');
+    expect(html).toContain('src="blob:available-cover"');
+    expect(html).toContain(
+      'data-ewe-attachment-source="Attachments/image.png"'
+    );
+    expect(html).toContain('data-ewe-ofm-source="![[image.png]]"');
+    expect(html).toContain('src="blob:available-diagram"');
+    expect(html).toContain('data-ewe-attachment-source="Assets/diagram.png"');
+    expect(html).toContain('width="300"');
+    expect(html).toContain('src="blob:available-wide"');
+    expect(html).toContain('width="640"');
+    expect(html).toContain('height="480"');
+  });
+
+  it('renders missing Obsidian image embeds as non-destructive placeholders', () => {
+    const source = 'Before ![[missing.png|300]] after';
+    const html = markdownToEditorHtml(source, {
+      attachments: [attachment('Attachments/other.png')],
+      attachmentUrls: { 'Attachments/other.png': 'blob:other' },
+      noteSourcePath: 'Notes/Imported Note.md',
+    });
+    const toEditor = ofmToMarkdown(source, { attachments: [] });
+    const back = markdownToOfm(toEditor);
+
+    expect(html).toContain('data-ewe-broken-attachment="true"');
+    expect(html).toContain('data-ewe-ofm-source="![[missing.png|300]]"');
+    expect(html).toContain('![[missing.png|300]]');
+    expect(back).toContain('![[missing.png|300]]');
     expect(
       editorJsonToMarkdown({
         type: 'doc',
@@ -247,14 +316,55 @@ describe('TipTap markdown bridge', () => {
             content: [
               {
                 type: 'text',
-                text: '![[Attachments/test-image.png|640x480]]',
+                text: '![[missing.png|300]]',
               },
             ],
           },
         ],
       })
-    ).toBe('![[Attachments/test-image.png|640x480]]');
+    ).toBe('![[missing.png|300]]');
   });
+
+  it('resolves image embed targets through Obsidian attachment metadata candidates', () => {
+    const resolved = resolveAttachmentEmbed('image.png', {
+      attachments: [attachment('Attachments/image.png')],
+      attachmentUrls: {
+        'Attachments/image.png': 'blob:resolved-image',
+      },
+      noteSourcePath: 'Notes/Imported Note.md',
+    });
+
+    expect(resolved.status).toBe('resolved');
+    if (resolved.status !== 'resolved') {
+      throw new Error(
+        'Expected image.png to resolve to the attachment record.'
+      );
+    }
+    expect(resolved.sourcePath).toBe('Attachments/image.png');
+    expect(resolved.url).toBe('blob:resolved-image');
+    expect(resolved.originalSource).toBe('![[image.png]]');
+  });
+
+  it.each(['../secret.png', '..\\secret.png', '%2e%2e/secret.png'])(
+    'keeps unsafe vault image embed target %s source-visible instead of constructing local URLs',
+    (target) => {
+      const source = `![[${target}]]`;
+      const context = {
+        vaultConfig: {
+          localServerBaseUrl: 'http://localhost:5174',
+          strategy: 'local_file' as const,
+          vaultPath: '/Users/jacob/vault',
+        },
+      };
+
+      expect(resolveAttachmentEmbed(target, context).status).toBe('missing');
+
+      const html = markdownToEditorHtml(source, context);
+      expect(html).toContain(source);
+      expect(html).not.toContain('/vault/');
+      expect(html).not.toContain('file://');
+    }
+  );
 
   it('serializes vault image nodes to OFM instead of dropping them', () => {
     expect(
@@ -273,6 +383,36 @@ describe('TipTap markdown bridge', () => {
         ],
       })
     ).toBe('![[Attachments/test-image.png|640x480]]');
+  });
+
+  it('serializes rendered image nodes with attachment resolver metadata back to OFM', () => {
+    expect(
+      editorJsonToMarkdown({
+        type: 'doc',
+        content: [
+          {
+            type: 'image',
+            attrs: {
+              src: 'blob:rendered-diagram',
+              alt: 'diagram.png',
+              sourcePath: 'Assets/diagram.png',
+              width: 300,
+            },
+          },
+          {
+            type: 'image',
+            attrs: {
+              src: 'blob:rendered-wide',
+              alt: 'wide.png',
+              originalSource: '![[wide.png|640x480]]',
+              sourcePath: 'Media/wide.png',
+              width: 640,
+              height: 480,
+            },
+          },
+        ],
+      })
+    ).toBe('![[Assets/diagram.png|300]]\n\n![[wide.png|640x480]]');
   });
 
   it('uses one slug contract for editor headings and outline links', () => {

--- a/packages/ewe-note/src/editor/markdown.ts
+++ b/packages/ewe-note/src/editor/markdown.ts
@@ -2,6 +2,7 @@ import type { JSONContent } from '@tiptap/react';
 import MarkdownIt from 'markdown-it';
 import { markdownToOfm, ofmToMarkdown } from '../extensions/ofm-serializer';
 import { toImageEmbedSyntax } from '../extensions/image-embed';
+import type { AttachmentResolverContext } from '../utils/attachment-resolver';
 
 const markdown = new MarkdownIt({
   html: true,
@@ -59,12 +60,18 @@ function preprocessTaskLines(source: string): string {
   return output.join('\n');
 }
 
-function markdownToEditorMarkdown(source: string): string {
-  return ofmToMarkdown(source);
+function markdownToEditorMarkdown(
+  source: string,
+  attachmentContext?: AttachmentResolverContext
+): string {
+  return ofmToMarkdown(source, attachmentContext);
 }
 
-export function markdownToEditorHtml(source: string): string {
-  const normalized = markdownToEditorMarkdown(source);
+export function markdownToEditorHtml(
+  source: string,
+  attachmentContext?: AttachmentResolverContext
+): string {
+  const normalized = markdownToEditorMarkdown(source, attachmentContext);
   return renderHighlightHtml(markdown.render(preprocessTaskLines(normalized)));
 }
 
@@ -175,18 +182,35 @@ function decodeVaultSrc(src: string) {
   }
 }
 
+function isImageEmbedSource(value: string): boolean {
+  return value.startsWith('![[') && value.endsWith(']]');
+}
+
 function renderImage(node: JSONContent): string {
   const src = String(node.attrs?.src ?? '');
   const alt = String(node.attrs?.alt ?? '');
+  const originalSource = String(node.attrs?.originalSource ?? '');
+  const sourcePath = String(node.attrs?.sourcePath ?? '');
   const vaultPath = decodeVaultSrc(src);
   const width = Number(node.attrs?.width);
   const height = Number(node.attrs?.height);
+  const dimensions = {
+    ...(Number.isFinite(width) && width > 0 ? { width } : {}),
+    ...(Number.isFinite(height) && height > 0 ? { height } : {}),
+  };
+
+  if (isImageEmbedSource(originalSource)) {
+    return originalSource;
+  }
+
+  if (sourcePath) {
+    return toImageEmbedSyntax({ sourcePath, ...dimensions });
+  }
 
   if (vaultPath) {
     return toImageEmbedSyntax({
       sourcePath: vaultPath,
-      ...(Number.isFinite(width) && width > 0 ? { width } : {}),
-      ...(Number.isFinite(height) && height > 0 ? { height } : {}),
+      ...dimensions,
     });
   }
 

--- a/packages/ewe-note/src/extensions/image-embed.ts
+++ b/packages/ewe-note/src/extensions/image-embed.ts
@@ -19,6 +19,30 @@ export interface ImageEmbedOptions {
   height?: number;
 }
 
+export interface ParsedImageEmbed {
+  /** Attachment target as written inside the embed, without dimension alias. */
+  target: string;
+  /** Raw pipe alias, if present. Obsidian uses numeric aliases for dimensions. */
+  alias?: string;
+  /** Display width in pixels (if specified via |300 or |640x480 syntax). */
+  width?: number;
+  /** Display height in pixels (if specified via |640x480 syntax). */
+  height?: number;
+  /** Original Obsidian source string, preserving the user's target spelling. */
+  originalSource: string;
+}
+
+const IMAGE_EXTENSIONS = new Set([
+  '.avif',
+  '.bmp',
+  '.gif',
+  '.jpeg',
+  '.jpg',
+  '.png',
+  '.svg',
+  '.webp',
+]);
+
 /**
  * Parse Obsidian image embed syntax alias to extract dimension hints.
  *
@@ -46,6 +70,40 @@ export function parseImageDimensions(alias: string | undefined): {
   }
 
   return {};
+}
+
+export function isImagePath(path: string): boolean {
+  const cleanPath = path.split(/[?#]/, 1)[0] ?? path;
+  const lastDot = cleanPath.lastIndexOf('.');
+  if (lastDot === -1) return false;
+  return IMAGE_EXTENSIONS.has(cleanPath.slice(lastDot).toLowerCase());
+}
+
+/**
+ * Parse the inner text of an Obsidian image embed.
+ *
+ * Examples:
+ *   image.png          → target image.png
+ *   image.png|300      → target image.png, width 300
+ *   image.png|640x480  → target image.png, width 640, height 480
+ */
+export function parseImageEmbed(raw: string): ParsedImageEmbed | null {
+  const normalized = raw.trim();
+  if (!normalized) return null;
+
+  const [rawTarget = '', ...aliasParts] = normalized.split('|');
+  const target = rawTarget.trim();
+  if (!target) return null;
+
+  const alias = aliasParts.join('|').trim() || undefined;
+  const dimensions = parseImageDimensions(alias);
+
+  return {
+    target,
+    ...(alias ? { alias } : {}),
+    ...dimensions,
+    originalSource: `![[${normalized}]]`,
+  };
 }
 
 /**

--- a/packages/ewe-note/src/extensions/ofm-serializer.ts
+++ b/packages/ewe-note/src/extensions/ofm-serializer.ts
@@ -11,35 +11,121 @@
  *   - Tags: #tag (preserved as-is)
  */
 
-import type { VaultConfig } from '../utils/attachment-resolver';
+import { parseImageEmbed } from './image-embed';
+import {
+  isResolvableImageTarget,
+  normalizeAttachmentResolverContext,
+  resolveAttachmentEmbed,
+  type AttachmentResolverContext,
+  type ResolvedAttachmentEmbed,
+  type VaultConfig,
+} from '../utils/attachment-resolver';
 
 // ---------------------------------------------------------------------------
 // Pre-processing: OFM -> Standard Markdown (for import into the editor)
 // ---------------------------------------------------------------------------
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function attr(name: string, value: string | number | undefined): string {
+  if (value === undefined || value === '') return '';
+  return ` ${name}="${escapeHtml(String(value))}"`;
+}
+
+function renderResolvedImage(resolution: ResolvedAttachmentEmbed): string {
+  return `<img${attr('src', resolution.url)}${attr(
+    'alt',
+    resolution.filename
+  )}${attr('data-ewe-attachment-source', resolution.sourcePath)}${attr(
+    'data-ewe-ofm-source',
+    resolution.originalSource
+  )}${attr('width', resolution.width)}${attr('height', resolution.height)} />`;
+}
+
+function renderMissingImage(
+  originalSource: string,
+  target: string,
+  width?: number,
+  height?: number
+): string {
+  return `<span class="ewe-broken-attachment" data-ewe-broken-attachment="true"${attr(
+    'data-ewe-ofm-source',
+    originalSource
+  )}${attr('data-ewe-attachment-target', target)}${attr('data-width', width)}${attr(
+    'data-height',
+    height
+  )} title="Attachment not found">${escapeHtml(originalSource)}</span>`;
+}
+
+function hasAttachmentResolutionInput(
+  context: AttachmentResolverContext
+): boolean {
+  return Boolean(
+    Object.prototype.hasOwnProperty.call(context, 'attachments') ||
+    context.attachmentUrls ||
+    context.vaultConfig
+  );
+}
 
 /**
  * Transform OFM-specific syntax into editor-compatible markdown
  * before passing to tryParseMarkdownToBlocks().
  *
  * @param ofm - Obsidian Flavored Markdown source
- * @param vaultConfig - Optional vault config for resolving attachment URLs
+ * @param context - Optional vault config or imported attachment metadata for resolving attachment URLs
  * @param noteSourcePath - Optional note source path for relative attachment resolution
  */
 export function ofmToMarkdown(
   ofm: string,
-  vaultConfig?: VaultConfig,
+  context?: VaultConfig | AttachmentResolverContext,
   noteSourcePath?: string
 ): string {
+  const attachmentContext = normalizeAttachmentResolverContext(
+    context,
+    noteSourcePath
+  );
   let result = ofm;
 
   // Preserve block comments %%...%% as plain text for source fidelity.
 
-  // Preserve all embeds as source-visible OFM until a real TipTap node owns
-  // media/embed serialization. This avoids image/media data loss on editor save.
+  // Render imported image embeds when their attachment metadata is available,
+  // but leave non-media note embeds as OFM source text to avoid data loss.
   result = result.replace(/!\[\[([^\]]+)\]\]/g, (_match, raw: string) => {
-    void vaultConfig;
-    void noteSourcePath;
-    return `![[${String(raw).trim()}]]`;
+    const parsed = parseImageEmbed(String(raw));
+    if (!parsed) return `![[${String(raw).trim()}]]`;
+
+    if (!hasAttachmentResolutionInput(attachmentContext)) {
+      return parsed.originalSource;
+    }
+
+    if (!isResolvableImageTarget(parsed.target, attachmentContext)) {
+      return parsed.originalSource;
+    }
+
+    const resolution = resolveAttachmentEmbed(parsed.target, {
+      ...attachmentContext,
+      originalSource: parsed.originalSource,
+      ...(parsed.width ? { width: parsed.width } : {}),
+      ...(parsed.height ? { height: parsed.height } : {}),
+    });
+
+    if (resolution.status === 'resolved') {
+      return renderResolvedImage(resolution);
+    }
+
+    return renderMissingImage(
+      resolution.originalSource,
+      resolution.target,
+      resolution.width,
+      resolution.height
+    );
   });
 
   // Wiki links with alias: [[Note Name|Alias]] → [Alias](wiki://Note Name)
@@ -74,6 +160,24 @@ export function ofmToMarkdown(
 // Post-processing: Standard Markdown -> OFM
 // ---------------------------------------------------------------------------
 
+function decodeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&');
+}
+
+function getHtmlAttribute(tag: string, name: string): string | undefined {
+  const match = tag.match(new RegExp(`${name}=["']([^"']+)["']`, 'i'));
+  return match ? decodeHtmlAttribute(match[1]) : undefined;
+}
+
+function isObsidianEmbedSource(value: string | undefined): value is string {
+  return Boolean(value?.startsWith('![[') && value.endsWith(']]'));
+}
+
 /**
  * Transform serialized markdown back to OFM syntax.
  *
@@ -84,6 +188,23 @@ export function ofmToMarkdown(
  */
 export function markdownToOfm(markdown: string): string {
   let result = markdown;
+
+  result = result.replace(/<img\b([^>]*)>/gi, (match, attrs: string) => {
+    const originalSource = getHtmlAttribute(attrs, 'data-ewe-ofm-source');
+    if (isObsidianEmbedSource(originalSource)) return originalSource;
+    return match;
+  });
+
+  result = result.replace(
+    /<span\b([^>]*)data-ewe-broken-attachment=["']true["']([^>]*)>([\s\S]*?)<\/span>/gi,
+    (match, beforeAttrs: string, afterAttrs: string, body: string) => {
+      const attrs = `${beforeAttrs} ${afterAttrs}`;
+      const originalSource = getHtmlAttribute(attrs, 'data-ewe-ofm-source');
+      if (isObsidianEmbedSource(originalSource)) return originalSource;
+      const bodyText = body.replace(/<[^>]+>/g, '').trim();
+      return isObsidianEmbedSource(bodyText) ? bodyText : match;
+    }
+  );
 
   // Back-compat for markdown image links written without a metadata token.
   result = result.replace(

--- a/packages/ewe-note/src/test/mocks/eweser-db.ts
+++ b/packages/ewe-note/src/test/mocks/eweser-db.ts
@@ -1,0 +1,3 @@
+export async function uploadFile(): Promise<never> {
+  throw new Error('@eweser/db uploadFile test mock was called unexpectedly.');
+}

--- a/packages/ewe-note/src/utils/attachment-resolver.ts
+++ b/packages/ewe-note/src/utils/attachment-resolver.ts
@@ -33,6 +33,51 @@ export interface VaultConfig {
   storageBaseUrl?: string;
 }
 
+export interface AttachmentResolverContext {
+  /** Imported attachment inventory for the note/base. */
+  attachments?: readonly FileAttachmentBase[];
+  /** Already-materialized URLs (Blob URLs, signed URLs, static URLs) keyed by sourcePath. */
+  attachmentUrls?: Readonly<Record<string, string>>;
+  /** Note source path used to resolve relative Obsidian attachment targets. */
+  noteSourcePath?: string;
+  /** Optional legacy URL-construction config. */
+  vaultConfig?: VaultConfig;
+}
+
+export interface AttachmentEmbedResolutionOptions extends AttachmentResolverContext {
+  /** Original Obsidian source to preserve through editor round-trips. */
+  originalSource?: string;
+  /** Display width parsed from Obsidian's pipe alias. */
+  width?: number;
+  /** Display height parsed from Obsidian's pipe alias. */
+  height?: number;
+}
+
+export interface ResolvedAttachmentEmbed {
+  status: 'resolved';
+  target: string;
+  sourcePath: string;
+  filename: string;
+  url: string;
+  originalSource: string;
+  attachment?: FileAttachmentBase;
+  width?: number;
+  height?: number;
+}
+
+export interface MissingAttachmentEmbed {
+  status: 'missing';
+  target: string;
+  sourcePath?: string;
+  originalSource: string;
+  width?: number;
+  height?: number;
+}
+
+export type AttachmentEmbedResolution =
+  | ResolvedAttachmentEmbed
+  | MissingAttachmentEmbed;
+
 /** Common Obsidian attachment folder names to search */
 const ATTACHMENT_FOLDERS = [
   'Attachments',
@@ -42,6 +87,83 @@ const ATTACHMENT_FOLDERS = [
   '_attachments',
 ];
 
+function normalizeAttachmentPath(path: string): string {
+  return path.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+/g, '/');
+}
+
+function decodeAttachmentPathForSafety(path: string): string | null {
+  let decoded = path;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      const next = decodeURIComponent(decoded);
+      if (next === decoded) break;
+      decoded = next;
+    } catch {
+      return null;
+    }
+  }
+  return decoded;
+}
+
+function isSafeVaultRelativePath(path: string): boolean {
+  const targetPath = path.split(/[?#]/, 1)[0]?.trim() ?? '';
+  const decoded = decodeAttachmentPathForSafety(targetPath);
+  if (!decoded) return false;
+
+  const normalized = normalizeAttachmentPath(decoded);
+  if (!normalized || normalized.startsWith('/')) return false;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(normalized)) return false;
+  for (const character of normalized) {
+    const codePoint = character.charCodeAt(0);
+    if (codePoint <= 31 || codePoint === 127) return false;
+  }
+
+  return normalized.split('/').every((segment) => segment !== '..');
+}
+
+function attachmentKey(path: string): string {
+  return normalizeAttachmentPath(path).toLowerCase();
+}
+
+function baseName(path: string): string {
+  return normalizeAttachmentPath(path).split('/').pop() ?? path;
+}
+
+function isImageAttachment(attachment: FileAttachmentBase): boolean {
+  return attachment.mimeType.toLowerCase().startsWith('image/');
+}
+
+function isVaultConfig(
+  context: VaultConfig | AttachmentResolverContext | undefined
+): context is VaultConfig {
+  return Boolean(
+    context &&
+    typeof (context as VaultConfig).vaultPath === 'string' &&
+    typeof (context as VaultConfig).strategy === 'string'
+  );
+}
+
+export function normalizeAttachmentResolverContext(
+  context?: VaultConfig | AttachmentResolverContext,
+  noteSourcePath?: string
+): AttachmentResolverContext {
+  if (!context) {
+    return noteSourcePath ? { noteSourcePath } : {};
+  }
+
+  if (isVaultConfig(context)) {
+    return {
+      vaultConfig: context,
+      ...(noteSourcePath ? { noteSourcePath } : {}),
+    };
+  }
+
+  return {
+    ...context,
+    noteSourcePath: context.noteSourcePath ?? noteSourcePath,
+  };
+}
+
 /**
  * Resolve an attachment name to all candidate paths relative to vault root.
  * Returns paths in order of priority.
@@ -50,38 +172,214 @@ export function getAttachmentCandidates(
   attachmentName: string,
   noteSourcePath?: string
 ): string[] {
+  if (!isSafeVaultRelativePath(attachmentName)) return [];
+
+  const normalizedAttachmentName = normalizeAttachmentPath(attachmentName);
   const candidates: string[] = [];
 
   // 1. Exact path as given (e.g. "Attachments/image.png")
-  candidates.push(attachmentName);
+  candidates.push(normalizedAttachmentName);
 
   // 2. Common attachment folders
   for (const folder of ATTACHMENT_FOLDERS) {
-    candidates.push(`${folder}/${attachmentName}`);
+    candidates.push(`${folder}/${normalizedAttachmentName}`);
   }
 
   // 3. Same folder as note (if source path known)
   if (noteSourcePath) {
-    const noteDir = noteSourcePath.split('/').slice(0, -1).join('/');
+    const normalizedNoteSourcePath = normalizeAttachmentPath(noteSourcePath);
+    const noteDir = normalizedNoteSourcePath.split('/').slice(0, -1).join('/');
     if (noteDir) {
-      candidates.push(`${noteDir}/${attachmentName}`);
+      candidates.push(`${noteDir}/${normalizedAttachmentName}`);
     }
     // Also check attachment folders relative to note's parent
     for (const folder of ATTACHMENT_FOLDERS) {
       if (noteDir) {
-        candidates.push(`${noteDir}/${folder}/${attachmentName}`);
+        candidates.push(`${noteDir}/${folder}/${normalizedAttachmentName}`);
       }
     }
   }
 
-  // 4. Vault root
-  const baseName = attachmentName.split('/').pop() ?? attachmentName;
-  if (baseName !== attachmentName) {
-    candidates.push(baseName);
+  // 4. Vault root basename fallback for wikilinks written with a nested path.
+  const name = baseName(normalizedAttachmentName);
+  if (name !== normalizedAttachmentName) {
+    candidates.push(name);
   }
 
   // Deduplicate preserving order
   return Array.from(new Set(candidates));
+}
+
+export function findAttachmentForTarget(
+  attachmentName: string,
+  context: AttachmentResolverContext = {}
+): FileAttachmentBase | undefined {
+  if (!isSafeVaultRelativePath(attachmentName)) return undefined;
+
+  const attachments = context.attachments;
+  if (!attachments?.length) return undefined;
+
+  const candidates = getAttachmentCandidates(
+    attachmentName,
+    context.noteSourcePath
+  ).map(attachmentKey);
+  const candidateSet = new Set(candidates);
+
+  const exact = attachments.find((attachment) =>
+    candidateSet.has(attachmentKey(attachment.sourcePath))
+  );
+  if (exact) return exact;
+
+  const targetBaseName = baseName(attachmentName).toLowerCase();
+  return attachments.find(
+    (attachment) =>
+      baseName(attachment.sourcePath).toLowerCase() === targetBaseName ||
+      attachment.filename.toLowerCase() === targetBaseName
+  );
+}
+
+export function isResolvableImageTarget(
+  attachmentName: string,
+  context: AttachmentResolverContext = {}
+): boolean {
+  if (!isSafeVaultRelativePath(attachmentName)) return false;
+
+  const matchedAttachment = findAttachmentForTarget(attachmentName, context);
+  if (matchedAttachment) return isImageAttachment(matchedAttachment);
+
+  const normalizedName =
+    normalizeAttachmentPath(attachmentName).split(/[?#]/, 1)[0] ??
+    attachmentName;
+  const lastDot = normalizedName.lastIndexOf('.');
+  if (lastDot === -1) return false;
+
+  return new Set([
+    '.avif',
+    '.bmp',
+    '.gif',
+    '.jpeg',
+    '.jpg',
+    '.png',
+    '.svg',
+    '.webp',
+  ]).has(normalizedName.slice(lastDot).toLowerCase());
+}
+
+function findMaterializedUrl(
+  attachment: FileAttachmentBase | undefined,
+  attachmentName: string,
+  context: AttachmentResolverContext
+): string | undefined {
+  const attachmentUrls = context.attachmentUrls;
+  if (attachmentUrls) {
+    const urlEntries = Object.entries(attachmentUrls);
+    const lookupKeys = new Set(
+      getAttachmentCandidates(attachmentName, context.noteSourcePath).map(
+        attachmentKey
+      )
+    );
+
+    if (attachment) {
+      lookupKeys.add(attachmentKey(attachment.sourcePath));
+      lookupKeys.add(attachment.filename.toLowerCase());
+    }
+
+    for (const [key, url] of urlEntries) {
+      if (lookupKeys.has(attachmentKey(key)) && url) return url;
+    }
+
+    const targetBaseName = baseName(
+      attachment?.sourcePath ?? attachmentName
+    ).toLowerCase();
+    for (const [key, url] of urlEntries) {
+      if (baseName(key).toLowerCase() === targetBaseName && url) return url;
+    }
+  }
+
+  if (attachment && context.vaultConfig) {
+    const url = resolveAttachmentRecord(attachment, context.vaultConfig);
+    return url || undefined;
+  }
+
+  if (!attachment && !context.attachments?.length && context.vaultConfig) {
+    const url = resolveAttachment(
+      attachmentName,
+      context.vaultConfig,
+      context.noteSourcePath
+    );
+    return url || undefined;
+  }
+
+  return undefined;
+}
+
+export function resolveAttachmentEmbed(
+  attachmentName: string,
+  options: AttachmentEmbedResolutionOptions = {}
+): AttachmentEmbedResolution {
+  const normalizedContext = normalizeAttachmentResolverContext(options);
+  const originalSource =
+    options.originalSource ??
+    `![[${attachmentName}${
+      options.width && options.height
+        ? `|${options.width}x${options.height}`
+        : options.width
+          ? `|${options.width}`
+          : ''
+    }]]`;
+
+  if (!isSafeVaultRelativePath(attachmentName)) {
+    return {
+      status: 'missing',
+      target: attachmentName,
+      originalSource,
+      ...(options.width ? { width: options.width } : {}),
+      ...(options.height ? { height: options.height } : {}),
+    };
+  }
+
+  const attachment = findAttachmentForTarget(attachmentName, normalizedContext);
+  const url = findMaterializedUrl(
+    attachment,
+    attachmentName,
+    normalizedContext
+  );
+
+  if (attachment && url) {
+    return {
+      status: 'resolved',
+      target: attachmentName,
+      sourcePath: attachment.sourcePath,
+      filename: attachment.filename || baseName(attachment.sourcePath),
+      url,
+      originalSource,
+      attachment,
+      ...(options.width ? { width: options.width } : {}),
+      ...(options.height ? { height: options.height } : {}),
+    };
+  }
+
+  if (!attachment && !normalizedContext.attachments?.length && url) {
+    return {
+      status: 'resolved',
+      target: attachmentName,
+      sourcePath: attachmentName,
+      filename: baseName(attachmentName),
+      url,
+      originalSource,
+      ...(options.width ? { width: options.width } : {}),
+      ...(options.height ? { height: options.height } : {}),
+    };
+  }
+
+  return {
+    status: 'missing',
+    target: attachmentName,
+    sourcePath: attachment?.sourcePath,
+    originalSource,
+    ...(options.width ? { width: options.width } : {}),
+    ...(options.height ? { height: options.height } : {}),
+  };
 }
 
 /**
@@ -101,7 +399,8 @@ export function resolveAttachment(
 ): string {
   const candidates = getAttachmentCandidates(attachmentName, noteSourcePath);
   // Return the first candidate as the "best guess" URL
-  const primaryCandidate = candidates[0] ?? attachmentName;
+  const primaryCandidate = candidates[0];
+  if (!primaryCandidate) return '';
 
   switch (vaultConfig.strategy) {
     case 'local_file': {

--- a/packages/ewe-note/src/utils/attachment-resolver.ts
+++ b/packages/ewe-note/src/utils/attachment-resolver.ts
@@ -87,6 +87,17 @@ const ATTACHMENT_FOLDERS = [
   '_attachments',
 ];
 
+const RESOLVABLE_IMAGE_EXTENSIONS = new Set([
+  '.avif',
+  '.bmp',
+  '.gif',
+  '.jpeg',
+  '.jpg',
+  '.png',
+  '.svg',
+  '.webp',
+]);
+
 function normalizeAttachmentPath(path: string): string {
   return path.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+/g, '/');
 }
@@ -105,20 +116,28 @@ function decodeAttachmentPathForSafety(path: string): string | null {
   return decoded;
 }
 
-function isSafeVaultRelativePath(path: string): boolean {
+function normalizeSafeAttachmentTarget(path: string): string | null {
   const targetPath = path.split(/[?#]/, 1)[0]?.trim() ?? '';
   const decoded = decodeAttachmentPathForSafety(targetPath);
-  if (!decoded) return false;
+  if (!decoded) return null;
 
   const normalized = normalizeAttachmentPath(decoded);
-  if (!normalized || normalized.startsWith('/')) return false;
-  if (/^[a-z][a-z0-9+.-]*:/i.test(normalized)) return false;
+  if (!normalized || normalized.startsWith('/')) return null;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(normalized)) return null;
   for (const character of normalized) {
     const codePoint = character.charCodeAt(0);
-    if (codePoint <= 31 || codePoint === 127) return false;
+    if (codePoint <= 31 || codePoint === 127) return null;
   }
 
-  return normalized.split('/').every((segment) => segment !== '..');
+  if (normalized.split('/').some((segment) => segment === '..')) {
+    return null;
+  }
+
+  return normalized;
+}
+
+function isSafeVaultRelativePath(path: string): boolean {
+  return normalizeSafeAttachmentTarget(path) !== null;
 }
 
 function attachmentKey(path: string): string {
@@ -172,9 +191,10 @@ export function getAttachmentCandidates(
   attachmentName: string,
   noteSourcePath?: string
 ): string[] {
-  if (!isSafeVaultRelativePath(attachmentName)) return [];
+  const normalizedAttachmentName =
+    normalizeSafeAttachmentTarget(attachmentName);
+  if (!normalizedAttachmentName) return [];
 
-  const normalizedAttachmentName = normalizeAttachmentPath(attachmentName);
   const candidates: string[] = [];
 
   // 1. Exact path as given (e.g. "Attachments/image.png")
@@ -214,7 +234,9 @@ export function findAttachmentForTarget(
   attachmentName: string,
   context: AttachmentResolverContext = {}
 ): FileAttachmentBase | undefined {
-  if (!isSafeVaultRelativePath(attachmentName)) return undefined;
+  const normalizedAttachmentName =
+    normalizeSafeAttachmentTarget(attachmentName);
+  if (!normalizedAttachmentName) return undefined;
 
   const attachments = context.attachments;
   if (!attachments?.length) return undefined;
@@ -230,7 +252,7 @@ export function findAttachmentForTarget(
   );
   if (exact) return exact;
 
-  const targetBaseName = baseName(attachmentName).toLowerCase();
+  const targetBaseName = baseName(normalizedAttachmentName).toLowerCase();
   return attachments.find(
     (attachment) =>
       baseName(attachment.sourcePath).toLowerCase() === targetBaseName ||
@@ -242,27 +264,18 @@ export function isResolvableImageTarget(
   attachmentName: string,
   context: AttachmentResolverContext = {}
 ): boolean {
-  if (!isSafeVaultRelativePath(attachmentName)) return false;
+  const normalizedName = normalizeSafeAttachmentTarget(attachmentName);
+  if (!normalizedName) return false;
 
   const matchedAttachment = findAttachmentForTarget(attachmentName, context);
   if (matchedAttachment) return isImageAttachment(matchedAttachment);
 
-  const normalizedName =
-    normalizeAttachmentPath(attachmentName).split(/[?#]/, 1)[0] ??
-    attachmentName;
   const lastDot = normalizedName.lastIndexOf('.');
   if (lastDot === -1) return false;
 
-  return new Set([
-    '.avif',
-    '.bmp',
-    '.gif',
-    '.jpeg',
-    '.jpg',
-    '.png',
-    '.svg',
-    '.webp',
-  ]).has(normalizedName.slice(lastDot).toLowerCase());
+  return RESOLVABLE_IMAGE_EXTENSIONS.has(
+    normalizedName.slice(lastDot).toLowerCase()
+  );
 }
 
 function findMaterializedUrl(
@@ -270,6 +283,10 @@ function findMaterializedUrl(
   attachmentName: string,
   context: AttachmentResolverContext
 ): string | undefined {
+  const normalizedAttachmentName =
+    normalizeSafeAttachmentTarget(attachmentName);
+  if (!normalizedAttachmentName) return undefined;
+
   const attachmentUrls = context.attachmentUrls;
   if (attachmentUrls) {
     const urlEntries = Object.entries(attachmentUrls);
@@ -289,7 +306,7 @@ function findMaterializedUrl(
     }
 
     const targetBaseName = baseName(
-      attachment?.sourcePath ?? attachmentName
+      attachment?.sourcePath ?? normalizedAttachmentName
     ).toLowerCase();
     for (const [key, url] of urlEntries) {
       if (baseName(key).toLowerCase() === targetBaseName && url) return url;

--- a/packages/ewe-note/test-fixtures/obsidian-feature-vault/Attachments/diagram.svg
+++ b/packages/ewe-note/test-fixtures/obsidian-feature-vault/Attachments/diagram.svg
@@ -1,1 +1,51 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64"><rect width="64" height="64" fill="#f4efe2"/><circle cx="20" cy="20" r="10" fill="#3f6f5f"/><rect x="30" y="14" width="20" height="12" fill="#d98c4a"/><path d="M12 46 L52 46" stroke="#2a2a2a" stroke-width="4"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="360" viewBox="0 0 640 360" role="img" aria-labelledby="title desc">
+  <title id="title">Obsidian attachment import flow</title>
+  <desc id="desc">A diagram showing an Obsidian vault image flowing through attachment metadata and local cache into the Ewe Note editor.</desc>
+  <defs>
+    <linearGradient id="panel" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#f8fbff"/>
+      <stop offset="1" stop-color="#eef4ff"/>
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-20%" width="120%" height="140%">
+      <feDropShadow dx="0" dy="8" flood-color="#25466b" flood-opacity="0.16" stdDeviation="10"/>
+    </filter>
+    <marker id="arrow" markerHeight="12" markerWidth="12" orient="auto" refX="10" refY="6">
+      <path d="M2 2 L10 6 L2 10 Z" fill="#2563eb"/>
+    </marker>
+  </defs>
+  <rect width="640" height="360" rx="28" fill="#f5f7fb"/>
+  <rect x="32" y="34" width="576" height="292" rx="24" fill="url(#panel)" stroke="#c7d7ee"/>
+  <text x="64" y="78" fill="#0f172a" font-family="Inter, Arial, sans-serif" font-size="26" font-weight="700">Imported attachment rendering</text>
+  <text x="64" y="104" fill="#475569" font-family="Inter, Arial, sans-serif" font-size="14">Obsidian media stays visible while the original ![[...]] source is preserved.</text>
+
+  <g filter="url(#shadow)">
+    <rect x="66" y="144" width="132" height="104" rx="16" fill="#ffffff" stroke="#b9c9df"/>
+    <path d="M91 172 H173 V222 H91 Z" fill="#ecfdf5" stroke="#65a30d" stroke-width="2"/>
+    <circle cx="113" cy="194" r="14" fill="#22c55e"/>
+    <path d="M132 216 L151 191 L173 222 H91 L111 202 Z" fill="#15803d"/>
+    <text x="132" y="273" text-anchor="middle" fill="#0f172a" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700">Obsidian vault</text>
+    <text x="132" y="293" text-anchor="middle" fill="#64748b" font-family="Inter, Arial, sans-serif" font-size="12">photo.jpg</text>
+  </g>
+
+  <g filter="url(#shadow)">
+    <rect x="254" y="144" width="132" height="104" rx="16" fill="#ffffff" stroke="#b9c9df"/>
+    <rect x="282" y="170" width="76" height="12" rx="6" fill="#60a5fa"/>
+    <rect x="282" y="194" width="54" height="12" rx="6" fill="#93c5fd"/>
+    <rect x="282" y="218" width="88" height="12" rx="6" fill="#bfdbfe"/>
+    <text x="320" y="273" text-anchor="middle" fill="#0f172a" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700">Metadata</text>
+    <text x="320" y="293" text-anchor="middle" fill="#64748b" font-family="Inter, Arial, sans-serif" font-size="12">sourcePath + cache key</text>
+  </g>
+
+  <g filter="url(#shadow)">
+    <rect x="442" y="144" width="132" height="104" rx="16" fill="#ffffff" stroke="#b9c9df"/>
+    <rect x="467" y="170" width="82" height="54" rx="8" fill="#dbeafe" stroke="#2563eb" stroke-width="2"/>
+    <path d="M482 208 L497 190 L512 205 L526 185 L549 224 H467 L482 208 Z" fill="#2563eb"/>
+    <text x="508" y="273" text-anchor="middle" fill="#0f172a" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700">Ewe Note editor</text>
+    <text x="508" y="293" text-anchor="middle" fill="#64748b" font-family="Inter, Arial, sans-serif" font-size="12">rendered image embed</text>
+  </g>
+
+  <path d="M204 196 H244" stroke="#2563eb" stroke-width="4" marker-end="url(#arrow)"/>
+  <path d="M392 196 H432" stroke="#2563eb" stroke-width="4" marker-end="url(#arrow)"/>
+  <path d="M132 124 C132 104 508 104 508 124" fill="none" stroke="#94a3b8" stroke-dasharray="6 8" stroke-width="3"/>
+  <text x="320" y="130" text-anchor="middle" fill="#475569" font-family="Inter, Arial, sans-serif" font-size="13">round-trip saves the original OFM source</text>
+</svg>

--- a/packages/ewe-note/vitest.config.ts
+++ b/packages/ewe-note/vitest.config.ts
@@ -5,6 +5,8 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      '@eweser/db': path.resolve(__dirname, './src/test/mocks/eweser-db.ts'),
+      '@eweser/shared': path.resolve(__dirname, '../shared/src/index.ts'),
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- render imported Obsidian image embeds from preserved attachment metadata
- preserve local browser attachment bytes in an IndexedDB cache for offline imported vaults
- add tests for OFM image round-trips, attachment resolution, editor refresh, and local import error handling

## Verification
- npm test --workspace @eweser/ewe-note -- src/editor/markdown.test.ts src/app/lib/browser-vault-import.test.ts src/app/lib/browser-attachment-cache.test.ts src/components/editor-attachments.test.ts src/components/tiptap-editor-refresh.test.ts
- npm run type-check --workspace @eweser/ewe-note
- git diff --cached --check
- git diff --check
- pre-commit hooks: secrets-scan, lint-staged
- pre-push hooks: autofix, secrets-scan, verify