### PR TITLE
fix(ewe-note): honor notes route base

### DIFF
--- a/packages/ewe-note/src/app/INDEX.md
+++ b/packages/ewe-note/src/app/INDEX.md
@@ -30,6 +30,8 @@ including page routes, note context, and product-specific app components.
 
 - Route changes must stay aligned with links and navigation commands in the app
   components.
+- Browser routes must honor the configured router base so the app works at both
+  the local root path and the deployed `/notes` mount point.
 - Notes state should preserve local-first behavior through `@eweser/db` and the
   existing room hooks.
 - User-visible workflow changes should keep Cypress selectors stable or update

--- a/packages/ewe-note/src/app/routes.test.tsx
+++ b/packages/ewe-note/src/app/routes.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createEweNoteRouter, routes } from './routes';
+
+const addNote = vi.hoisted(() => vi.fn(() => ({ id: 'created-note' })));
+
+vi.mock('./contexts/NotesContext', () => ({
+  useNotes: () => ({
+    addNote,
+  }),
+}));
+
+vi.mock('./components/WorkspaceShell', () => ({
+  WorkspaceShell: ({ children }: { children: ReactNode }) => (
+    <div data-cy="workspace-shell">{children}</div>
+  ),
+}));
+
+vi.mock('./pages/EnhancedEditor', () => ({
+  EnhancedEditor: () => <div data-cy="editor-route">Editor route</div>,
+}));
+
+vi.mock('./pages/Settings', () => ({
+  Settings: () => <div data-cy="settings-route">Settings route</div>,
+}));
+
+describe('Ewe Note routes', () => {
+  beforeEach(() => {
+    addNote.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the editor route when the notes app is mounted under /notes', () => {
+    window.history.replaceState(null, '', '/notes/editor/note-123');
+    const router = createEweNoteRouter('/notes');
+
+    render(<RouterProvider router={router} />);
+
+    expect(document.querySelector('[data-cy="editor-route"]')).not.toBeNull();
+    expect(router.state.matches.at(-1)?.params.noteId).toBe('note-123');
+    router.dispose();
+  });
+
+  it('keeps new-note navigation under the /notes mount point', async () => {
+    const router = createMemoryRouter(routes, {
+      basename: '/notes',
+      initialEntries: ['/notes/'],
+    });
+
+    render(<RouterProvider router={router} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'New note' }));
+
+    expect(addNote).toHaveBeenCalledWith({ title: 'Untitled', content: '' });
+    expect(router.state.location.pathname).toBe('/notes/editor/created-note');
+    expect(document.querySelector('[data-cy="editor-route"]')).not.toBeNull();
+  });
+
+  it('keeps local root new-note navigation root-based', () => {
+    const router = createMemoryRouter(routes, {
+      initialEntries: ['/'],
+    });
+
+    render(<RouterProvider router={router} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'New note' }));
+
+    expect(addNote).toHaveBeenCalledWith({ title: 'Untitled', content: '' });
+    expect(router.state.location.pathname).toBe('/editor/created-note');
+    expect(document.querySelector('[data-cy="editor-route"]')).not.toBeNull();
+  });
+});

--- a/packages/ewe-note/src/app/routes.tsx
+++ b/packages/ewe-note/src/app/routes.tsx
@@ -1,15 +1,16 @@
 /**
  * Purpose: Browser route table for redesigned Ewe Note screens.
- * Exports: router.
+ * Exports: routes, createEweNoteRouter, router.
  * Touches: Home, editor, and settings navigation.
  * Read before editing: packages/ewe-note/src/INDEX.md.
  */
-import { createBrowserRouter } from 'react-router';
+import { createBrowserRouter, type RouteObject } from 'react-router';
+import { routerBase } from '@/config';
 import { EnhancedHome } from './pages/EnhancedHome';
 import { EnhancedEditor } from './pages/EnhancedEditor';
 import { Settings } from './pages/Settings';
 
-export const router = createBrowserRouter([
+export const routes: RouteObject[] = [
   {
     path: '/',
     Component: EnhancedHome,
@@ -22,4 +23,12 @@ export const router = createBrowserRouter([
     path: '/settings',
     Component: Settings,
   },
-]);
+];
+
+export function createEweNoteRouter(base = routerBase) {
+  return createBrowserRouter(routes, {
+    basename: base,
+  });
+}
+
+export const router = createEweNoteRouter();

--- a/packages/ewe-note/src/config.test.ts
+++ b/packages/ewe-note/src/config.test.ts
@@ -3,6 +3,7 @@ import {
   buildAppPath,
   normalizeBase,
   resolveAuthServerUrl,
+  resolveRouterBase,
   stripTrailingSlash,
 } from './config';
 
@@ -16,6 +17,12 @@ describe('config helpers', () => {
   it('builds app paths under the /notes mount point', () => {
     expect(buildAppPath('/notes/', '/')).toBe('/notes/');
     expect(buildAppPath('/notes/', 'editor')).toBe('/notes/editor');
+  });
+
+  it('uses the /notes router base when the root-built app is loaded there', () => {
+    expect(resolveRouterBase('/', '/notes/')).toBe('/notes');
+    expect(resolveRouterBase('/', '/notes/editor/note-123')).toBe('/notes');
+    expect(resolveRouterBase('/', '/editor/note-123')).toBe('/');
   });
 
   it('resolves the auth server against the current origin by default', () => {

--- a/packages/ewe-note/src/config.ts
+++ b/packages/ewe-note/src/config.ts
@@ -55,7 +55,33 @@ export function buildAppPath(base: string, path = '/') {
   return `${normalizedBase}${normalizedPath}`;
 }
 
-export const routerBase = normalizeBase(import.meta.env.BASE_URL ?? '/');
+const notesMountPath = '/notes';
+
+export function resolveRouterBase(
+  viteBase = import.meta.env.BASE_URL ?? '/',
+  pathname = typeof window === 'undefined' ? '/' : window.location.pathname
+) {
+  const normalizedViteBase = normalizeBase(viteBase);
+
+  if (normalizedViteBase !== '/') {
+    return normalizedViteBase;
+  }
+
+  const normalizedPathname = pathname.startsWith('/')
+    ? pathname
+    : `/${pathname}`;
+
+  if (
+    normalizedPathname === notesMountPath ||
+    normalizedPathname.startsWith(`${notesMountPath}/`)
+  ) {
+    return notesMountPath;
+  }
+
+  return '/';
+}
+
+export const routerBase = resolveRouterBase(import.meta.env.BASE_URL ?? '/');
 
 export const AUTH_SERVER = resolveAuthServerUrl();
 


### PR DESCRIPTION
## Summary
- Honor the configured Ewe Note route base so production /notes editor routes render correctly.
- Add focused route/config coverage for the /notes base behavior.

## Verification
- npm test --workspace @eweser/ewe-note
- npm run type-check --workspace @eweser/ewe-note
- git diff --check HEAD~1 HEAD
- npm run code-index:check
- lefthook pre-push secret scan / verify passed during SSH push