### PR TITLE
Reduce Railway egress for uploads and webhooks

### DIFF
--- a/packages/auth-server-hono/src/lib/storage.ts
+++ b/packages/auth-server-hono/src/lib/storage.ts
@@ -185,6 +185,25 @@ export async function createDownloadUrl(
   );
 }
 
+export async function createUploadUrl(params: {
+  contentType: string;
+  objectKey: string;
+  providerProfileId?: string | undefined;
+}): Promise<string> {
+  const client = createStorageClient(params.providerProfileId);
+  const { bucket } = ensureStorageConfig(params.providerProfileId);
+
+  return getSignedUrl(
+    client,
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: params.objectKey,
+      ContentType: params.contentType,
+    }),
+    { expiresIn: PRESIGN_TTL_SECONDS }
+  );
+}
+
 export function getDownloadUrlTtlSeconds(): number {
   return PRESIGN_TTL_SECONDS;
 }

--- a/packages/auth-server-hono/src/routes/backups.test.ts
+++ b/packages/auth-server-hono/src/routes/backups.test.ts
@@ -2,10 +2,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Hono } from 'hono';
 
 const createDownloadUrlMock = vi.fn();
+const createUploadUrlMock = vi.fn();
 const getStorageProviderProfileMock = vi.fn();
 const objectExistsMock = vi.fn();
 const storageIsConfiguredMock = vi.fn();
-const uploadObjectMock = vi.fn();
 const getSessionMock = vi.fn();
 const insertBackupSnapshotMock = vi.fn();
 const listBackupSnapshotsMock = vi.fn();
@@ -13,6 +13,7 @@ const getBackupSnapshotForActorMock = vi.fn();
 const TEST_SERVER_SIGNING_KEY = ['1234567890', '1234567890123456789012'].join(
   ''
 );
