### PR TITLE
feat(ewe-note): improve wiki-link navigation

### DIFF
--- a/packages/ewe-note/src/app/components/RightPanel.tsx
+++ b/packages/ewe-note/src/app/components/RightPanel.tsx
@@ -242,6 +242,9 @@ export function RightPanel({ noteId, onClose }: RightPanelProps) {
                           link.raw ||
                           `${link.target}:${link.noteId ?? link.alias}`
                         }
+                        role="status"
+                        aria-label={`Unresolved wiki link: ${link.target}`}
+                        data-cy="ewe-note-unresolved-wiki-link"
                         className="w-full flex items-start gap-2 px-2 py-2 rounded bg-muted/30"
                       >
                         <FileText className="w-4 h-4 text-muted-foreground mt-0.5 flex-shrink-0" />

--- a/packages/ewe-note/src/app/components/RightPanel.wiki-links.test.tsx
+++ b/packages/ewe-note/src/app/components/RightPanel.wiki-links.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { RightPanel } from './RightPanel';
+
+const mocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  updateNote: vi.fn(),
+  convertUnlinkedMentionToLink: vi.fn(),
+  note: {
+    id: 'note-linking',
+    roomId: 'room-notes',
+    title: 'Linking Note',
+    content: 'Read [[Missing Feature Note]] before shipping.',
+    folder: '',
+    tags: [],
+    properties: {},
+    aliases: [],
+    createdAt: '2026-05-04T00:00:00.000Z',
+    updatedAt: '2026-05-05T00:00:00.000Z',
+    pinned: false,
+    links: [],
+    outgoingLinks: [
+      {
+        target: 'Missing Feature Note',
+        display: 'Missing Feature Note',
+        noteId: null,
+        raw: '[[Missing Feature Note]]',
+      },
+    ],
+    backlinks: [],
+    unlinkedMentions: [],
+  },
+}));
+
+vi.mock('react-router', () => ({
+  useNavigate: () => mocks.navigate,
+}));
+
+vi.mock('../contexts/NotesContext', () => ({
+  useNotes: () => ({
+    notes: [mocks.note],
+    updateNote: mocks.updateNote,
+    convertUnlinkedMentionToLink: mocks.convertUnlinkedMentionToLink,
+  }),
+}));
+
+describe('RightPanel wiki links', () => {
+  beforeEach(() => {
+    mocks.navigate.mockClear();
+    mocks.updateNote.mockClear();
+    mocks.convertUnlinkedMentionToLink.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('exposes unresolved wiki links as an accessible broken-link status', () => {
+    render(<RightPanel noteId="note-linking" />);
+
+    fireEvent.mouseDown(screen.getByRole('tab', { name: /links/i }), {
+      button: 0,
+      ctrlKey: false,
+    });
+
+    const linksPanel = screen.getByText('Unresolved Links (1)').closest('div');
+    expect(linksPanel).not.toBeNull();
+    const unresolved = within(linksPanel as HTMLElement).getByRole('status', {
+      name: 'Unresolved wiki link: Missing Feature Note',
+    });
+
+    expect(unresolved.getAttribute('data-cy')).toBe(
+      'ewe-note-unresolved-wiki-link'
+    );
+    expect(within(unresolved).getByText('Missing Feature Note')).not.toBeNull();
+    expect(within(unresolved).getByText('Unresolved wiki link')).not.toBeNull();
+  });
+});

--- a/packages/ewe-note/src/app/contexts/NotesContext.test.tsx
+++ b/packages/ewe-note/src/app/contexts/NotesContext.test.tsx
@@ -511,6 +511,99 @@ describe('NotesContext parity behavior', () => {
     expect(overview?.backlinks).toContain(linking?.id);
   });
 
+  it('resolves imported wiki links by path extension, basename, alias, and heading', async () => {
+    latestContext = undefined;
+    const now = Date.now();
+    const importedNote = {
+      _id: 'note-imported-target',
+      _ref: 'local|notes|room-notes|note-imported-target',
+      _created: now,
+      _updated: now,
+      text: '# Canonical Note Title\n\n## Install Steps\n\nImported target.',
+      frontmatter: { title: 'Canonical Note Title' },
+      tags: [],
+      aliases: ['Imported Alias'],
+      folderIds: [],
+      wikiLinks: [],
+      attachmentRefs: [],
+      sourcePath: '  .\\Projects\\Deep\\Original File.md  ',
+      sourceVault: 'feature-vault',
+    } as unknown as DbNote;
+    const linkingNote = {
+      _id: 'note-imported-linking',
+      _ref: 'local|notes|room-notes|note-imported-linking',
+      _created: now + 1,
+      _updated: now + 1,
+      text: [
+        'Read [[Projects/Deep/Original File.md#Install Steps|setup guide]].',
+        'Then compare [[Original File]] and [[Imported Alias]].',
+      ].join('\n'),
+      frontmatter: {},
+      tags: [],
+      aliases: [],
+      folderIds: [],
+      wikiLinks: [],
+      attachmentRefs: [],
+      sourcePath: 'Linking.md',
+      sourceVault: 'feature-vault',
+    } as unknown as DbNote;
+    const docs = new FakeDocuments([importedNote, linkingNote]);
+    const room = createRoom('room-notes', 'Notes', docs);
+
+    dbState = createDbState(room);
+    mockUseDb.mockImplementation(() => dbState);
+    mockUseFolders.mockReturnValue({
+      folders: [],
+      createFolder: vi.fn(),
+      renameFolder: vi.fn(),
+      deleteFolder: vi.fn(),
+    });
+
+    render(
+      <NotesProvider>
+        <Probe />
+      </NotesProvider>
+    );
+
+    await waitFor(() => {
+      expect(latestContext?.notes.length).toBe(2);
+    });
+
+    const target = latestContext?.notes.find(
+      (note) => note.id === 'note-imported-target'
+    );
+    const linking = latestContext?.notes.find(
+      (note) => note.id === 'note-imported-linking'
+    );
+
+    expect(target?.title).toBe('Canonical Note Title');
+    expect(target?.sourcePath).toBe('Projects/Deep/Original File.md');
+    expect(
+      latestContext?.resolveWikiLink('Projects/Deep/Original File.md')
+    ).toBe(target?.id);
+    expect(latestContext?.resolveWikiLink('Original File')).toBe(target?.id);
+    expect(latestContext?.resolveWikiLink('Imported Alias')).toBe(target?.id);
+    expect(linking?.outgoingLinks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          target: 'Projects/Deep/Original File.md',
+          heading: 'Install Steps',
+          alias: 'setup guide',
+          noteId: target?.id,
+        }),
+        expect.objectContaining({
+          target: 'Original File',
+          noteId: target?.id,
+        }),
+        expect.objectContaining({
+          target: 'Imported Alias',
+          noteId: target?.id,
+        }),
+      ])
+    );
+    expect(target?.backlinks).toEqual([linking?.id]);
+  });
+
   it('keeps templates available and creates today notes in the Daily Notes folder', async () => {
     await renderProviderWithFixtures([
       '09 Daily Notes and Templates.md',

--- a/packages/ewe-note/src/app/contexts/NotesContext.tsx
+++ b/packages/ewe-note/src/app/contexts/NotesContext.tsx
@@ -8,6 +8,7 @@ import { buildDefaultUntitledNoteTitle, UNTITLED_TITLE } from './note-titles';
 import {
   extractWikiLinkTargets,
   extractUnlinkedMentions,
+  getNormalizedWikiTargetEntries,
   getNormalizedWikiTargetKeys,
   getSourcePathTargets,
   linkUnlinkedMentionInMarkdown,
@@ -227,10 +228,14 @@ function buildResolvableTargets(notes: InternalNote[]): ResolvableTargets {
   for (const note of notes) {
     const noteMentions = mentionsByNoteId.get(note.id) ?? new Set<string>();
     const addTarget = (target: string, mention = target) => {
-      for (const normalizedTarget of getNormalizedWikiTargetKeys(target)) {
+      for (const entry of getNormalizedWikiTargetEntries(target)) {
+        const normalizedTarget = entry.key;
         noteMentions.add(normalizedTarget);
         if (!targets.has(normalizedTarget)) {
-          targets.set(normalizedTarget, { noteId: note.id, mention });
+          targets.set(normalizedTarget, {
+            noteId: note.id,
+            mention: mention === target ? entry.mention : mention,
+          });
         }
       }
     };

--- a/packages/ewe-note/src/app/contexts/NotesContext.tsx
+++ b/packages/ewe-note/src/app/contexts/NotesContext.tsx
@@ -8,7 +8,10 @@ import { buildDefaultUntitledNoteTitle, UNTITLED_TITLE } from './note-titles';
 import {
   extractWikiLinkTargets,
   extractUnlinkedMentions,
+  getNormalizedWikiTargetKeys,
+  getSourcePathTargets,
   linkUnlinkedMentionInMarkdown,
+  normalizeSourcePath,
   normalizeWikiTarget,
   type OutgoingWikiLink,
   type UnlinkedMention,
@@ -129,22 +132,6 @@ function normalize(text: string) {
   return normalizeWikiTarget(text);
 }
 
-function getSourcePathTarget(sourcePath?: string) {
-  const normalized = normalizeSourcePath(sourcePath);
-  if (!normalized) return null;
-  return normalized.replace(/\.md$/i, '').trim() || null;
-}
-
-function normalizeSourcePath(sourcePath?: string) {
-  const normalized = sourcePath
-    ?.trim()
-    .replace(/\\/g, '/')
-    .replace(/^\.\/+/, '')
-    .replace(/\/+/g, '/')
-    .trim();
-  return normalized || undefined;
-}
-
 function buildSourceMetadata(
   source: Pick<DbNote, 'sourcePath' | 'sourceVault'>
 ) {
@@ -238,36 +225,29 @@ function buildResolvableTargets(notes: InternalNote[]): ResolvableTargets {
   const mentionsByNoteId = new Map<string, Set<string>>();
 
   for (const note of notes) {
-    const normalizedTitle = normalize(note.title);
     const noteMentions = mentionsByNoteId.get(note.id) ?? new Set<string>();
-    noteMentions.add(normalizedTitle);
-    mentionsByNoteId.set(note.id, noteMentions);
-
-    if (!targets.has(normalizedTitle)) {
-      targets.set(normalizedTitle, { noteId: note.id, mention: note.title });
-    }
-
-    const sourcePathTarget = getSourcePathTarget(note.source.sourcePath);
-    if (sourcePathTarget) {
-      const normalizedPath = normalize(sourcePathTarget);
-      noteMentions.add(normalizedPath);
-      mentionsByNoteId.set(note.id, noteMentions);
-      if (!targets.has(normalizedPath)) {
-        targets.set(normalizedPath, {
-          noteId: note.id,
-          mention: sourcePathTarget,
-        });
+    const addTarget = (target: string, mention = target) => {
+      for (const normalizedTarget of getNormalizedWikiTargetKeys(target)) {
+        noteMentions.add(normalizedTarget);
+        if (!targets.has(normalizedTarget)) {
+          targets.set(normalizedTarget, { noteId: note.id, mention });
+        }
       }
+    };
+
+    addTarget(note.title, note.title);
+
+    for (const sourcePathTarget of getSourcePathTargets(
+      note.source.sourcePath
+    )) {
+      addTarget(sourcePathTarget, sourcePathTarget);
     }
 
     for (const alias of note.aliases) {
-      const normalizedAlias = normalize(alias);
-      noteMentions.add(normalizedAlias);
-      mentionsByNoteId.set(note.id, noteMentions);
-      if (!targets.has(normalizedAlias)) {
-        targets.set(normalizedAlias, { noteId: note.id, mention: alias });
-      }
+      addTarget(alias, alias);
     }
+
+    mentionsByNoteId.set(note.id, noteMentions);
   }
 
   return { candidates: targets, mentionsByNoteId };
@@ -295,6 +275,19 @@ function normalizeResolvableTargets(
   );
 }
 
+function resolveTargetId(
+  resolvableTargets: Map<string, ResolvableTargetValue>,
+  target: string
+) {
+  for (const targetKey of getNormalizedWikiTargetKeys(target)) {
+    const candidate = resolvableTargets.get(targetKey);
+    if (typeof candidate === 'string') return candidate;
+    if (candidate?.noteId) return candidate.noteId;
+  }
+
+  return null;
+}
+
 function buildOutboundLinks(
   note: InternalNote,
   resolvableTargets: Map<string, ResolvableTargetValue>
@@ -303,17 +296,9 @@ function buildOutboundLinks(
   const seen = new Set<string>();
 
   const outgoingLinks = raw.map((entry) => {
-    const targetKey = normalize(entry.target);
     return {
       ...entry,
-      noteId:
-        entry.noteId ??
-        (() => {
-          const candidate = resolvableTargets.get(targetKey);
-          return typeof candidate === 'string'
-            ? candidate
-            : (candidate?.noteId ?? null);
-        })(),
+      noteId: entry.noteId ?? resolveTargetId(resolvableTargets, entry.target),
       raw: entry.raw,
     };
   });
@@ -844,21 +829,33 @@ export function NotesProvider({ children }: { children: React.ReactNode }) {
 
   const wikiResolutionMap = useMemo(() => {
     const map = new Map<string, string>();
-    for (const note of notes) {
-      map.set(normalize(note.title), note.id);
-      for (const alias of note.aliases) {
-        map.set(normalize(alias), note.id);
+    const addTarget = (target: string, noteId: string, overwrite = true) => {
+      for (const targetKey of getNormalizedWikiTargetKeys(target)) {
+        if (overwrite || !map.has(targetKey)) {
+          map.set(targetKey, noteId);
+        }
       }
-      const sourcePathTarget = getSourcePathTarget(note.sourcePath);
-      if (sourcePathTarget && !map.has(normalize(sourcePathTarget))) {
-        map.set(normalize(sourcePathTarget), note.id);
+    };
+
+    for (const note of notes) {
+      addTarget(note.title, note.id);
+      for (const alias of note.aliases) {
+        addTarget(alias, note.id);
+      }
+      for (const sourcePathTarget of getSourcePathTargets(note.sourcePath)) {
+        addTarget(sourcePathTarget, note.id, false);
       }
     }
     return map;
   }, [notes]);
 
   const resolveWikiLink = (target: string) => {
-    return wikiResolutionMap.get(normalize(target)) ?? null;
+    for (const targetKey of getNormalizedWikiTargetKeys(target)) {
+      const noteId = wikiResolutionMap.get(targetKey);
+      if (noteId) return noteId;
+    }
+
+    return null;
   };
 
   const convertUnlinkedMentionToLink = (

--- a/packages/ewe-note/src/app/contexts/note-links.test.ts
+++ b/packages/ewe-note/src/app/contexts/note-links.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   extractWikiLinkTargets,
   extractUnlinkedMentions,
+  getNormalizedWikiTargetEntries,
   linkUnlinkedMentionInMarkdown,
   normalizeWikiTarget,
 } from './note-links';
@@ -152,6 +153,51 @@ describe('note link extraction', () => {
         mention: 'artificial intelligence',
         start: 16,
         end: 39,
+      },
+    ]);
+  });
+
+  it('pairs source path target keys with their matching mention variants', () => {
+    const sourcePathEntries = getNormalizedWikiTargetEntries(
+      'Vault/Original File.md'
+    );
+    const candidates = new Map(
+      sourcePathEntries.map(({ key, mention }) => [
+        key,
+        { noteId: 'note-source', mention },
+      ])
+    );
+
+    expect(sourcePathEntries).toEqual([
+      {
+        key: 'vault original file md',
+        mention: 'Vault/Original File.md',
+      },
+      {
+        key: 'vault original file',
+        mention: 'Vault/Original File',
+      },
+      {
+        key: 'original file md',
+        mention: 'Original File.md',
+      },
+      {
+        key: 'original file',
+        mention: 'Original File',
+      },
+    ]);
+    expect(
+      extractUnlinkedMentions(
+        'Original File should be linked.',
+        candidates,
+        new Set()
+      )
+    ).toEqual([
+      {
+        noteId: 'note-source',
+        mention: 'Original File',
+        start: 0,
+        end: 13,
       },
     ]);
   });

--- a/packages/ewe-note/src/app/contexts/note-links.ts
+++ b/packages/ewe-note/src/app/contexts/note-links.ts
@@ -40,6 +40,48 @@ export function normalizeWikiTarget(target: string): string {
     .replace(/\s+/g, ' ');
 }
 
+export function normalizeSourcePath(sourcePath?: string) {
+  const normalized = sourcePath
+    ?.trim()
+    .replace(/\\/g, '/')
+    .replace(/^\.\/+/, '')
+    .replace(/\/+/g, '/')
+    .trim();
+  return normalized || undefined;
+}
+
+function withoutMarkdownExtension(target: string) {
+  return target.replace(/\.md$/i, '').trim();
+}
+
+function uniqueNonEmpty(values: Array<string | null | undefined>) {
+  return Array.from(
+    new Set(values.map((value) => value?.trim()).filter(Boolean) as string[])
+  );
+}
+
+export function getSourcePathTargets(sourcePath?: string): string[] {
+  const normalized = normalizeSourcePath(sourcePath);
+  if (!normalized) return [];
+
+  const extensionless = withoutMarkdownExtension(normalized);
+  const basename = normalized.split('/').filter(Boolean).at(-1) ?? normalized;
+  const basenameExtensionless = withoutMarkdownExtension(basename);
+
+  return uniqueNonEmpty([
+    normalized,
+    extensionless,
+    basename,
+    basenameExtensionless,
+  ]);
+}
+
+export function getNormalizedWikiTargetKeys(target: string): string[] {
+  return uniqueNonEmpty([target, ...getSourcePathTargets(target)]).map(
+    (value) => normalizeWikiTarget(value)
+  );
+}
+
 function parseWikiHrefTarget(href: string): ExtractedWikiLink | null {
   if (!href.startsWith('wiki://')) return null;
 

--- a/packages/ewe-note/src/app/contexts/note-links.ts
+++ b/packages/ewe-note/src/app/contexts/note-links.ts
@@ -82,6 +82,14 @@ export function getNormalizedWikiTargetKeys(target: string): string[] {
   );
 }
 
+export function getNormalizedWikiTargetEntries(
+  target: string
+): Array<{ key: string; mention: string }> {
+  return uniqueNonEmpty([target, ...getSourcePathTargets(target)]).map(
+    (mention) => ({ key: normalizeWikiTarget(mention), mention })
+  );
+}
+
 function parseWikiHrefTarget(href: string): ExtractedWikiLink | null {
   if (!href.startsWith('wiki://')) return null;
 

--- a/packages/ewe-note/src/app/pages/EnhancedEditor.tsx
+++ b/packages/ewe-note/src/app/pages/EnhancedEditor.tsx
@@ -28,13 +28,29 @@ import {
 } from '../components/ui/dropdown-menu';
 import Editor from '@/components/editor';
 import { useDb } from '@/db';
-import { parseWikiHref } from '@/extensions/wiki-link';
+import { slugHeading } from '@/editor/markdown';
+import { parseWikiHref, type WikiLinkResolution } from '@/extensions/wiki-link';
 import {
   WorkspaceShell,
   useWorkspaceShell,
 } from '../components/WorkspaceShell';
 import type { Note } from '../contexts/NotesContext';
 import { useIsMobile } from '../components/ui/use-mobile';
+
+export function buildEditorWikiLinkPath(
+  noteId: string,
+  parsed: WikiLinkResolution
+) {
+  const hashTarget = parsed.blockRef
+    ? `^${parsed.blockRef}`
+    : parsed.heading
+      ? slugHeading(parsed.heading)
+      : '';
+
+  return hashTarget
+    ? `/editor/${noteId}#${encodeURIComponent(hashTarget)}`
+    : `/editor/${noteId}`;
+}
 
 export function EnhancedEditor() {
   const [focusMode, setFocusMode] = useState(false);
@@ -94,7 +110,7 @@ export function EnhancedEditor() {
 
     const matched = resolveWikiLink(parsed.noteName);
     if (matched) {
-      navigate(`/editor/${matched}`);
+      navigate(buildEditorWikiLinkPath(matched, parsed));
       return;
     }
 
@@ -103,7 +119,7 @@ export function EnhancedEditor() {
       folder: note?.folder,
       content: `# ${parsed.noteName}\n\n`,
     });
-    navigate(`/editor/${created.id}`);
+    navigate(buildEditorWikiLinkPath(created.id, parsed));
   };
   const { allRooms, selectedRoom, setSelectedRoom, setSelectedNoteId } =
     useDb();

--- a/packages/ewe-note/src/app/pages/EnhancedEditor.wiki-navigation.test.ts
+++ b/packages/ewe-note/src/app/pages/EnhancedEditor.wiki-navigation.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../contexts/NotesContext', () => ({
+  useNotes: () => ({
+    notes: [],
+    folders: [],
+    updateNote: () => undefined,
+    togglePinNote: () => undefined,
+    deleteNote: () => undefined,
+    addNote: () => ({ id: 'created-note' }),
+    moveNote: () => undefined,
+    resolveWikiLink: () => null,
+  }),
+}));
+
+vi.mock('@/db', () => ({
+  getDeviceType: () => 'Unknown',
+  useDb: () => ({
+    allRooms: [],
+    selectedRoom: null,
+    setSelectedRoom: () => undefined,
+    setSelectedNoteId: () => undefined,
+  }),
+}));
+
+import { buildEditorWikiLinkPath } from './EnhancedEditor';
+
+describe('EnhancedEditor wiki navigation helpers', () => {
+  it('preserves heading targets as editor URL hashes', () => {
+    expect(
+      buildEditorWikiLinkPath('note-target', {
+        noteId: null,
+        noteName: '05 Link Targets',
+        heading: 'Canonical Heading Target',
+      })
+    ).toBe('/editor/note-target#canonical-heading-target');
+  });
+
+  it('preserves block references as editor URL hashes', () => {
+    expect(
+      buildEditorWikiLinkPath('note-target', {
+        noteId: null,
+        noteName: '05 Link Targets',
+        blockRef: 'addressable-block',
+      })
+    ).toBe('/editor/note-target#%5Eaddressable-block');
+  });
+});


### PR DESCRIPTION
## Summary
- Resolve imported wiki links through normalized source path variants, including `.md` full paths, extensionless paths, basenames, aliases, and titles.
- Preserve heading and block-reference targets when navigating editor wiki links.
- Expose unresolved wiki links in the right panel as an accessible status with a stable data-cy hook.

## Stack
- Stacked on #51 / `hermes/eweser/ewe-note-source-path-navigation` because that PR is still open.

## Verification
- `/home/jacob/.codex/skills/eweser-runtime-orientation/scripts/eweser-runtime-orientation.sh status`
- `/home/jacob/.codex/skills/eweser-runtime-orientation/scripts/eweser-runtime-orientation.sh refresh`
- `git diff --cached --check`
- `npm test --workspace @eweser/ewe-note -- src/app/components/RightPanel.wiki-links.test.tsx src/app/contexts/NotesContext.test.tsx src/app/pages/EnhancedEditor.wiki-navigation.test.ts` (3 files, 8 tests passed)
- `npm run type-check --workspace @eweser/ewe-note`
- focused static/secret scan on added staged lines (no findings)
- independent code review subagent passed; non-blocking suggestion: add future integration coverage for clicking resolved wiki links with hashes
- lefthook pre-commit secrets-scan and staged-checks passed
- lefthook pre-push autofix, tracked secrets-scan, and verify passed during SSH push
