### PR TITLE
Fix Ewe Note post-grant sync login

### DIFF
--- a/.changeset/ewe-note-post-grant-sync-login.md
+++ b/.changeset/ewe-note-post-grant-sync-login.md
@@ -1,0 +1,5 @@
+---
+'@eweser/db': patch
+---
+
+Fix access-grant login so single-room registries are accepted and load-all-room login starts remote sync connections.

--- a/packages/db/src/methods/connection/login.test.ts
+++ b/packages/db/src/methods/connection/login.test.ts
@@ -47,7 +47,7 @@ describe('login', () => {
     expect(result).toBe(true);
     expect(db.useSync).toBe(true);
     expect(pollConnectionMock).toHaveBeenCalledWith(db);
-    expect(db.loadRooms).toHaveBeenCalledWith(db.registry);
+    expect(db.loadRooms).toHaveBeenCalledWith(db.registry, true);
     expect(db.emit).toHaveBeenCalledWith('onLoggedInChange', true);
   });
 });

--- a/packages/db/src/methods/connection/login.ts
+++ b/packages/db/src/methods/connection/login.ts
@@ -26,7 +26,7 @@ export const login =
     db.useSync = true;
     pollConnection(db); // start polling for auth server connection status if db was started in offline mode previously
     if (options?.loadAllRooms) {
-      await db.loadRooms(db.registry); // connects the sync providers. Could make this more atomic in the future to avoid creating too many connections.
+      await db.loadRooms(db.registry, true); // connects the sync providers. Could make this more atomic in the future to avoid creating too many connections.
     }
     db.emit('onLoggedInChange', true);
     return true;

--- a/packages/db/src/methods/connection/syncRegistry.test.ts
+++ b/packages/db/src/methods/connection/syncRegistry.test.ts
@@ -47,8 +47,8 @@ describe('syncRegistry', () => {
     expect(db.emit).toHaveBeenCalledWith('registrySync', 'error', 'boom');
   });
 
-  it('updates token, registry and userId on success', async () => {
-    const rooms = [{ id: 'room-1' }, { id: 'room-2' }];
+  it('updates token, registry and userId on success with a single returned room', async () => {
+    const rooms = [{ id: 'room-1', name: 'Notes', collectionKey: 'notes' }];
 
     const db = {
       registry: [],

--- a/packages/db/src/methods/connection/syncRegistry.ts
+++ b/packages/db/src/methods/connection/syncRegistry.ts
@@ -48,7 +48,7 @@ export const syncRegistry =
       rooms &&
       typeof rooms === 'object' &&
       Array.isArray(rooms) &&
-      rooms.length >= 2
+      rooms.length >= 1
     ) {
       db.debug('setting new rooms', rooms);
       // TODO: if a new room was created locally before the sync finishes, this might overwrite it


### PR DESCRIPTION
## Summary
- Accept single-room registry sync responses as a valid login sync result.
- Force remote room reloads after access-grant login so sync providers start after redirect.
- Add regression coverage and a patch changeset for @eweser/db.

## Root Cause
Ewe Note can have a valid one-room registry, but syncRegistry only accepted two or more rooms. The load-all login path also reloaded rooms without the remote-sync flag, leaving the note app in local-only mode after a successful access grant.

## Verification
- npm test --workspace @eweser/db -- syncRegistry.test.ts login.test.ts
- npm run type-check --workspace @eweser/db
- npm run secrets:scan
- Worker also completed full @eweser/db test/type-check/build, @eweser/ewe-note test/type-check/build, and a local browser preview checkpoint before hitting its iteration budget.