+const TEST_CONTENT_HASH = 'a'.repeat(64);
 
 vi.mock('../auth.js', () => ({
   auth: {
@@ -41,11 +42,11 @@ vi.mock('../lib/storage.js', () => ({
     filename: string;
   }) => `backups/${userId}/${contentHash}/${filename}`,
   createDownloadUrl: createDownloadUrlMock,
+  createUploadUrl: createUploadUrlMock,
   getDownloadUrlTtlSeconds: () => 900,
   getStorageProviderProfile: getStorageProviderProfileMock,
   objectExists: objectExistsMock,
   storageIsConfigured: storageIsConfiguredMock,
-  uploadObject: uploadObjectMock,
 }));
 
 vi.mock('../model/backup-snapshots.js', () => ({
@@ -110,52 +111,95 @@ describe('backupsRouter', () => {
     createDownloadUrlMock.mockResolvedValue(
       'https://bucket.example.com/snapshot'
     );
+    createUploadUrlMock.mockResolvedValue(
+      'https://bucket.example.com/snapshot-upload'
+    );
     getSessionMock.mockResolvedValue(null);
     insertBackupSnapshotMock.mockResolvedValue(snapshotRow());
     listBackupSnapshotsMock.mockResolvedValue([snapshotRow()]);
     getBackupSnapshotForActorMock.mockResolvedValue(snapshotRow());
   });
 
-  it('uploads a snapshot for an access-grant actor', async () => {
-    const form = new FormData();
-    form.append(
-      'metadata',
-      JSON.stringify({
-        filename: 'snapshot.json',
-        roomCount: 1,
-        documentCount: 2,
-      })
-    );
-    form.append(
-      'snapshot',
-      new File([new Uint8Array([1, 2, 3])], 'snapshot.json', {
-        type: 'application/json',
-      })
-    );
-
+  it('rejects legacy proxy snapshot uploads', async () => {
     const response = await app.fetch(
       new Request('http://localhost/api/backups/upload', {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${await accessGrantToken()}`,
         },
-        body: form,
+      })
+    );
+
+    expect(response.status).toBe(410);
+    await expect(response.json()).resolves.toEqual({
+      error:
+        'Proxy backup uploads are disabled. Use /api/backups/prepare-upload and upload directly to object storage.',
+    });
+  });
+
+  it('prepares and completes a direct snapshot upload for an access-grant actor', async () => {
+    const metadata = {
+      contentHash: TEST_CONTENT_HASH,
+      documentCount: 2,
+      filename: 'snapshot.json',
+      roomCount: 1,
+      sizeBytes: 100,
+    };
+
+    const response = await app.fetch(
+      new Request('http://localhost/api/backups/prepare-upload', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${await accessGrantToken()}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ metadata }),
       })
     );
 
     expect(response.status).toBe(200);
-    const body = await response.json();
+    await expect(response.json()).resolves.toEqual({
+      objectKey: `backups/user-1/${metadata.contentHash}/snapshot.json`,
+      providerProfileId: 'railway-buckets',
+      upload: {
+        expiresInSeconds: 900,
+        headers: {
+          'content-type': 'application/vnd.eweser.snapshot+json',
+        },
+        method: 'PUT',
+        url: 'https://bucket.example.com/snapshot-upload',
+      },
+    });
+    expect(createUploadUrlMock).toHaveBeenCalledWith({
+      contentType: 'application/vnd.eweser.snapshot+json',
+      objectKey: `backups/user-1/${metadata.contentHash}/snapshot.json`,
+      providerProfileId: 'railway-buckets',
+    });
+
+    objectExistsMock.mockResolvedValueOnce(true);
+    const completeResponse = await app.fetch(
+      new Request('http://localhost/api/backups/complete-upload', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${await accessGrantToken()}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ metadata }),
+      })
+    );
+
+    expect(completeResponse.status).toBe(200);
+    const body = await completeResponse.json();
     expect(body.snapshot.id).toBe('58e14414-8fa6-4c31-86f1-bf78fc153a2b');
     expect(insertBackupSnapshotMock).toHaveBeenCalledWith(
       expect.objectContaining({
         accessGrantId: 'user-1|app.local',
+        contentHash: metadata.contentHash,
         documentCount: 2,
+        objectKey: `backups/user-1/${metadata.contentHash}/snapshot.json`,
         providerProfileId: 'railway-buckets',
         userId: 'user-1',
       })
-    );
-    expect(uploadObjectMock).toHaveBeenCalledWith(
-      expect.objectContaining({ providerProfileId: 'railway-buckets' })
     );
   });
 
@@ -203,25 +247,24 @@ describe('backupsRouter', () => {
 
   it('rejects unavailable provider profiles before upload', async () => {
     getStorageProviderProfileMock.mockReturnValueOnce(null);
-    const form = new FormData();
-    form.append(
-      'metadata',
-      JSON.stringify({
-        filename: 'snapshot.json',
-        roomCount: 1,
-        documentCount: 2,
-      })
-    );
-    form.append('providerProfileId', 'unknown-profile');
-    form.append('snapshot', new File([new Uint8Array([1])], 'snapshot.json'));
 
     const response = await app.fetch(
-      new Request('http://localhost/api/backups/upload', {
+      new Request('http://localhost/api/backups/prepare-upload', {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${await accessGrantToken()}`,
+          'Content-Type': 'application/json',
         },
-        body: form,
+        body: JSON.stringify({
+          metadata: {
+            contentHash: TEST_CONTENT_HASH,
+            documentCount: 2,
+            filename: 'snapshot.json',
+            roomCount: 1,
+            sizeBytes: 1,
+          },
+          providerProfileId: 'unknown-profile',
+        }),
       })
     );
 
@@ -229,36 +272,34 @@ describe('backupsRouter', () => {
     await expect(response.json()).resolves.toEqual({
       error: 'Storage provider profile unavailable',
     });
-    expect(uploadObjectMock).not.toHaveBeenCalled();
+    expect(createUploadUrlMock).not.toHaveBeenCalled();
   });
 
   it('rejects unused snapshot creation-time metadata', async () => {
-    const form = new FormData();
-    form.append(
-      'metadata',
-      JSON.stringify({
-        createdAt: '2026-05-19T00:00:00.000Z',
-        filename: 'snapshot.json',
-        roomCount: 1,
-        documentCount: 2,
-      })
-    );
-    form.append('snapshot', new File([new Uint8Array([1])], 'snapshot.json'));
-
     const response = await app.fetch(
-      new Request('http://localhost/api/backups/upload', {
+      new Request('http://localhost/api/backups/prepare-upload', {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${await accessGrantToken()}`,
+          'Content-Type': 'application/json',
         },
-        body: form,
+        body: JSON.stringify({
+          metadata: {
+            contentHash: TEST_CONTENT_HASH,
+            createdAt: '2026-05-19T00:00:00.000Z',
+            documentCount: 2,
+            filename: 'snapshot.json',
+            roomCount: 1,
+            sizeBytes: 1,
+          },
+        }),
       })
     );
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({
-      error: 'Invalid snapshot metadata',
+      error: 'Invalid snapshot upload payload',
     });
-    expect(uploadObjectMock).not.toHaveBeenCalled();
+    expect(createUploadUrlMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/auth-server-hono/src/routes/backups.ts
+++ b/packages/auth-server-hono/src/routes/backups.ts
@@ -4,7 +4,6 @@
  * Touches: Access-grant/session auth, object storage, and backup snapshot metadata.
  * Read before editing: packages/auth-server-hono/src/INDEX.md and AGENTS.md.
  */
-import { createHash } from 'node:crypto';
 import { Hono, type Context } from 'hono';
 import jwt from 'jsonwebtoken';
 import { z } from 'zod';
@@ -20,11 +19,11 @@ import type { BackupSnapshot } from '../db/schema/backup_snapshots.js';
 import {
   buildSnapshotObjectKey,
   createDownloadUrl,
+  createUploadUrl,
   getDownloadUrlTtlSeconds,
   getStorageProviderProfile,
   objectExists,
   storageIsConfigured,
-  uploadObject,
 } from '../lib/storage.js';
 
 const DEFAULT_RETENTION_DAYS = 90;
@@ -37,6 +36,19 @@ const uploadMetadataSchema = z
     providerProfileId: z.string().min(1).optional(),
     retentionDays: z.number().int().positive().max(3650).optional(),
     roomCount: z.number().int().nonnegative(),
+  })
+  .strict();
+
+const directUploadMetadataSchema = uploadMetadataSchema.extend({
+  contentHash: z.string().regex(/^[a-f0-9]{64}$/),
+  filename: z.string().min(1).max(200),
+  sizeBytes: z.number().int().nonnegative(),
+});
+
+const directUploadSchema = z
+  .object({
+    metadata: directUploadMetadataSchema,
+    providerProfileId: z.string().min(1).optional(),
   })
   .strict();
 
@@ -134,61 +146,110 @@ function serializeSnapshot(snapshot: BackupSnapshot) {
 }
 
 backupsRouter.post('/upload', async (c) => {
+  return c.json(
+    {
+      error:
+        'Proxy backup uploads are disabled. Use /api/backups/prepare-upload and upload directly to object storage.',
+    },
+    410
+  );
+});
+
+backupsRouter.post('/prepare-upload', async (c) => {
   const actor = await resolveActor(c.req.raw);
   if (!actor) {
     return c.json({ error: 'Unauthorized' }, 401);
   }
 
-  const form = await c.req.formData();
-  const metadataRaw = form.get('metadata');
-  const providerProfileIdRaw = form.get('providerProfileId');
-  const snapshot = form.get('snapshot');
-
-  if (typeof metadataRaw !== 'string' || !(snapshot instanceof File)) {
+  let rawBody: unknown;
+  try {
+    rawBody = await c.req.json();
+  } catch {
     return c.json({ error: 'Invalid snapshot upload payload' }, 400);
   }
 
-  let rawMetadata: unknown;
-  try {
-    rawMetadata = JSON.parse(metadataRaw);
-  } catch {
-    return c.json({ error: 'Invalid snapshot metadata' }, 400);
-  }
-  const parsedMetadata = uploadMetadataSchema.safeParse(rawMetadata);
-  if (!parsedMetadata.success) {
-    return c.json({ error: 'Invalid snapshot metadata' }, 400);
+  const parsedBody = directUploadSchema.safeParse(rawBody);
+  if (!parsedBody.success) {
+    return c.json({ error: 'Invalid snapshot upload payload' }, 400);
   }
 
   const providerProfileId =
-    parsedMetadata.data.providerProfileId ??
-    (typeof providerProfileIdRaw === 'string' && providerProfileIdRaw.length > 0
-      ? providerProfileIdRaw
-      : env.STORAGE_PROVIDER_PROFILE_ID);
+    parsedBody.data.metadata.providerProfileId ??
+    parsedBody.data.providerProfileId ??
+    env.STORAGE_PROVIDER_PROFILE_ID;
   const storageError = storageProfileError(providerProfileId);
   if (storageError) {
     return c.json({ error: storageError.error }, storageError.status);
   }
 
-  if (snapshot.size > env.STORAGE_MAX_FILE_SIZE_MB * 1024 * 1024) {
+  const metadata = parsedBody.data.metadata;
+  if (metadata.sizeBytes > env.STORAGE_MAX_FILE_SIZE_MB * 1024 * 1024) {
     return c.json({ error: 'Snapshot exceeds configured size limit' }, 413);
   }
 
-  const bytes = new Uint8Array(await snapshot.arrayBuffer());
-  const contentHash = createHash('sha256').update(bytes).digest('hex');
-  const filename = parsedMetadata.data.filename ?? snapshot.name;
   const objectKey = buildSnapshotObjectKey({
-    contentHash,
-    filename,
+    contentHash: metadata.contentHash,
+    filename: metadata.filename,
+    userId: actor.userId,
+  });
+  const exists = await objectExists(objectKey, providerProfileId);
+
+  return c.json({
+    objectKey,
+    providerProfileId,
+    upload: exists
+      ? null
+      : {
+          expiresInSeconds: getDownloadUrlTtlSeconds(),
+          headers: {
+            'content-type': SNAPSHOT_CONTENT_TYPE,
+          },
+          method: 'PUT',
+          url: await createUploadUrl({
+            contentType: SNAPSHOT_CONTENT_TYPE,
+            objectKey,
+            providerProfileId,
+          }),
+        },
+  });
+});
+
+backupsRouter.post('/complete-upload', async (c) => {
+  const actor = await resolveActor(c.req.raw);
+  if (!actor) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
+
+  let rawBody: unknown;
+  try {
+    rawBody = await c.req.json();
+  } catch {
+    return c.json({ error: 'Invalid snapshot upload payload' }, 400);
+  }
+
+  const parsedBody = directUploadSchema.safeParse(rawBody);
+  if (!parsedBody.success) {
+    return c.json({ error: 'Invalid snapshot upload payload' }, 400);
+  }
+
+  const metadata = parsedBody.data.metadata;
+  const providerProfileId =
+    metadata.providerProfileId ??
+    parsedBody.data.providerProfileId ??
+    env.STORAGE_PROVIDER_PROFILE_ID;
+  const storageError = storageProfileError(providerProfileId);
+  if (storageError) {
+    return c.json({ error: storageError.error }, storageError.status);
+  }
+
+  const objectKey = buildSnapshotObjectKey({
+    contentHash: metadata.contentHash,
+    filename: metadata.filename,
     userId: actor.userId,
   });
 
   if (!(await objectExists(objectKey, providerProfileId))) {
-    await uploadObject({
-      body: bytes,
-      contentType: snapshot.type || SNAPSHOT_CONTENT_TYPE,
-      objectKey,
-      providerProfileId,
-    });
+    return c.json({ error: 'Snapshot object was not uploaded' }, 409);
   }
 
   const created = await insertBackupSnapshot({
@@ -196,12 +257,12 @@ backupsRouter.post('/upload', async (c) => {
     accessGrantId: actor.kind === 'grant' ? actor.accessGrantId : null,
     providerProfileId,
     objectKey,
-    filename,
-    contentHash,
-    sizeBytes: bytes.byteLength,
-    roomCount: parsedMetadata.data.roomCount,
-    documentCount: parsedMetadata.data.documentCount,
-    retentionExpiresAt: retentionExpiry(parsedMetadata.data.retentionDays),
+    filename: metadata.filename,
+    contentHash: metadata.contentHash,
+    sizeBytes: metadata.sizeBytes,
+    roomCount: metadata.roomCount,
+    documentCount: metadata.documentCount,
+    retentionExpiresAt: retentionExpiry(metadata.retentionDays),
   });
 
   return c.json({ snapshot: serializeSnapshot(created) });

--- a/packages/auth-server-hono/src/routes/files.test.ts
+++ b/packages/auth-server-hono/src/routes/files.test.ts
@@ -3,14 +3,16 @@ import { Hono } from 'hono';
 
 const getRoomByIdMock = vi.fn();
 const createDownloadUrlMock = vi.fn();
+const createUploadUrlMock = vi.fn();
 const getStorageProviderProfileMock = vi.fn();
 const objectExistsMock = vi.fn();
 const storageIsConfiguredMock = vi.fn();
-const uploadObjectMock = vi.fn();
 const getSessionMock = vi.fn();
 const TEST_SERVER_SIGNING_KEY = ['1234567890', '1234567890123456789012'].join(
   ''
 );
+const TEST_CONTENT_HASH = 'a'.repeat(64);
+const DIFFERENT_TEST_CONTENT_HASH = 'b'.repeat(64);
 
 vi.mock('../auth.js', () => ({
   auth: {
@@ -43,13 +45,13 @@ vi.mock('../lib/storage.js', () => ({
     filename: string;
   }) => `rooms/${roomId}/${contentHash}/${filename}`,
   createDownloadUrl: createDownloadUrlMock,
+  createUploadUrl: createUploadUrlMock,
   getDownloadUrlTtlSeconds: () => 900,
   getStorageProviderProfile: getStorageProviderProfileMock,
   objectExists: objectExistsMock,
   objectKeyMatchesRoom: (roomId: string, objectKey: string) =>
     objectKey.startsWith(`rooms/${roomId}/`),
   storageIsConfigured: storageIsConfiguredMock,
-  uploadObject: uploadObjectMock,
 }));
 
 const { filesRouter } = await import('./files.js');
@@ -75,6 +77,7 @@ describe('filesRouter', () => {
     });
     objectExistsMock.mockResolvedValue(false);
     createDownloadUrlMock.mockResolvedValue('https://bucket.example.com/file');
+    createUploadUrlMock.mockResolvedValue('https://bucket.example.com/upload');
     getSessionMock.mockResolvedValue(null);
     getRoomByIdMock.mockResolvedValue({
       id: 'attachments-room',
@@ -87,26 +90,33 @@ describe('filesRouter', () => {
     });
   });
 
-  it('uploads an attachment for an authorized access-grant token', async () => {
-    const form = new FormData();
-    form.append('roomId', 'attachments-room');
-    form.append(
-      'attachment',
-      JSON.stringify({
+  it('rejects legacy proxy uploads before accepting file bytes', async () => {
+    const response = await app.fetch(
+      new Request('http://localhost/api/files/upload', {
+        method: 'POST',
+      })
+    );
+
+    expect(response.status).toBe(410);
+    await expect(response.json()).resolves.toEqual({
+      error:
+        'Proxy uploads are disabled. Use /api/files/prepare-upload and upload directly to object storage.',
+    });
+  });
+
+  it('prepares a direct attachment upload for an authorized access-grant token', async () => {
+    const body = {
+      roomId: 'attachments-room',
+      attachment: {
         baseId: 'base-1',
+        contentHash: TEST_CONTENT_HASH,
         filename: 'diagram.png',
         mimeType: 'image/png',
         size: 4,
         sourcePath: 'Attachments/diagram.png',
         sourceVault: 'Work',
-      })
-    );
-    form.append(
-      'file',
-      new File([new Uint8Array([1, 2, 3, 4])], 'diagram.png', {
-        type: 'image/png',
-      })
-    );
+      },
+    };
 
     const token = await import('jsonwebtoken').then(({ default: jwt }) =>
       jwt.sign(
@@ -119,44 +129,53 @@ describe('filesRouter', () => {
     );
 
     const response = await app.fetch(
-      new Request('http://localhost/api/files/upload', {
+      new Request('http://localhost/api/files/prepare-upload', {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${token}`,
+          'content-type': 'application/json',
         },
-        body: form,
+        body: JSON.stringify(body),
       })
     );
 
     expect(response.status).toBe(200);
     const payload = (await response.json()) as {
       attachment: { remoteProviderProfileId: string; remoteObjectKey: string };
+      upload: { headers: Record<string, string>; method: string; url: string };
     };
     expect(payload.attachment.remoteProviderProfileId).toBe('railway-buckets');
     expect(payload.attachment.remoteObjectKey).toContain(
       'rooms/attachments-room/'
     );
-    expect(uploadObjectMock).toHaveBeenCalledOnce();
-    expect(uploadObjectMock).toHaveBeenCalledWith(
-      expect.objectContaining({ providerProfileId: 'railway-buckets' })
+    expect(payload.upload).toEqual({
+      expiresInSeconds: 900,
+      headers: { 'content-type': 'image/png' },
+      method: 'PUT',
+      url: 'https://bucket.example.com/upload',
+    });
+    expect(createUploadUrlMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contentType: 'image/png',
+        providerProfileId: 'railway-buckets',
+      })
     );
   });
 
   it('rejects unavailable provider profiles before upload', async () => {
     getStorageProviderProfileMock.mockReturnValueOnce(null);
-    const form = new FormData();
-    form.append('roomId', 'attachments-room');
-    form.append(
-      'attachment',
-      JSON.stringify({
+    const body = {
+      roomId: 'attachments-room',
+      providerProfileId: 'unknown-profile',
+      attachment: {
         baseId: 'base-1',
+        contentHash: DIFFERENT_TEST_CONTENT_HASH,
         filename: 'diagram.png',
         mimeType: 'image/png',
+        size: 1,
         sourcePath: 'Attachments/diagram.png',
-      })
-    );
-    form.append('providerProfileId', 'unknown-profile');
-    form.append('file', new File([new Uint8Array([1])], 'diagram.png'));
+      },
+    };
 
     const token = await import('jsonwebtoken').then(({ default: jwt }) =>
       jwt.sign(
@@ -169,12 +188,13 @@ describe('filesRouter', () => {
     );
 
     const response = await app.fetch(
-      new Request('http://localhost/api/files/upload', {
+      new Request('http://localhost/api/files/prepare-upload', {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${token}`,
+          'content-type': 'application/json',
         },
-        body: form,
+        body: JSON.stringify(body),
       })
     );
 
@@ -182,7 +202,7 @@ describe('filesRouter', () => {
     await expect(response.json()).resolves.toEqual({
       error: 'Storage provider profile unavailable',
     });
-    expect(uploadObjectMock).not.toHaveBeenCalled();
+    expect(createUploadUrlMock).not.toHaveBeenCalled();
   });
 
   it('returns a presigned url for a session-authorized reader', async () => {

--- a/packages/auth-server-hono/src/routes/files.ts
+++ b/packages/auth-server-hono/src/routes/files.ts
@@ -4,7 +4,6 @@
  * Touches: Access-grant auth, room access checks, and object storage adapter.
  * Read before editing: packages/auth-server-hono/src/INDEX.md and AGENTS.md.
  */
-import { createHash } from 'node:crypto';
 import { Hono } from 'hono';
 import jwt from 'jsonwebtoken';
 import { z } from 'zod';
@@ -14,23 +13,32 @@ import { getRoomById } from '../model/rooms/calls.js';
 import {
   buildAttachmentObjectKey,
   createDownloadUrl,
+  createUploadUrl,
   getDownloadUrlTtlSeconds,
   getStorageProviderProfile,
   objectExists,
   objectKeyMatchesRoom,
   storageIsConfigured,
-  uploadObject,
 } from '../lib/storage.js';
 
 const uploadAttachmentSchema = z.object({
   baseId: z.string().min(1),
+  contentHash: z.string().regex(/^[a-f0-9]{64}$/),
   filename: z.string().min(1),
   mimeType: z.string().min(1),
   parentNoteRefs: z.array(z.string()).optional(),
-  size: z.number().int().nonnegative().optional(),
+  size: z.number().int().nonnegative(),
   sourcePath: z.string().min(1),
   sourceVault: z.string().min(1).optional(),
 });
+
+const prepareUploadSchema = z
+  .object({
+    attachment: uploadAttachmentSchema,
+    providerProfileId: z.string().min(1).optional(),
+    roomId: z.string().min(1),
+  })
+  .strict();
 
 const presignQuerySchema = z.object({
   objectKey: z.string().min(1),
@@ -142,28 +150,36 @@ async function requireAttachmentRoomAccess(params: {
 }
 
 filesRouter.post('/upload', async (c) => {
+  return c.json(
+    {
+      error:
+        'Proxy uploads are disabled. Use /api/files/prepare-upload and upload directly to object storage.',
+    },
+    410
+  );
+});
+
+filesRouter.post('/prepare-upload', async (c) => {
   const actor = await resolveActor(c.req.raw);
   if (!actor) {
     return c.json({ error: 'Unauthorized' }, 401);
   }
 
-  const form = await c.req.formData();
-  const roomId = form.get('roomId');
-  const attachmentRaw = form.get('attachment');
-  const providerProfileIdRaw = form.get('providerProfileId');
-  const file = form.get('file');
-
-  if (
-    typeof roomId !== 'string' ||
-    typeof attachmentRaw !== 'string' ||
-    !(file instanceof File)
-  ) {
+  let rawBody: unknown;
+  try {
+    rawBody = await c.req.json();
+  } catch {
     return c.json({ error: 'Invalid upload payload' }, 400);
   }
+
+  const parsedBody = prepareUploadSchema.safeParse(rawBody);
+  if (!parsedBody.success) {
+    return c.json({ error: 'Invalid upload payload' }, 400);
+  }
+
+  const { attachment, roomId } = parsedBody.data;
   const providerProfileId =
-    typeof providerProfileIdRaw === 'string' && providerProfileIdRaw.length > 0
-      ? providerProfileIdRaw
-      : env.STORAGE_PROVIDER_PROFILE_ID;
+    parsedBody.data.providerProfileId ?? env.STORAGE_PROVIDER_PROFILE_ID;
   const storageError = storageProfileError(providerProfileId);
   if (storageError) {
     return c.json({ error: storageError.error }, storageError.status);
@@ -178,54 +194,41 @@ filesRouter.post('/upload', async (c) => {
     return c.json({ error: access.error }, access.status);
   }
 
-  let rawAttachment: unknown;
-  try {
-    rawAttachment = JSON.parse(attachmentRaw);
-  } catch {
-    return c.json({ error: 'Invalid attachment metadata' }, 400);
-  }
-  const parsedAttachment = uploadAttachmentSchema.safeParse(rawAttachment);
-  if (!parsedAttachment.success) {
-    return c.json({ error: 'Invalid attachment metadata' }, 400);
-  }
-
-  if (file.size > env.STORAGE_MAX_FILE_SIZE_MB * 1024 * 1024) {
+  if (attachment.size > env.STORAGE_MAX_FILE_SIZE_MB * 1024 * 1024) {
     return c.json({ error: 'File exceeds configured size limit' }, 413);
   }
 
-  const bytes = new Uint8Array(await file.arrayBuffer());
-  const contentHash = createHash('sha256').update(bytes).digest('hex');
   const objectKey = buildAttachmentObjectKey({
     roomId,
-    contentHash,
-    filename: parsedAttachment.data.filename || file.name,
+    contentHash: attachment.contentHash,
+    filename: attachment.filename,
   });
-
-  if (!(await objectExists(objectKey, providerProfileId))) {
-    await uploadObject({
-      body: bytes,
-      contentType:
-        file.type ||
-        parsedAttachment.data.mimeType ||
-        'application/octet-stream',
-      objectKey,
-      providerProfileId,
-    });
-  }
+  const exists = await objectExists(objectKey, providerProfileId);
+  const contentType = attachment.mimeType || 'application/octet-stream';
 
   return c.json({
     attachment: {
-      ...parsedAttachment.data,
-      contentHash,
+      ...attachment,
       localAvailability: 'unknown',
-      mimeType:
-        file.type ||
-        parsedAttachment.data.mimeType ||
-        'application/octet-stream',
+      objectKey,
+      providerProfileId,
       remoteObjectKey: objectKey,
       remoteProviderProfileId: providerProfileId,
-      size: bytes.byteLength,
     },
+    upload: exists
+      ? null
+      : {
+          expiresInSeconds: getDownloadUrlTtlSeconds(),
+          headers: {
+            'content-type': contentType,
+          },
+          method: 'PUT',
+          url: await createUploadUrl({
+            contentType,
+            objectKey,
+            providerProfileId,
+          }),
+        },
   });
 });
 

--- a/packages/db/src/utils/backup.test.ts
+++ b/packages/db/src/utils/backup.test.ts
@@ -153,7 +153,7 @@ describe('database snapshot helpers', () => {
     );
   });
 
-  it('uploads snapshot bytes and lists remote snapshots through the auth API', async () => {
+  it('prepares a direct snapshot upload and lists remote snapshots through the auth API', async () => {
     const room = createRoomFixture();
     const { db } = createFakeDatabase([room]);
     const remoteSnapshot = {
@@ -170,8 +170,26 @@ describe('database snapshot helpers', () => {
       createdAt: '2026-05-19T00:00:00.000Z',
       updatedAt: null,
     };
+    const prepareResponse = {
+      objectKey: 'backups/user-1/hash/snapshot.json',
+      providerProfileId: 'railway-buckets',
+      upload: {
+        headers: {
+          'content-type': 'application/vnd.eweser.snapshot+json',
+        },
+        method: 'PUT',
+        url: 'https://bucket.example.com/snapshot-upload',
+      },
+    };
     const fetchMock = vi
       .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(prepareResponse), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
       .mockResolvedValueOnce(
         new Response(JSON.stringify({ snapshot: remoteSnapshot }), {
           status: 200,
@@ -193,16 +211,39 @@ describe('database snapshot helpers', () => {
       })
     ).resolves.toEqual(remoteSnapshot);
     expect(fetchMock.mock.calls[0]?.[0]).toBe(
-      'https://auth.example.com/api/backups/upload'
+      'https://auth.example.com/api/backups/prepare-upload'
     );
-    expect(
-      (fetchMock.mock.calls[0]?.[1]?.body as FormData).get('snapshot')
-    ).toBeInstanceOf(File);
+    const prepareBody = JSON.parse(
+      fetchMock.mock.calls[0]?.[1]?.body as string
+    );
+    expect(prepareBody.metadata).toEqual(
+      expect.objectContaining({
+        documentCount: 1,
+        filename: 'snapshot.json',
+        providerProfileId: 'railway-buckets',
+        roomCount: 1,
+      })
+    );
+    expect(prepareBody.metadata.contentHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(
+      'https://bucket.example.com/snapshot-upload'
+    );
+    expect(fetchMock.mock.calls[1]?.[1]).toEqual(
+      expect.objectContaining({
+        headers: {
+          'content-type': 'application/vnd.eweser.snapshot+json',
+        },
+        method: 'PUT',
+      })
+    );
+    expect(fetchMock.mock.calls[2]?.[0]).toBe(
+      'https://auth.example.com/api/backups/complete-upload'
+    );
 
     await expect(listDatabaseSnapshots({ db })).resolves.toEqual([
       remoteSnapshot,
     ]);
-    expect(fetchMock.mock.calls[1]?.[0]).toBe(
+    expect(fetchMock.mock.calls[3]?.[0]).toBe(
       'https://auth.example.com/api/backups'
     );
   });

--- a/packages/db/src/utils/backup.ts
+++ b/packages/db/src/utils/backup.ts
@@ -88,6 +88,16 @@ type SnapshotApiResponse = {
   snapshot: RemoteSnapshotRecord;
 };
 
+type SnapshotPrepareUploadResponse = {
+  objectKey: string;
+  providerProfileId: string;
+  upload: {
+    headers: Record<string, string>;
+    method: 'PUT';
+    url: string;
+  } | null;
+};
+
 type SnapshotListResponse = {
   snapshots: RemoteSnapshotRecord[];
 };
@@ -449,28 +459,57 @@ export async function uploadDatabaseSnapshot(params: {
     `eweser-snapshot-${snapshot.createdAt.slice(0, 10)}.json`;
 
   const metadata = {
+    contentHash: await sha256Hex(bytes),
     documentCount: snapshot.documentCount,
     filename,
     providerProfileId: params.providerProfileId,
     retentionDays: params.retentionDays,
     roomCount: snapshot.roomCount,
+    sizeBytes: bytes.byteLength,
   };
-  const form = new FormData();
-  form.append('metadata', JSON.stringify(metadata));
-  if (params.providerProfileId) {
-    form.append('providerProfileId', params.providerProfileId);
-  }
-  form.append(
-    'snapshot',
-    new Blob([bytes], { type: SNAPSHOT_CONTENT_TYPE }),
-    filename
+
+  const prepared = await fetchJson<SnapshotPrepareUploadResponse>(
+    params.db,
+    '/api/backups/prepare-upload',
+    {
+      body: JSON.stringify({
+        metadata,
+        ...(params.providerProfileId
+          ? { providerProfileId: params.providerProfileId }
+          : {}),
+      }),
+      headers: {
+        'content-type': 'application/json',
+      },
+      method: 'POST',
+    }
   );
+
+  if (prepared.upload) {
+    const response = await fetch(prepared.upload.url, {
+      body: new Blob([bytes], { type: SNAPSHOT_CONTENT_TYPE }),
+      headers: prepared.upload.headers,
+      method: prepared.upload.method,
+    });
+    if (!response.ok) {
+      throw new Error(`Direct snapshot upload failed: ${response.status}`);
+    }
+  }
 
   const data = await fetchJson<SnapshotApiResponse>(
     params.db,
-    '/api/backups/upload',
+    '/api/backups/complete-upload',
     {
-      body: form,
+      body: JSON.stringify({
+        metadata: {
+          ...metadata,
+          providerProfileId: prepared.providerProfileId,
+        },
+        providerProfileId: prepared.providerProfileId,
+      }),
+      headers: {
+        'content-type': 'application/json',
+      },
       method: 'POST',
     }
   );

--- a/packages/db/src/utils/files.test.ts
+++ b/packages/db/src/utils/files.test.ts
@@ -26,18 +26,15 @@ function createMemoryCache() {
   return { cache, records };
 }
 
-const verifiedFixtureHash = [
-  '06df4f7e1394f1c',
-  '57cc6583fba4d806',
-  '0a5a66f4f4771c14',
-  'aeff6b9af8a28c9b3',
-].join('');
-const differentFixtureHash = [
-  '9f64a747e1b97f13',
-  '1fabb6b447296c9b',
-  '6f0201e79fb3c535',
-  '6e6c77e89b6a806a',
-].join('');
+async function fixtureHash(bytes: Uint8Array) {
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+const verifiedFixtureHash = await fixtureHash(new Uint8Array([9, 8, 7]));
+const differentFixtureHash = await fixtureHash(new Uint8Array([1, 2, 3, 4]));
 
 describe('file helpers', () => {
   const getToken = vi.fn(() => 'grant-token');
@@ -51,27 +48,35 @@ describe('file helpers', () => {
     vi.restoreAllMocks();
   });
 
-  it('uploads multipart form data to the auth server', async () => {
-    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
-      new Response(
-        JSON.stringify({
-          attachment: {
-            _id: 'attachment-1',
-            _createdAt: new Date().toISOString(),
-            _updatedAt: new Date().toISOString(),
-            baseId: 'base-1',
-            contentHash: 'hash',
-            filename: 'file.png',
-            mimeType: 'image/png',
-            remoteObjectKey: 'rooms/attachments/hash/file.png',
-            remoteProviderProfileId: 'railway-buckets',
-            size: 4,
-            sourcePath: 'Attachments/file.png',
-          },
-        }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } }
+  it('prepares a direct upload and PUTs bytes to object storage', async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            attachment: {
+              _id: 'attachment-1',
+              _createdAt: new Date().toISOString(),
+              _updatedAt: new Date().toISOString(),
+              baseId: 'base-1',
+              contentHash: differentFixtureHash,
+              filename: 'file.png',
+              mimeType: 'image/png',
+              remoteObjectKey: `rooms/attachments/${differentFixtureHash}/file.png`,
+              remoteProviderProfileId: 'railway-buckets',
+              size: 4,
+              sourcePath: 'Attachments/file.png',
+            },
+            upload: {
+              headers: { 'content-type': 'image/png' },
+              method: 'PUT',
+              url: 'https://bucket.example.com/upload',
+            },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
       )
-    );
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
 
     const attachment = await uploadFile({
       db: db as never,
@@ -87,18 +92,37 @@ describe('file helpers', () => {
       providerProfileId: 'railway-buckets',
     });
 
-    expect(attachment.remoteObjectKey).toBe('rooms/attachments/hash/file.png');
+    expect(attachment.remoteObjectKey).toBe(
+      `rooms/attachments/${differentFixtureHash}/file.png`
+    );
     expect(fetchMock.mock.calls[0]?.[0]).toBe(
-      'https://auth.example.com/api/files/upload'
+      'https://auth.example.com/api/files/prepare-upload'
     );
     const init = fetchMock.mock.calls[0]?.[1];
     expect(init?.method).toBe('POST');
     expect((init?.headers as Record<string, string>).Authorization).toBe(
       'Bearer grant-token'
     );
-    expect(init?.body).toBeInstanceOf(FormData);
-    expect((init?.body as FormData).get('providerProfileId')).toBe(
-      'railway-buckets'
+    expect(JSON.parse(init?.body as string)).toEqual({
+      attachment: {
+        baseId: 'base-1',
+        contentHash: differentFixtureHash,
+        filename: 'file.png',
+        mimeType: 'image/png',
+        size: 4,
+        sourcePath: 'Attachments/file.png',
+      },
+      providerProfileId: 'railway-buckets',
+      roomId: 'attachments-room',
+    });
+    expect(fetchMock.mock.calls[1]).toEqual(
+      expect.arrayContaining([
+        'https://bucket.example.com/upload',
+        expect.objectContaining({
+          headers: { 'content-type': 'image/png' },
+          method: 'PUT',
+        }),
+      ])
     );
   });
 

--- a/packages/db/src/utils/files.ts
+++ b/packages/db/src/utils/files.ts
@@ -6,6 +6,7 @@ type FileBody = Blob | Uint8Array | ArrayBuffer;
 type UploadAttachmentMetadata = Pick<
   FileAttachment,
   | 'baseId'
+  | 'contentHash'
   | 'filename'
   | 'mimeType'
   | 'parentNoteRefs'
@@ -16,6 +17,11 @@ type UploadAttachmentMetadata = Pick<
 
 type UploadResponse = {
   attachment: FileAttachment;
+  upload: {
+    headers: Record<string, string>;
+    method: 'PUT';
+    url: string;
+  } | null;
 };
 
 type PresignResponse = {
@@ -69,6 +75,16 @@ function resolveBlob(file: FileBody, fallbackMimeType: string): Blob {
   }
 
   return new Blob([Uint8Array.from(file)], { type: fallbackMimeType });
+}
+
+async function resolveBytes(file: FileBody): Promise<Uint8Array> {
+  if (file instanceof Blob) {
+    return new Uint8Array(await file.arrayBuffer());
+  }
+  if (file instanceof ArrayBuffer) {
+    return new Uint8Array(file);
+  }
+  return Uint8Array.from(file);
 }
 
 function cacheKey(attachment: CacheableAttachment): string | null {
@@ -184,23 +200,48 @@ async function fetchJson<T>(
 export async function uploadFile(params: {
   db: Database;
   file: FileBody;
-  metadata: UploadAttachmentMetadata;
+  metadata: Omit<UploadAttachmentMetadata, 'contentHash'> &
+    Partial<Pick<UploadAttachmentMetadata, 'contentHash'>>;
   providerProfileId?: string | undefined;
   roomId: string;
 }): Promise<FileAttachment> {
+  const bytes = await resolveBytes(params.file);
+  const contentHash = params.metadata.contentHash ?? (await sha256Hex(bytes));
+  const metadata: UploadAttachmentMetadata = {
+    ...params.metadata,
+    contentHash,
+    size: params.metadata.size ?? bytes.byteLength,
+  };
   const blob = resolveBlob(params.file, params.metadata.mimeType);
-  const form = new FormData();
-  form.append('roomId', params.roomId);
-  form.append('attachment', JSON.stringify(params.metadata));
-  if (params.providerProfileId) {
-    form.append('providerProfileId', params.providerProfileId);
-  }
-  form.append('file', blob, params.metadata.filename);
 
-  const data = await fetchJson<UploadResponse>(params.db, '/api/files/upload', {
-    body: form,
-    method: 'POST',
-  });
+  const data = await fetchJson<UploadResponse>(
+    params.db,
+    '/api/files/prepare-upload',
+    {
+      body: JSON.stringify({
+        attachment: metadata,
+        ...(params.providerProfileId
+          ? { providerProfileId: params.providerProfileId }
+          : {}),
+        roomId: params.roomId,
+      }),
+      headers: {
+        'content-type': 'application/json',
+      },
+      method: 'POST',
+    }
+  );
+
+  if (data.upload) {
+    const response = await fetch(data.upload.url, {
+      body: blob,
+      headers: data.upload.headers,
+      method: data.upload.method,
+    });
+    if (!response.ok) {
+      throw new Error(`Direct file upload failed: ${response.status}`);
+    }
+  }
 
   return data.attachment;
 }

--- a/packages/sync-server/src/aggregator-webhook.test.ts
+++ b/packages/sync-server/src/aggregator-webhook.test.ts
@@ -13,7 +13,7 @@ describe('createAggregatorWebhookExtension', () => {
     vi.unstubAllGlobals();
   });
 
-  it('posts serialized EweserDB document state to the aggregator after debounce', async () => {
+  it('posts bounded public document summaries to the aggregator after debounce', async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
     vi.stubGlobal('fetch', fetchMock);
     const extension = createAggregatorWebhookExtension({
@@ -23,7 +23,9 @@ describe('createAggregatorWebhookExtension', () => {
     });
     const sourceDoc = new Y.Doc();
     sourceDoc.getMap('documents').set('note1', {
+      sourcePath: 'Public.md',
       text: 'searchable aggregator payload',
+      unusedLargeField: 'x'.repeat(200),
     });
 
     await extension.onChange?.({
@@ -58,19 +60,18 @@ describe('createAggregatorWebhookExtension', () => {
           collectionKey: 'notes',
           publicAccess: 'read',
         },
-        document: {
-          documents: {
-            note1: { text: 'searchable aggregator payload' },
+        documentData: {
+          note1: {
+            sourcePath: 'Public.md',
+            text: 'searchable aggregator payload',
           },
         },
         documentName: 'room-1',
-        requestHeaders: {},
-        requestParameters: {},
       },
     });
   });
 
-  it('merges multiple updates for the same room before posting', async () => {
+  it('merges multiple updates for the same room before posting summaries', async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
     vi.stubGlobal('fetch', fetchMock);
     const extension = createAggregatorWebhookExtension({
@@ -131,17 +132,84 @@ describe('createAggregatorWebhookExtension', () => {
           collectionKey: 'notes',
           publicAccess: 'read',
         },
-        document: {
-          documents: {
-            note1: { text: 'first aggregator payload' },
-            note2: { text: 'second aggregator payload' },
-          },
+        documentData: {
+          note1: { text: 'first aggregator payload' },
+          note2: { text: 'second aggregator payload' },
         },
         documentName: 'room-1',
-        requestHeaders: {},
-        requestParameters: {},
       },
     });
+  });
+
+  it('sends a tiny deindexing event for private rooms', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', fetchMock);
+    const extension = createAggregatorWebhookExtension({
+      debounceMs: 10,
+      url: 'http://aggregator.local/webhooks/hocuspocus',
+    });
+    const sourceDoc = new Y.Doc();
+    sourceDoc.getMap('documents').set('note1', {
+      text: 'private content must not leave the sync server',
+    });
+
+    await extension.onChange?.({
+      context: {
+        collectionKey: 'notes',
+        publicAccess: 'private',
+      },
+      document: new Y.Doc(),
+      documentName: 'room-1',
+      instance: {
+        documents: new Map(),
+      },
+      requestHeaders: {},
+      requestParameters: new URLSearchParams(),
+      update: Y.encodeStateAsUpdate(sourceDoc),
+    } as onChangePayload);
+
+    await vi.advanceTimersByTimeAsync(10);
+
+    const [, init] = fetchMock.mock.calls[0] as [
+      string,
+      { body: string; headers: Record<string, string>; method: string },
+    ];
+    expect(JSON.parse(init.body)).toEqual({
+      event: 'change',
+      payload: {
+        context: {
+          collectionKey: 'notes',
+          publicAccess: 'private',
+        },
+        documentData: {},
+        documentName: 'room-1',
+      },
+    });
+  });
+
+  it('skips events without collection metadata', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', fetchMock);
+    const extension = createAggregatorWebhookExtension({
+      debounceMs: 10,
+      url: 'http://aggregator.local/webhooks/hocuspocus',
+    });
+
+    await extension.onChange?.({
+      context: {},
+      document: new Y.Doc(),
+      documentName: 'room-1',
+      instance: {
+        documents: new Map(),
+      },
+      requestHeaders: {},
+      requestParameters: new URLSearchParams(),
+      update: Y.encodeStateAsUpdate(new Y.Doc()),
+    } as onChangePayload);
+
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('reports failed webhook posts through onError', async () => {
@@ -155,7 +223,10 @@ describe('createAggregatorWebhookExtension', () => {
     });
 
     await extension.onChange?.({
-      context: {},
+      context: {
+        collectionKey: 'notes',
+        publicAccess: 'read',
+      },
       document: new Y.Doc(),
       documentName: 'room-1',
       instance: {

--- a/packages/sync-server/src/aggregator-webhook.ts
+++ b/packages/sync-server/src/aggregator-webhook.ts
@@ -11,10 +11,23 @@ import { yDocSharedTypesToJson } from './webhook-transformer.js';
 
 type AggregatorWebhookOptions = {
   debounceMs?: number;
+  maxDocuments?: number;
+  maxPayloadBytes?: number;
+  maxTextChars?: number;
   onError?: (error: unknown) => void;
   secret?: string;
   url: string;
 };
+
+type WebhookContext = {
+  collectionKey?: string;
+  publicAccess?: string;
+  userId?: string;
+};
+
+const DEFAULT_MAX_DOCUMENTS = 25;
+const DEFAULT_MAX_PAYLOAD_BYTES = 64 * 1024;
+const DEFAULT_MAX_TEXT_CHARS = 2000;
 
 function createSignature(body: string, secret: string): string {
   return `sha256=${createHmac('sha256', secret).update(body).digest('hex')}`;
@@ -57,10 +70,8 @@ async function postAggregatorWebhook(
     event: 'change',
     payload: {
       context: data.context,
-      document,
+      documentData: document,
       documentName: data.documentName,
-      requestHeaders: data.requestHeaders,
-      requestParameters: Object.fromEntries(data.requestParameters.entries()),
     },
   });
   const headers: Record<string, string> = {
@@ -85,10 +96,121 @@ async function postAggregatorWebhook(
   }
 }
 
+function readContext(context: unknown): WebhookContext {
+  if (
+    typeof context !== 'object' ||
+    context === null ||
+    Array.isArray(context)
+  ) {
+    return {};
+  }
+  const record = context as Record<string, unknown>;
+  const output: WebhookContext = {};
+  if (typeof record.collectionKey === 'string') {
+    output.collectionKey = record.collectionKey;
+  }
+  if (typeof record.publicAccess === 'string') {
+    output.publicAccess = record.publicAccess;
+  }
+  if (typeof record.userId === 'string') {
+    output.userId = record.userId;
+  }
+  return output;
+}
+
+function isPublicContext(context: WebhookContext): boolean {
+  return context.publicAccess === 'read' || context.publicAccess === 'write';
+}
+
+function truncateText(
+  value: unknown,
+  maxTextChars: number
+): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  return value.length > maxTextChars
+    ? `${value.slice(0, maxTextChars)}...`
+    : value;
+}
+
+function summarizeDocument(
+  value: unknown,
+  maxTextChars: number
+): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return {};
+  }
+  const record = value as Record<string, unknown>;
+  const summary: Record<string, unknown> = {};
+
+  for (const key of [
+    '_deleted',
+    '_id',
+    '_updated',
+    'aliases',
+    'filename',
+    'folderIds',
+    'frontmatter',
+    'sourcePath',
+    'sourceVault',
+    'tags',
+    'title',
+    'type',
+  ]) {
+    if (record[key] !== undefined) {
+      summary[key] = record[key];
+    }
+  }
+
+  const text = truncateText(record.text, maxTextChars);
+  if (text !== undefined) {
+    summary.text = text;
+  }
+
+  return summary;
+}
+
+function summarizeDocuments(params: {
+  documentJson: Record<string, unknown>;
+  maxDocuments: number;
+  maxPayloadBytes: number;
+  maxTextChars: number;
+}): Record<string, unknown> {
+  const documents =
+    typeof params.documentJson.documents === 'object' &&
+    params.documentJson.documents !== null &&
+    !Array.isArray(params.documentJson.documents)
+      ? (params.documentJson.documents as Record<string, unknown>)
+      : params.documentJson;
+
+  const summarizedEntries: [string, Record<string, unknown>][] = [];
+  for (const [id, value] of Object.entries(documents).slice(
+    0,
+    params.maxDocuments
+  )) {
+    summarizedEntries.push([id, summarizeDocument(value, params.maxTextChars)]);
+  }
+
+  let maxEntries = summarizedEntries.length;
+  let summarized = Object.fromEntries(summarizedEntries.slice(0, maxEntries));
+  while (
+    maxEntries > 0 &&
+    Buffer.byteLength(JSON.stringify(summarized), 'utf8') >
+      params.maxPayloadBytes
+  ) {
+    maxEntries -= 1;
+    summarized = Object.fromEntries(summarizedEntries.slice(0, maxEntries));
+  }
+
+  return summarized;
+}
+
 export function createAggregatorWebhookExtension(
   options: AggregatorWebhookOptions
 ): Extension {
   const debounceMs = options.debounceMs ?? 1000;
+  const maxDocuments = options.maxDocuments ?? DEFAULT_MAX_DOCUMENTS;
+  const maxPayloadBytes = options.maxPayloadBytes ?? DEFAULT_MAX_PAYLOAD_BYTES;
+  const maxTextChars = options.maxTextChars ?? DEFAULT_MAX_TEXT_CHARS;
   const pendingByDocument = new Map<string, NodeJS.Timeout>();
   const mirrorsByDocument = new Map<string, Y.Doc>();
   const latestJsonByDocument = new Map<string, Record<string, unknown>>();
@@ -96,6 +218,11 @@ export function createAggregatorWebhookExtension(
   return {
     extensionName: 'AggregatorWebhook',
     async onChange(data) {
+      const context = readContext(data.context);
+      if (!context.collectionKey) {
+        return;
+      }
+
       let mirror = mirrorsByDocument.get(data.documentName);
       if (!mirror) {
         mirror = new Y.Doc();
@@ -126,11 +253,24 @@ export function createAggregatorWebhookExtension(
           const document =
             latestJsonByDocument.get(data.documentName) ??
             yDocSharedTypesToJson(data.document);
-          void postAggregatorWebhook(data, document, options).catch(
-            (error: unknown) => {
-              options.onError?.(error);
-            }
-          );
+          const documentData = isPublicContext(context)
+            ? summarizeDocuments({
+                documentJson: document,
+                maxDocuments,
+                maxPayloadBytes,
+                maxTextChars,
+              })
+            : {};
+          void postAggregatorWebhook(
+            {
+              ...data,
+              context,
+            },
+            documentData,
+            options
+          ).catch((error: unknown) => {
+            options.onError?.(error);
+          });
         }, debounceMs)
       );
     },


### PR DESCRIPTION
## Summary
- disable Railway-proxied attachment and backup uploads in favor of direct object-storage PUTs through presigned upload URLs
- add prepare/complete backup upload flow and update DB helpers to PUT snapshot bytes directly to storage
- bound sync-server aggregator webhook payloads to public room summaries and skip/private-minimize non-indexable rooms

## Verification
- npm test --workspace @eweser/auth-server-hono -- src/routes/files.test.ts src/routes/backups.test.ts
- npm test --workspace @eweser/db -- src/utils/files.test.ts src/utils/backup.test.ts
- npm test --workspace @eweser/sync-server -- src/aggregator-webhook.test.ts
- npm run type-check --workspace @eweser/auth-server-hono
- npm run type-check --workspace @eweser/db
- npm run type-check --workspace @eweser/sync-server
- npm run lint --workspace @eweser/auth-server-hono
- npm run lint --workspace @eweser/db
- npm run lint --workspace @eweser/sync-server
- npm run secrets:scan -- --staged

## Deploy notes
- object storage must allow browser/client PUT CORS for the presigned URL origin and the content-type header
- keep sync-server offline until this lands if webhook egress is the suspected cost driver
- after deploy, restore auth-api first, then test a small attachment/backup upload, then restore sync-server with aggregator webhook enabled only if egress stays flat