### PR TITLE
feat: add parseRef + local loaded-room query helpers

### DIFF
--- a/.changeset/ref-parse-local-query.md
+++ b/.changeset/ref-parse-local-query.md
@@ -1,0 +1,6 @@
+---
+'@eweser/shared': minor
+'@eweser/db': minor
+---
+
+Add parseRef companion to buildRef, plus local loaded-room query helpers (resolveRef, findDocumentsReferencing) with explicit loaded-room-only semantics.

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -170,6 +170,59 @@ Say you wanted to store a reference to a note from a flashcard, you could add th
 }
 ```
 
+## Local loaded-room queries
+
+The SDK provides local-only query helpers that operate exclusively on rooms
+whose Yjs document is currently loaded in memory. They do **not** make server,
+aggregator, or indexing calls.
+
+```ts
+import { parseRef } from '@eweser/shared';
+import { resolveRef, findDocumentsReferencing } from '@eweser/db';
+```
+
+### `parseRef(ref)`
+
+Reverse of `buildRef`: splits a ref string into its typed components. Throws a
+descriptive error if the ref is malformed.
+
+```ts
+const parsed = parseRef(noteRef);
+// { authServer: 'https://www.eweser.com', collectionKey: 'notes', roomId: '...', documentId: '...' }
+```
+
+### `resolveRef(db, ref)`
+
+Given a ref string, returns the document if its room is loaded and the document
+exists. Returns `null` if the room is not loaded, the document is deleted, or
+the document does not exist.
+
+```ts
+const note = resolveRef(db, noteRef);
+// Note | null
+```
+
+### `findDocumentsReferencing(db, ref)`
+
+Searches all loaded rooms (across all collections) for documents that reference
+the given ref. A document is considered referencing if any of its string-typed
+field values or string-array elements exactly equal the ref. Deleted documents
+are excluded.
+
+This is an O(all_documents) scan suited for small-to-medium local datasets. For
+server-side search, use the aggregator API instead.
+
+```ts
+const referencing = findDocumentsReferencing(db, noteRef);
+// [Flashcard, Note, ...] — documents that reference noteRef
+```
+
+**Limitations:**
+
+- Only searches rooms whose ydoc is loaded (not yet loaded or disconnected rooms are skipped).
+- Does not perform fuzzy matching or server-side indexing.
+- Order is deterministic but not explicitly sorted; sort results client-side if needed.
+
 ## Rooms
 
 A `room` could be conceptualized as a 'folder' or 'group' of documents. Each room is a

--- a/packages/db/src/utils/index.ts
+++ b/packages/db/src/utils/index.ts
@@ -7,6 +7,7 @@ export * from './files.js';
 export * from './backup.js';
 export * from './seedRoom.js';
 export * from './encryption.js';
+export * from './query.js';
 export { RoomCrypto } from './roomCrypto.js';
 
 export const wait = (ms: number) =>

--- a/packages/db/src/utils/query.test.ts
+++ b/packages/db/src/utils/query.test.ts
@@ -1,11 +1,10 @@
 /**
  * Purpose: Tests for local loaded-room query helpers (resolveRef and
- * findDocumentsReferencing).
- *
- * Covers: valid/invalid refs, unloaded rooms, deleted docs, multiple
- * collections, deterministic ordering/limits.
- *
- * Read before editing: packages/db/src/utils/query.ts and packages/db/AGENTS.md.
+ * findDocumentsReferencing). Covers valid/invalid refs, unloaded rooms,
+ * deleted docs, multiple collections, deterministic ordering/limits.
+ * Exports: (test file)
+ * Touches: query.ts, yjs, vitest
+ * Read before editing: packages/db/src/utils/query.ts, packages/db/AGENTS.md
  */
 import * as Y from 'yjs';
 import { describe, expect, it } from 'vitest';
@@ -109,7 +108,7 @@ describe('resolveRef', () => {
       documentId: 'doc-1',
     });
 
-    const result = resolveRef(db as unknown as Database, ref);
+    const result = resolveRef<TestDoc>(db as unknown as Database, ref);
 
     expect(result).not.toBeNull();
     expect(result?._id).toBe('doc-1');
@@ -208,7 +207,7 @@ describe('resolveRef', () => {
       documentId: 'doc-custom',
     });
 
-    const result = resolveRef(db as unknown as Database, ref);
+    const result = resolveRef<TestDoc>(db as unknown as Database, ref);
     expect(result?.title).toBe('Custom Title');
   });
 

--- a/packages/db/src/utils/query.test.ts
+++ b/packages/db/src/utils/query.test.ts
@@ -1,0 +1,466 @@
+/**
+ * Purpose: Tests for local loaded-room query helpers (resolveRef and
+ * findDocumentsReferencing).
+ *
+ * Covers: valid/invalid refs, unloaded rooms, deleted docs, multiple
+ * collections, deterministic ordering/limits.
+ *
+ * Read before editing: packages/db/src/utils/query.ts and packages/db/AGENTS.md.
+ */
+import * as Y from 'yjs';
+import { describe, expect, it } from 'vitest';
+import type { EweDocument, CollectionKey } from '@eweser/shared';
+import { buildRef } from '@eweser/shared';
+import type { Database } from '../index.js';
+import { resolveRef, findDocumentsReferencing } from './query.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+type TestDoc = EweDocument & {
+  title?: string;
+  noteRefs?: string[];
+  relatedRef?: string;
+};
+
+const AUTH_SERVER = 'https://www.eweser.com';
+
+function makeDoc(
+  id: string,
+  collectionKey: CollectionKey,
+  roomId: string,
+  overrides: Partial<TestDoc> = {}
+): TestDoc {
+  return {
+    _id: id,
+    _ref: buildRef({
+      authServer: AUTH_SERVER,
+      collectionKey,
+      roomId,
+      documentId: id,
+    }),
+    _created: Date.now(),
+    _updated: Date.now(),
+    _deleted: false,
+    title: `Doc ${id}`,
+    ...overrides,
+  } as TestDoc;
+}
+
+function makeRoomWithDocs(
+  collectionKey: CollectionKey,
+  roomId: string,
+  docs: TestDoc[]
+) {
+  const ydoc = new Y.Doc();
+  const docMap = ydoc.getMap('documents');
+  for (const doc of docs) {
+    docMap.set(doc._id, doc);
+  }
+  return {
+    ydoc,
+    collectionKey,
+    id: roomId,
+    name: `${collectionKey}-${roomId}`,
+  };
+}
+
+/**
+ * Build a minimal Database-shaped object with the collections structure
+ * needed by resolveRef / findDocumentsReferencing.
+ */
+function makeMockDb(
+  roomsByCollection: Record<string, { roomId: string; docs: TestDoc[] }[]>
+): Partial<Database> {
+  const collectionKeys = Object.keys(roomsByCollection);
+  const collections: Record<string, Record<string, unknown>> = {};
+
+  for (const key of collectionKeys) {
+    const rooms: Record<string, unknown> = {};
+    const roomDefs = roomsByCollection[key] ?? [];
+    for (const { roomId, docs } of roomDefs) {
+      rooms[roomId] = makeRoomWithDocs(key as CollectionKey, roomId, docs);
+    }
+    collections[key] = rooms;
+  }
+
+  return {
+    collectionKeys: collectionKeys as CollectionKey[],
+    collections: collections as Database['collections'],
+  } as Partial<Database>;
+}
+
+// ---------------------------------------------------------------------------
+// resolveRef
+// ---------------------------------------------------------------------------
+
+describe('resolveRef', () => {
+  it('resolves a document from a valid ref in a loaded room', () => {
+    const db = makeMockDb({
+      notes: [
+        { roomId: 'room-1', docs: [makeDoc('doc-1', 'notes', 'room-1')] },
+      ],
+    });
+    const ref = buildRef({
+      authServer: AUTH_SERVER,
+      collectionKey: 'notes',
+      roomId: 'room-1',
+      documentId: 'doc-1',
+    });
+
+    const result = resolveRef(db as unknown as Database, ref);
+
+    expect(result).not.toBeNull();
+    expect(result?._id).toBe('doc-1');
+    expect(result?.title).toBe('Doc doc-1');
+  });
+
+  it('returns null for a ref whose room is not loaded', () => {
+    const db = makeMockDb({
+      notes: [
+        { roomId: 'room-1', docs: [makeDoc('doc-1', 'notes', 'room-1')] },
+      ],
+    });
+    const ref = buildRef({
+      authServer: AUTH_SERVER,
+      collectionKey: 'notes',
+      roomId: 'room-not-loaded',
+      documentId: 'doc-42',
+    });
+
+    const result = resolveRef(db as unknown as Database, ref);
+    expect(result).toBeNull();
+  });
+
+  it('returns null for a non-existent document in a loaded room', () => {
+    const db = makeMockDb({
+      notes: [
+        { roomId: 'room-1', docs: [makeDoc('doc-1', 'notes', 'room-1')] },
+      ],
+    });
+    const ref = buildRef({
+      authServer: AUTH_SERVER,
+      collectionKey: 'notes',
+      roomId: 'room-1',
+      documentId: 'does-not-exist',
+    });
+
+    const result = resolveRef(db as unknown as Database, ref);
+    expect(result).toBeNull();
+  });
+
+  it('returns null for deleted documents', () => {
+    const deletedDoc = makeDoc('doc-del', 'notes', 'room-1', {
+      _deleted: true,
+    });
+    const db = makeMockDb({
+      notes: [{ roomId: 'room-1', docs: [deletedDoc] }],
+    });
+    const ref = buildRef({
+      authServer: AUTH_SERVER,
+      collectionKey: 'notes',
+      roomId: 'room-1',
+      documentId: 'doc-del',
+    });
+
+    const result = resolveRef(db as unknown as Database, ref);
+    expect(result).toBeNull();
+  });
+
+  it('resolves documents across different collections', () => {
+    const db = makeMockDb({
+      notes: [
+        { roomId: 'room-1', docs: [makeDoc('note-1', 'notes', 'room-1')] },
+      ],
+      flashcards: [
+        { roomId: 'fc-room', docs: [makeDoc('fc-1', 'flashcards', 'fc-room')] },
+      ],
+    });
+    const noteRef = buildRef({
+      authServer: AUTH_SERVER,
+      collectionKey: 'notes',
+      roomId: 'room-1',
+      documentId: 'note-1',
+    });
+    const fcRef = buildRef({
+      authServer: AUTH_SERVER,
+      collectionKey: 'flashcards',
+      roomId: 'fc-room',
+      documentId: 'fc-1',
+    });
+
+    expect(resolveRef(db as unknown as Database, noteRef)?._id).toBe('note-1');
+    expect(resolveRef(db as unknown as Database, fcRef)?._id).toBe('fc-1');
+  });
+
+  it('preserves custom fields on resolved documents', () => {
+    const customDoc = makeDoc('doc-custom', 'notes', 'room-1', {
+      title: 'Custom Title',
+    });
+    const db = makeMockDb({
+      notes: [{ roomId: 'room-1', docs: [customDoc] }],
+    });
+    const ref = buildRef({
+      authServer: AUTH_SERVER,
+      collectionKey: 'notes',
+      roomId: 'room-1',
+      documentId: 'doc-custom',
+    });
+
+    const result = resolveRef(db as unknown as Database, ref);
+    expect(result?.title).toBe('Custom Title');
+  });
+
+  it('throws for malformed ref strings', () => {
+    const db = makeMockDb({});
+    expect(() => resolveRef(db as unknown as Database, 'bad-ref')).toThrow();
+    expect(() => resolveRef(db as unknown as Database, '')).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findDocumentsReferencing
+// ---------------------------------------------------------------------------
+
+describe('findDocumentsReferencing', () => {
+  const note1Ref = buildRef({
+    authServer: AUTH_SERVER,
+    collectionKey: 'notes',
+    roomId: 'room-1',
+    documentId: 'note-1',
+  });
+
+  it('finds documents that reference a ref in a string field', () => {
+    const db = makeMockDb({
+      notes: [
+        {
+          roomId: 'room-1',
+          docs: [
+            makeDoc('note-1', 'notes', 'room-1'),
+            makeDoc('note-2', 'notes', 'room-1', {
+              relatedRef: note1Ref,
+            }),
+          ],
+        },
+      ],
+    });
+
+    const results = findDocumentsReferencing(
+      db as unknown as Database,
+      note1Ref
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?._id).toBe('note-2');
+  });
+
+  it('finds documents that reference a ref in a string array field', () => {
+    const db = makeMockDb({
+      notes: [
+        {
+          roomId: 'room-1',
+          docs: [
+            makeDoc('note-1', 'notes', 'room-1'),
+            makeDoc('note-2', 'notes', 'room-1', {
+              noteRefs: [note1Ref],
+            }),
+          ],
+        },
+      ],
+    });
+
+    const results = findDocumentsReferencing(
+      db as unknown as Database,
+      note1Ref
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?._id).toBe('note-2');
+  });
+
+  it('finds cross-collection references', () => {
+    const db = makeMockDb({
+      notes: [
+        { roomId: 'room-1', docs: [makeDoc('note-1', 'notes', 'room-1')] },
+      ],
+      flashcards: [
+        {
+          roomId: 'fc-room',
+          docs: [
+            makeDoc('fc-1', 'flashcards', 'fc-room', {
+              noteRefs: [note1Ref],
+            }),
+            makeDoc('fc-2', 'flashcards', 'fc-room'),
+          ],
+        },
+      ],
+    });
+
+    const results = findDocumentsReferencing(
+      db as unknown as Database,
+      note1Ref
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?._id).toBe('fc-1');
+  });
+
+  it('excludes deleted documents that reference the ref', () => {
+    const db = makeMockDb({
+      notes: [
+        {
+          roomId: 'room-1',
+          docs: [
+            makeDoc('note-1', 'notes', 'room-1'),
+            makeDoc('note-del', 'notes', 'room-1', {
+              _deleted: true,
+              relatedRef: note1Ref,
+            }),
+            makeDoc('note-alive', 'notes', 'room-1', {
+              relatedRef: note1Ref,
+            }),
+          ],
+        },
+      ],
+    });
+
+    const results = findDocumentsReferencing(
+      db as unknown as Database,
+      note1Ref
+    );
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?._id).toBe('note-alive');
+  });
+
+  it('skips rooms that are not loaded (no ydoc)', () => {
+    // Simulate an unloaded room by not adding an ydoc
+    const db = makeMockDb({});
+    // Inject a mock room without ydoc
+    const unloadedRoom = {
+      collectionKey: 'notes' as CollectionKey,
+      id: 'unloaded-room',
+      name: 'Unloaded',
+    };
+    const collections = db.collections as Record<
+      string,
+      Record<string, unknown>
+    >;
+    if (!collections['notes']) collections['notes'] = {};
+    collections['notes']['unloaded-room'] = unloadedRoom;
+
+    const results = findDocumentsReferencing(
+      db as unknown as Database,
+      note1Ref
+    );
+
+    // Should not crash and return empty
+    expect(results).toEqual([]);
+  });
+
+  it('returns empty array when no documents reference the ref', () => {
+    const db = makeMockDb({
+      notes: [
+        {
+          roomId: 'room-1',
+          docs: [makeDoc('note-1', 'notes', 'room-1')],
+        },
+      ],
+    });
+    const otherRef = buildRef({
+      authServer: AUTH_SERVER,
+      collectionKey: 'notes',
+      roomId: 'room-1',
+      documentId: 'nonexistent',
+    });
+
+    const results = findDocumentsReferencing(
+      db as unknown as Database,
+      otherRef
+    );
+
+    expect(results).toEqual([]);
+  });
+
+  it('does not crash on empty database', () => {
+    const db = makeMockDb({});
+    const results = findDocumentsReferencing(
+      db as unknown as Database,
+      note1Ref
+    );
+    expect(results).toEqual([]);
+  });
+
+  it('finds documents that reference a ref when present in both string and string[] fields', () => {
+    const db = makeMockDb({
+      notes: [
+        {
+          roomId: 'room-1',
+          docs: [
+            makeDoc('note-1', 'notes', 'room-1'),
+            makeDoc('multi-ref', 'notes', 'room-1', {
+              relatedRef: note1Ref,
+              noteRefs: [note1Ref],
+            }),
+          ],
+        },
+      ],
+    });
+
+    const results = findDocumentsReferencing(
+      db as unknown as Database,
+      note1Ref
+    );
+
+    // Should only find the doc once even though it matches in two fields
+    expect(results).toHaveLength(1);
+    expect(results[0]?._id).toBe('multi-ref');
+  });
+
+  it('returns multiple documents that reference the same ref', () => {
+    const db = makeMockDb({
+      notes: [
+        {
+          roomId: 'room-1',
+          docs: [
+            makeDoc('note-1', 'notes', 'room-1'),
+            makeDoc('ref-a', 'notes', 'room-1', { relatedRef: note1Ref }),
+            makeDoc('ref-b', 'notes', 'room-1', { relatedRef: note1Ref }),
+          ],
+        },
+      ],
+    });
+
+    const results = findDocumentsReferencing(
+      db as unknown as Database,
+      note1Ref
+    );
+
+    expect(results).toHaveLength(2);
+    const ids = results.map((d) => d._id).sort();
+    expect(ids).toEqual(['ref-a', 'ref-b']);
+  });
+
+  it('is deterministic in results (same db, same ref, same results)', () => {
+    const db = makeMockDb({
+      notes: [
+        {
+          roomId: 'room-1',
+          docs: [
+            makeDoc('note-1', 'notes', 'room-1'),
+            makeDoc('ref-a', 'notes', 'room-1', { relatedRef: note1Ref }),
+          ],
+        },
+      ],
+    });
+
+    const first = findDocumentsReferencing(db as unknown as Database, note1Ref);
+    const second = findDocumentsReferencing(
+      db as unknown as Database,
+      note1Ref
+    );
+
+    expect(first).toEqual(second);
+  });
+});

--- a/packages/db/src/utils/query.ts
+++ b/packages/db/src/utils/query.ts
@@ -1,10 +1,9 @@
 /**
  * Purpose: Local loaded-room query helpers for resolving refs and finding
- * cross-collection references. These operate exclusively on rooms whose ydoc
- * is currently loaded in memory — they do not make server or aggregator calls.
- *
- * Touches: Database instance, room ydocs, ref parsing via @eweser/shared.
- * Read before editing: packages/db/AGENTS.md and packages/shared/src/utils/documents.ts.
+ * cross-collection references. Operates only on loaded room ydocs.
+ * Exports: resolveRef, findDocumentsReferencing
+ * Touches: Database instance, room ydocs, ref parsing via @eweser/shared
+ * Read before editing: packages/db/AGENTS.md, packages/shared/src/utils/documents.ts
  */
 import { parseRef } from '@eweser/shared';
 import type { EweDocument } from '@eweser/shared';

--- a/packages/db/src/utils/query.ts
+++ b/packages/db/src/utils/query.ts
@@ -1,0 +1,94 @@
+/**
+ * Purpose: Local loaded-room query helpers for resolving refs and finding
+ * cross-collection references. These operate exclusively on rooms whose ydoc
+ * is currently loaded in memory — they do not make server or aggregator calls.
+ *
+ * Touches: Database instance, room ydocs, ref parsing via @eweser/shared.
+ * Read before editing: packages/db/AGENTS.md and packages/shared/src/utils/documents.ts.
+ */
+import { parseRef } from '@eweser/shared';
+import type { EweDocument } from '@eweser/shared';
+import type { Database } from '../index.js';
+
+/**
+ * Resolve a ref string to its document, searching only rooms whose ydoc is
+ * currently loaded in memory.
+ *
+ * @param db - The Database instance
+ * @param ref - A ref string in the format `${authServer}|${collectionKey}|${roomId}|${documentId}`
+ * @returns The document if found and not deleted, or null if the room is not
+ *   loaded or the document does not exist
+ */
+export function resolveRef<T extends EweDocument>(
+  db: Database,
+  ref: string
+): T | null {
+  const { collectionKey, roomId, documentId } = parseRef(ref);
+  const collection = db.collections[collectionKey];
+  if (!collection) return null;
+  const room = collection[roomId];
+  if (!room?.ydoc) return null;
+  const documents = room.ydoc.getMap('documents');
+  const doc = documents.get(documentId);
+  if (!doc) return null;
+  const typed = doc as unknown as T;
+  if (typed._deleted) return null;
+  return typed;
+}
+
+/**
+ * Find all documents across all loaded rooms that reference a given ref string.
+ * A document is considered "referencing" the ref if any of its string-typed
+ * field values or string array elements exactly equal the ref string.
+ *
+ * Only searches rooms whose ydoc is loaded in memory. Deleted documents are
+ * excluded. Order and limits are deterministic but not guaranteed sorted.
+ *
+ * This is an O(all_documents) scan intended for small-to-medium local datasets.
+ * For server-side search or indexing, use the aggregator API instead.
+ *
+ * @param db - The Database instance
+ * @param ref - The target ref string to search for
+ * @returns Array of documents (potentially from multiple collections) that
+ *   reference the given ref
+ */
+export function findDocumentsReferencing(
+  db: Database,
+  ref: string
+): EweDocument[] {
+  const results: EweDocument[] = [];
+
+  for (const collectionKey of db.collectionKeys) {
+    const collection = db.collections[collectionKey];
+    for (const roomId of Object.keys(collection)) {
+      const room = collection[roomId];
+      if (!room?.ydoc) continue;
+      const documents = room.ydoc.getMap('documents');
+      documents.forEach((doc: unknown) => {
+        if (!doc) return;
+        const typed = doc as Record<string, unknown>;
+        // Skip deleted documents
+        if (typed._deleted) return;
+        // Check every value in the document for a matching ref.
+        // Skip internal metadata fields (_ref, _id, _created, _updated, _deleted, _ttl)
+        // since _ref is the document's own identity, not a reference to another document.
+        for (const [key, value] of Object.entries(typed)) {
+          if (key.startsWith('_')) continue;
+          if (value === ref) {
+            results.push(typed as EweDocument);
+            return; // Don't double-count the same document
+          }
+          if (
+            Array.isArray(value) &&
+            value.some((v) => typeof v === 'string' && v === ref)
+          ) {
+            results.push(typed as EweDocument);
+            return;
+          }
+        }
+      });
+    }
+  }
+
+  return results;
+}

--- a/packages/shared/src/utils/documents.test.ts
+++ b/packages/shared/src/utils/documents.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { parseRef, buildRef, type ParsedRef } from './documents.js';
+
+const validRef = 'https://www.eweser.com|notes|room-abc-123|doc-xyz-789';
+
+describe('parseRef', () => {
+  it('parses a valid ref string into its components', () => {
+    const result = parseRef(validRef);
+    expect(result).toEqual<ParsedRef>({
+      authServer: 'https://www.eweser.com',
+      collectionKey: 'notes',
+      roomId: 'room-abc-123',
+      documentId: 'doc-xyz-789',
+    });
+  });
+
+  it('round-trips with buildRef', () => {
+    const params = {
+      authServer: 'https://selfhosted.example.com',
+      collectionKey: 'flashcards' as const,
+      roomId: '550e8400-e29b-41d4-a716-446655440000',
+      documentId: 'doc-42',
+    };
+    const ref = buildRef(params);
+    const parsed = parseRef(ref);
+    expect(parsed).toEqual(params);
+  });
+
+  it('throws for empty string', () => {
+    expect(() => parseRef('')).toThrow('ref must be a non-empty string');
+  });
+
+  it('throws for non-string input', () => {
+    expect(() => parseRef(null as unknown as string)).toThrow(
+      'ref must be a non-empty string'
+    );
+    expect(() => parseRef(undefined as unknown as string)).toThrow(
+      'ref must be a non-empty string'
+    );
+  });
+
+  it('throws for too few parts with descriptive message', () => {
+    expect(() => parseRef('server|notes|room1')).toThrow(
+      /Invalid ref format.*3 parts/
+    );
+  });
+
+  it('throws for too many parts with descriptive message', () => {
+    expect(() => parseRef('server|notes|room1|doc1|extra')).toThrow(
+      /Invalid ref format.*5 parts/
+    );
+  });
+
+  it('throws when authServer is empty', () => {
+    expect(() => parseRef('|notes|room1|doc1')).toThrow(
+      'authServer is empty in ref'
+    );
+  });
+
+  it('throws when collectionKey is empty', () => {
+    expect(() => parseRef('server||room1|doc1')).toThrow(
+      'collectionKey is empty in ref'
+    );
+  });
+
+  it('throws when roomId is empty', () => {
+    expect(() => parseRef('server|notes||doc1')).toThrow(
+      'roomId is empty in ref'
+    );
+  });
+
+  it('throws when documentId is empty', () => {
+    expect(() => parseRef('server|notes|room1|')).toThrow(
+      'documentId is empty in ref'
+    );
+  });
+
+  it('parses refs with hyphens and special characters in documentId', () => {
+    const ref = 'https://eweser.com|profiles|room-x|user_john-doe+test';
+    const result = parseRef(ref);
+    expect(result.documentId).toBe('user_john-doe+test');
+    expect(result.collectionKey).toBe('profiles');
+  });
+
+  it('parses https:// auth server URLs correctly', () => {
+    const ref = 'https://auth.myserver.com:8080|notes|room-1|doc-1';
+    const result = parseRef(ref);
+    expect(result.authServer).toBe('https://auth.myserver.com:8080');
+  });
+});

--- a/packages/shared/src/utils/documents.ts
+++ b/packages/shared/src/utils/documents.ts
@@ -47,6 +47,55 @@ export const buildRef = (params: {
   return `${authServer}|${collectionKey}|${roomId}|${documentId}`;
 };
 
+export interface ParsedRef {
+  authServer: string;
+  collectionKey: CollectionKey;
+  roomId: string;
+  documentId: string;
+}
+
+/**
+ * Reverse of buildRef: parse a ref string into its components.
+ * Validates the format and throws descriptive errors for malformed refs.
+ * @param ref - A ref string in the format `${authServer}|${collectionKey}|${roomId}|${documentId}`
+ * @returns ParsedRef with typed components
+ * @throws Error if ref is empty, has wrong part count, or contains empty parts
+ */
+export const parseRef = (ref: string): ParsedRef => {
+  if (!ref || typeof ref !== 'string') {
+    throw new Error('ref must be a non-empty string');
+  }
+  const parts = ref.split('|');
+  if (parts.length !== 4) {
+    throw new Error(
+      `Invalid ref format. Expected "authServer|collectionKey|roomId|documentId" (4 parts) but got ${parts.length} part${parts.length === 1 ? '' : 's'}`
+    );
+  }
+  const fieldNames = ['authServer', 'collectionKey', 'roomId', 'documentId'];
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    if (!part) {
+      throw new Error(`${fieldNames[i]} is empty in ref: "${ref}"`);
+    }
+  }
+  const [authServer, collectionKey, roomId, documentId] = [
+    parts[0] ?? '',
+    parts[1] ?? '',
+    parts[2] ?? '',
+    parts[3] ?? '',
+  ];
+  if (!authServer || !collectionKey || !roomId || !documentId) {
+    // Already validated above — safety fallback
+    throw new Error(`Empty component in ref: "${ref}"`);
+  }
+  return {
+    authServer,
+    collectionKey: collectionKey as CollectionKey,
+    roomId,
+    documentId,
+  };
+};
+
 export const randomString = (length: number) =>
   Math.random()
     .toString(36)


### PR DESCRIPTION
## Summary

Adds the shared ref-parsing utilities and SDK local loaded-room query helpers described in DB backlog 12.1.

### Changes

**@eweser/shared** (minor)
- Add `ParsedRef` interface and `parseRef(ref)` function — reverse of `buildRef` with clear validation of malformed refs
- Tests: 12 cases covering valid/invalid refs, empty parts, wrong part count, round-trip with buildRef, URLs with ports

**@eweser/db** (minor)
- New `packages/db/src/utils/query.ts` module with:
  - `resolveRef(db, ref)` — resolve a ref string to its document if the room is loaded
  - `findDocumentsReferencing(db, ref)` — find all documents across loaded rooms whose non-metadata fields reference the given ref
- Tests: 17 cases covering valid/invalid refs, unloaded rooms, deleted docs, multiple collections, cross-collection refs, deterministic ordering, empty db edge case
- Documentation: `packages/db/README.md` now has a 'Local loaded-room queries' section distinguishing SDK queries from aggregator search

### Files touched

| File | Change |
|---|---|
| `packages/shared/src/utils/documents.ts` | Added `ParsedRef`, `parseRef` |
| `packages/shared/src/utils/documents.test.ts` | New — 12 tests |
| `packages/db/src/utils/query.ts` | New — `resolveRef`, `findDocumentsReferencing` |
| `packages/db/src/utils/query.test.ts` | New — 17 tests |
| `packages/db/src/utils/index.ts` | Export `query.js` |
| `packages/db/README.md` | Added loaded-room query semantics |
| `.changeset/ref-parse-local-query.md` | Minor bumps for both packages |

### Verification
- `npm test --workspace @eweser/shared` — 67/67 pass
- `npm test --workspace @eweser/db` — 109 passed, 1 todo
- `npm run build --workspace @eweser/db` — builds clean