### PR TITLE
Mount local Markdown vaults in EweNote

### DIFF
--- a/packages/ewe-note/src/INDEX.md
+++ b/packages/ewe-note/src/INDEX.md
@@ -43,6 +43,8 @@ helpers.
   note content.
 - Import/export code is user-data sensitive and should avoid lossy transforms.
 - App loading waits until a selected room, note, and Yjs document are ready.
+- Browser-mounted Markdown vaults use the existing notes room and editor;
+  EweNote changes are written back through persisted local file handles.
 
 ## Update Triggers
 

--- a/packages/ewe-note/src/app/contexts/NotesContext.tsx
+++ b/packages/ewe-note/src/app/contexts/NotesContext.tsx
@@ -4,6 +4,7 @@ import removeMarkdown from 'markdown-to-text';
 import { useDb } from '@/db';
 import { useFolders } from '@/notes-room';
 import { collectFolderTreeIds } from './folder-tree';
+import { writeBrowserLocalVaultNotes } from '../lib/browser-local-vault';
 import { buildDefaultUntitledNoteTitle, UNTITLED_TITLE } from './note-titles';
 import {
   extractWikiLinkTargets,
@@ -404,10 +405,14 @@ export function NotesProvider({ children }: { children: React.ReactNode }) {
       try {
         const docs = typedRoom.getDocuments();
         const handler = () => {
+          const roomNotes = getNotes(typedRoom);
           setNotesByRoomId((prev) => ({
             ...prev,
-            [typedRoom.id]: getNotes(typedRoom),
+            [typedRoom.id]: roomNotes,
           }));
+          void writeBrowserLocalVaultNotes(typedRoom.id, roomNotes).catch(
+            () => undefined
+          );
         };
         docs.onChange(handler);
         handlers.push({ room: typedRoom, handler });

--- a/packages/ewe-note/src/app/lib/browser-local-vault.test.ts
+++ b/packages/ewe-note/src/app/lib/browser-local-vault.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { indexedDB } from 'fake-indexeddb';
+import {
+  clearBrowserLocalVaultsForTests,
+  pickBrowserLocalVault,
+  registerBrowserLocalVaultFiles,
+  writeBrowserLocalVaultNotes,
+  type BrowserDirectoryHandle,
+  type BrowserWritableFileHandle,
+} from './browser-local-vault';
+
+beforeEach(async () => {
+  Object.defineProperty(globalThis, 'indexedDB', {
+    configurable: true,
+    value: indexedDB,
+  });
+  await clearBrowserLocalVaultsForTests();
+  Reflect.deleteProperty(window, 'showDirectoryPicker');
+});
+
+describe('browser local vault bridge', () => {
+  it('mounts Markdown files only and skips private repository directories', async () => {
+    const markdownHandle = {
+      kind: 'file' as const,
+      name: 'Roadmap.md',
+      getFile: async () => new File(['# Roadmap\n'], 'Roadmap.md'),
+      createWritable: vi.fn(),
+    };
+    const configHandle = {
+      kind: 'file' as const,
+      name: 'config.json',
+      getFile: vi.fn(),
+      createWritable: vi.fn(),
+    };
+    const privateHandle = {
+      kind: 'file' as const,
+      name: 'private.md',
+      getFile: vi.fn(),
+      createWritable: vi.fn(),
+    };
+    const directory = (
+      name: string,
+      entries: Array<BrowserDirectoryHandle | BrowserWritableFileHandle>
+    ): BrowserDirectoryHandle => ({
+      kind: 'directory',
+      name,
+      async *values() {
+        yield* entries;
+      },
+    });
+    const root = directory('project-notes', [
+      markdownHandle,
+      configHandle,
+      directory('.git', [privateHandle]),
+    ]);
+    Object.defineProperty(window, 'showDirectoryPicker', {
+      configurable: true,
+      value: vi.fn(async () => root),
+    });
+
+    const picked = await pickBrowserLocalVault();
+
+    expect(picked.files).toHaveLength(1);
+    expect(picked.files[0]?.webkitRelativePath).toBe(
+      'project-notes/Roadmap.md'
+    );
+    expect([...picked.handlesBySourcePath.keys()]).toEqual(['Roadmap.md']);
+    expect(configHandle.getFile).not.toHaveBeenCalled();
+    expect(privateHandle.getFile).not.toHaveBeenCalled();
+  });
+
+  it('writes an EweNote edit back through the mounted file handle', async () => {
+    let fileContents = '# Original\n';
+    const write = vi.fn(async (next: string) => {
+      fileContents = next;
+    });
+    const handle: BrowserWritableFileHandle = {
+      kind: 'file',
+      name: 'Roadmap.md',
+      getFile: async () => new File([fileContents], 'Roadmap.md'),
+      queryPermission: async () => 'granted',
+      createWritable: async () => ({
+        write,
+        close: async () => undefined,
+      }),
+    };
+    const original = {
+      _id: 'roadmap-note',
+      frontmatter: {},
+      sourcePath: 'Roadmap.md',
+      sourceVault: 'project-notes',
+      text: '# Original\n',
+    };
+
+    await registerBrowserLocalVaultFiles({
+      handlesBySourcePath: new Map([['Roadmap.md', handle]]),
+      notes: [original],
+      roomId: 'project-room',
+    });
+    await writeBrowserLocalVaultNotes('project-room', [original]);
+    expect(write).not.toHaveBeenCalled();
+
+    await writeBrowserLocalVaultNotes('project-room', [
+      { ...original, text: '# Updated in EweNote\n' },
+    ]);
+
+    expect(write).toHaveBeenCalledWith('# Updated in EweNote\n');
+    expect(fileContents).toBe('# Updated in EweNote\n');
+  });
+});

--- a/packages/ewe-note/src/app/lib/browser-local-vault.ts
+++ b/packages/ewe-note/src/app/lib/browser-local-vault.ts
@@ -1,0 +1,288 @@
+import type { Note } from '@eweser/db';
+import { serializeFrontmatter } from '@eweser/shared';
+
+const DB_NAME = 'ewe-note-browser-local-vaults';
+const DB_VERSION = 1;
+const STORE_NAME = 'mounted-files';
+const IGNORED_DIRECTORIES = new Set([
+  '.git',
+  '.obsidian',
+  '.trash',
+  'node_modules',
+]);
+
+type BrowserWritable = {
+  write(data: string): Promise<void>;
+  close(): Promise<void>;
+};
+
+export type BrowserWritableFileHandle = {
+  kind: 'file';
+  name: string;
+  getFile(): Promise<File>;
+  createWritable(): Promise<BrowserWritable>;
+  queryPermission?(options: { mode: 'readwrite' }): Promise<PermissionState>;
+};
+
+export type BrowserDirectoryHandle = {
+  kind: 'directory';
+  name: string;
+  values(): AsyncIterableIterator<
+    BrowserDirectoryHandle | BrowserWritableFileHandle
+  >;
+};
+
+type DirectoryPickerWindow = Window & {
+  showDirectoryPicker?: (options?: {
+    id?: string;
+    mode?: 'read' | 'readwrite';
+  }) => Promise<BrowserDirectoryHandle>;
+};
+
+type BrowserBackedNote = Pick<
+  Note,
+  '_id' | 'frontmatter' | 'sourcePath' | 'sourceVault' | 'text'
+>;
+
+type MountedFileEntry = {
+  handle: BrowserWritableFileHandle;
+  key: string;
+  lastRoomMarkdown: string;
+  noteId: string;
+  roomId: string;
+  sourcePath: string;
+  sourceVault: string;
+};
+
+const mountedFileCache = new Map<string, MountedFileEntry>();
+const writeQueues = new Map<string, Promise<void>>();
+
+function mountedFileKey(roomId: string, noteId: string) {
+  return `${roomId}\u0000${noteId}`;
+}
+
+function normalizePath(path: string) {
+  return path.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+/g, '/');
+}
+
+function noteMarkdown(note: BrowserBackedNote) {
+  return serializeFrontmatter(note.frontmatter ?? {}, note.text);
+}
+
+function hasIndexedDb() {
+  return typeof indexedDB !== 'undefined';
+}
+
+function transactionDone(transaction: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () =>
+      reject(transaction.error ?? new Error('IndexedDB transaction failed'));
+    transaction.onabort = () =>
+      reject(transaction.error ?? new Error('IndexedDB transaction aborted'));
+  });
+}
+
+async function openMountedFilesDb(): Promise<IDBDatabase | null> {
+  if (!hasIndexedDb()) return null;
+
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      if (!request.result.objectStoreNames.contains(STORE_NAME)) {
+        request.result.createObjectStore(STORE_NAME, { keyPath: 'key' });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () =>
+      reject(request.error ?? new Error('IndexedDB open failed'));
+  });
+}
+
+async function putMountedFile(entry: MountedFileEntry) {
+  mountedFileCache.set(entry.key, entry);
+  const db = await openMountedFilesDb();
+  if (!db) return;
+
+  try {
+    const transaction = db.transaction(STORE_NAME, 'readwrite');
+    transaction.objectStore(STORE_NAME).put(entry);
+    await transactionDone(transaction);
+  } catch {
+    // Some test/browser environments cannot structured-clone file handles.
+    // The live session still remains mounted through mountedFileCache.
+  } finally {
+    db.close();
+  }
+}
+
+async function loadMountedFiles(roomId: string) {
+  const cached = Array.from(mountedFileCache.values()).filter(
+    (entry) => entry.roomId === roomId
+  );
+  const db = await openMountedFilesDb();
+  if (!db) return cached;
+
+  try {
+    const transaction = db.transaction(STORE_NAME, 'readonly');
+    const request = transaction.objectStore(STORE_NAME).getAll();
+    const stored = await new Promise<MountedFileEntry[]>((resolve, reject) => {
+      request.onsuccess = () => resolve(request.result as MountedFileEntry[]);
+      request.onerror = () =>
+        reject(request.error ?? new Error('IndexedDB read failed'));
+    });
+    await transactionDone(transaction);
+    for (const entry of stored) {
+      if (!mountedFileCache.has(entry.key)) {
+        mountedFileCache.set(entry.key, entry);
+      }
+    }
+    return Array.from(mountedFileCache.values()).filter(
+      (entry) => entry.roomId === roomId
+    );
+  } catch {
+    return cached;
+  } finally {
+    db.close();
+  }
+}
+
+async function collectDirectoryFiles(
+  directory: BrowserDirectoryHandle,
+  vaultName: string,
+  relativeDirectory = ''
+) {
+  const files: File[] = [];
+  const handlesBySourcePath = new Map<string, BrowserWritableFileHandle>();
+
+  for await (const entry of directory.values()) {
+    if (entry.kind === 'directory') {
+      if (IGNORED_DIRECTORIES.has(entry.name)) continue;
+      const nextRelativeDirectory = relativeDirectory
+        ? `${relativeDirectory}/${entry.name}`
+        : entry.name;
+      const nested = await collectDirectoryFiles(
+        entry,
+        vaultName,
+        nextRelativeDirectory
+      );
+      files.push(...nested.files);
+      nested.handlesBySourcePath.forEach((handle, path) =>
+        handlesBySourcePath.set(path, handle)
+      );
+      continue;
+    }
+
+    const sourcePath = normalizePath(
+      relativeDirectory ? `${relativeDirectory}/${entry.name}` : entry.name
+    );
+    if (!sourcePath.toLowerCase().endsWith('.md')) continue;
+
+    const file = await entry.getFile();
+    Object.defineProperty(file, 'webkitRelativePath', {
+      configurable: true,
+      value: `${vaultName}/${sourcePath}`,
+    });
+    files.push(file);
+    handlesBySourcePath.set(sourcePath, entry);
+  }
+
+  return { files, handlesBySourcePath };
+}
+
+export function supportsBrowserLocalVaults() {
+  return (
+    typeof (window as DirectoryPickerWindow).showDirectoryPicker === 'function'
+  );
+}
+
+export async function pickBrowserLocalVault() {
+  const picker = (window as DirectoryPickerWindow).showDirectoryPicker;
+  if (!picker) {
+    throw new Error(
+      'Writable local vaults require desktop Chrome or Edge. This browser can still import a folder copy.'
+    );
+  }
+
+  const directory = await picker({
+    id: 'ewe-note-local-vault',
+    mode: 'readwrite',
+  });
+  const collected = await collectDirectoryFiles(directory, directory.name);
+  return { ...collected, vaultName: directory.name };
+}
+
+export async function registerBrowserLocalVaultFiles(params: {
+  handlesBySourcePath: ReadonlyMap<string, BrowserWritableFileHandle>;
+  notes: readonly BrowserBackedNote[];
+  roomId: string;
+}) {
+  for (const note of params.notes) {
+    if (!note.sourcePath || !note.sourceVault) continue;
+    const handle = params.handlesBySourcePath.get(
+      normalizePath(note.sourcePath)
+    );
+    if (!handle) continue;
+
+    await putMountedFile({
+      handle,
+      key: mountedFileKey(params.roomId, note._id),
+      lastRoomMarkdown: noteMarkdown(note),
+      noteId: note._id,
+      roomId: params.roomId,
+      sourcePath: normalizePath(note.sourcePath),
+      sourceVault: note.sourceVault,
+    });
+  }
+}
+
+export async function writeBrowserLocalVaultNotes(
+  roomId: string,
+  notes: readonly BrowserBackedNote[]
+) {
+  const mountedFiles = await loadMountedFiles(roomId);
+  const noteById = new Map(notes.map((note) => [note._id, note]));
+
+  for (const entry of mountedFiles) {
+    const note = noteById.get(entry.noteId);
+    if (!note) continue;
+    const markdown = noteMarkdown(note);
+    if (markdown === entry.lastRoomMarkdown) continue;
+
+    const previousWrite = writeQueues.get(entry.key) ?? Promise.resolve();
+    const nextWrite = previousWrite.then(async () => {
+      if (markdown === entry.lastRoomMarkdown) return;
+
+      const permission = entry.handle.queryPermission
+        ? await entry.handle.queryPermission({ mode: 'readwrite' })
+        : 'granted';
+      if (permission !== 'granted') return;
+
+      const writable = await entry.handle.createWritable();
+      await writable.write(markdown);
+      await writable.close();
+      entry.lastRoomMarkdown = markdown;
+      await putMountedFile(entry);
+    });
+    writeQueues.set(entry.key, nextWrite);
+    await nextWrite.finally(() => {
+      if (writeQueues.get(entry.key) === nextWrite) {
+        writeQueues.delete(entry.key);
+      }
+    });
+  }
+}
+
+export async function clearBrowserLocalVaultsForTests() {
+  mountedFileCache.clear();
+  writeQueues.clear();
+  const db = await openMountedFilesDb();
+  if (!db) return;
+  try {
+    const transaction = db.transaction(STORE_NAME, 'readwrite');
+    transaction.objectStore(STORE_NAME).clear();
+    await transactionDone(transaction);
+  } finally {
+    db.close();
+  }
+}

--- a/packages/ewe-note/src/app/lib/browser-vault-import.ts
+++ b/packages/ewe-note/src/app/lib/browser-vault-import.ts
@@ -14,6 +14,10 @@ import {
 } from '@eweser/shared';
 import type { Doc } from 'yjs';
 import { putBrowserAttachmentCache } from './browser-attachment-cache';
+import {
+  registerBrowserLocalVaultFiles,
+  type BrowserWritableFileHandle,
+} from './browser-local-vault';
 
 const IGNORED_DIRS = new Set(['.obsidian', '.trash', '.git', 'node_modules']);
 const MARKDOWN_EXTENSION = '.md';
@@ -114,6 +118,7 @@ export type BrowserVaultImportResult = {
   remoteSyncEnabled: boolean;
   skippedPaths: string[];
   warnings: string[];
+  localFileBacked: boolean;
 };
 
 function normalizeSlashes(path: string) {
@@ -511,9 +516,11 @@ async function cacheBrowserAttachmentBytes({
 export async function importVaultFromFiles(params: {
   db: Database;
   files: FileList | File[];
+  handlesBySourcePath?: ReadonlyMap<string, BrowserWritableFileHandle>;
   onProgress?: (progress: BrowserVaultImportProgress) => void;
   remoteSyncEnabled: boolean;
   setSelectedRoom?: (room: Room<Note> | null) => void;
+  targetNoteRoomId?: string;
 }) {
   const prepared = await prepareVaultImport(params.files, params.onProgress);
   if (prepared.noteCount === 0) {
@@ -529,19 +536,25 @@ export async function importVaultFromFiles(params: {
     total: 1,
   });
 
-  const noteRoomId = crypto.randomUUID();
-  const attachmentsRoomId = crypto.randomUUID();
+  const noteRoomId = params.targetNoteRoomId ?? crypto.randomUUID();
+  const attachmentsRoomId = `${noteRoomId}-attachments`;
 
-  params.db.newRoom<Note>({
-    collectionKey: 'notes',
-    id: noteRoomId,
-    name: prepared.vaultName,
-  });
-  params.db.newRoom<FileAttachment>({
-    collectionKey: 'fileAttachments',
-    id: attachmentsRoomId,
-    name: `${prepared.vaultName} Attachments`,
-  });
+  if (!params.db.getRoom<Note>('notes', noteRoomId)) {
+    params.db.newRoom<Note>({
+      collectionKey: 'notes',
+      id: noteRoomId,
+      name: prepared.vaultName,
+    });
+  }
+  if (
+    !params.db.getRoom<FileAttachment>('fileAttachments', attachmentsRoomId)
+  ) {
+    params.db.newRoom<FileAttachment>({
+      collectionKey: 'fileAttachments',
+      id: attachmentsRoomId,
+      name: `${prepared.vaultName} Attachments`,
+    });
+  }
 
   const noteRoom = (await resolveNotesRoom(
     params.db,
@@ -594,6 +607,14 @@ export async function importVaultFromFiles(params: {
       message: `Imported ${note.sourcePath}`,
       phase: 'writing',
       total: prepared.noteCount,
+    });
+  }
+
+  if (params.handlesBySourcePath) {
+    await registerBrowserLocalVaultFiles({
+      handlesBySourcePath: params.handlesBySourcePath,
+      notes: prepared.notes,
+      roomId: noteRoomId,
     });
   }
 
@@ -765,5 +786,6 @@ export async function importVaultFromFiles(params: {
     remoteSyncEnabled: params.remoteSyncEnabled,
     skippedPaths: prepared.skippedPaths,
     warnings,
+    localFileBacked: Boolean(params.handlesBySourcePath),
   } satisfies BrowserVaultImportResult;
 }

--- a/packages/ewe-note/src/app/pages/Settings.test.tsx
+++ b/packages/ewe-note/src/app/pages/Settings.test.tsx
@@ -133,15 +133,15 @@ describe('Settings', () => {
     ).toBeGreaterThan(0);
   });
 
-  it('shows the real vault import entry point in sync settings', () => {
+  it('shows the local vault entry point in sync settings', () => {
     render(<Settings />);
 
     expect(
-      screen.getByRole('button', { name: 'Choose vault folder' })
+      screen.getByRole('button', { name: 'Open vault folder' })
     ).toBeTruthy();
     expect(
       screen.getByText(
-        'Choose an Obsidian vault folder to import markdown locally. Sign in first if you want attachments uploaded and synced across devices.'
+        'Open a local Markdown folder and edit its files in EweNote. Sign in first if you also want the room synced across devices.'
       )
     ).toBeTruthy();
   });

--- a/packages/ewe-note/src/app/pages/Settings.tsx
+++ b/packages/ewe-note/src/app/pages/Settings.tsx
@@ -29,6 +29,10 @@ import {
   type BrowserVaultImportProgress,
   type BrowserVaultImportResult,
 } from '../lib/browser-vault-import';
+import {
+  pickBrowserLocalVault,
+  supportsBrowserLocalVaults,
+} from '../lib/browser-local-vault';
 
 const SETTINGS_SECTIONS = [
   { id: 'account', label: 'Account' },
@@ -143,8 +147,43 @@ export function Settings() {
     target.scrollIntoView({ block: 'start', behavior: 'smooth' });
   };
 
-  const openVaultPicker = () => {
-    vaultInputRef.current?.click();
+  const openVaultPicker = async () => {
+    if (!supportsBrowserLocalVaults()) {
+      vaultInputRef.current?.click();
+      return;
+    }
+
+    setVaultImportError(null);
+    setVaultImportResult(null);
+    try {
+      setVaultImportProgress({
+        current: 0,
+        message: 'Opening local vault',
+        phase: 'parsing',
+        total: 1,
+      });
+      const mounted = await pickBrowserLocalVault();
+      const existingRoom = allRooms.find(
+        (room) => room.name === mounted.vaultName
+      );
+      const result = await importVaultFromFiles({
+        db,
+        files: mounted.files,
+        handlesBySourcePath: mounted.handlesBySourcePath,
+        onProgress: setVaultImportProgress,
+        remoteSyncEnabled: canSyncRemotely,
+        setSelectedRoom,
+        targetNoteRoomId: existingRoom?.id,
+      });
+      setVaultImportResult(result);
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') return;
+      setVaultImportError(
+        error instanceof Error ? error.message : 'Vault open failed.'
+      );
+    } finally {
+      setVaultImportProgress(null);
+    }
   };
 
   const handleVaultInputChange = async (
@@ -413,11 +452,11 @@ export function Settings() {
                     />
                     <InfoBlock
                       icon={Download}
-                      title="Obsidian vault import"
+                      title="Local Markdown vault"
                       description={
                         canSyncRemotely
-                          ? 'Choose an Obsidian vault folder to create synced notes and attachment rooms from the browser.'
-                          : 'Choose an Obsidian vault folder to import markdown locally. Sign in first if you want attachments uploaded and synced across devices.'
+                          ? 'Open a local Markdown folder as an EweNote room. Edits write back to disk and sync across devices.'
+                          : 'Open a local Markdown folder and edit its files in EweNote. Sign in first if you also want the room synced across devices.'
                       }
                     />
                     <div className="space-y-2 rounded-lg bg-accent/35 px-4 py-4">
@@ -452,25 +491,25 @@ export function Settings() {
                     <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                       <div className="space-y-1">
                         <div className="text-sm font-medium text-foreground">
-                          Import an Obsidian vault
+                          Open a local vault
                         </div>
                         <p className="text-sm text-muted-foreground">
                           {canSyncRemotely
-                            ? 'This creates a notes room plus a paired attachment room, then uploads files through the auth API.'
-                            : 'This creates a local notes room immediately. Attachments stay out until sync is enabled.'}
+                            ? 'Markdown files become normal synced EweNote notes while this desktop keeps writable links to the originals.'
+                            : 'Markdown files become normal local EweNote notes and edits write back to the originals.'}
                         </p>
                       </div>
                       <button
                         data-cy="ewe-note-settings-import-vault"
                         disabled={importingVault}
-                        onClick={openVaultPicker}
+                        onClick={() => void openVaultPicker()}
                         type="button"
                         className="inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
                       >
                         <Download className="h-4 w-4" />
                         {importingVault
-                          ? 'Importing vault...'
-                          : 'Choose vault folder'}
+                          ? 'Opening vault...'
+                          : 'Open vault folder'}
                       </button>
                     </div>
 
@@ -506,10 +545,12 @@ export function Settings() {
                         className="space-y-3 rounded-lg border border-border/70 bg-background/70 px-3 py-3 text-sm"
                       >
                         <div className="font-medium text-foreground">
-                          Vault imported
+                          {vaultImportResult.localFileBacked
+                            ? 'Local vault opened'
+                            : 'Vault imported'}
                         </div>
                         <div className="text-muted-foreground">
-                          {vaultImportResult.notesImported} notes imported into{' '}
+                          {vaultImportResult.notesImported} notes available in{' '}
                           {importedRoom?.name ?? 'a new room'}.{' '}
                           {vaultImportResult.remoteSyncEnabled
                             ? `${vaultImportResult.attachmentsUploaded} attachments uploaded`


### PR DESCRIPTION
## What changed

- adds a writable local Markdown folder picker to the existing Settings → Sync screen
- imports mounted Markdown files into normal EweNote rooms and the existing editor
- persists browser file handles locally and writes EweNote edits back to the original files
- reuses an existing room when reopening a folder with the same name
- keeps normal remote room sync enabled when the user is signed in
- scans Markdown files only and skips repository internals such as `.git`, `.obsidian`, `.trash`, and `node_modules`

## Why

EweNote could import a folder copy, but it could not treat a local Markdown folder as a writable vault. This adds the smallest Obsidian-like local-file flow without introducing a separate workspace or product-specific UI.

## User impact

Desktop Chrome and Edge users can open a local Markdown folder from EweNote Settings. Notes remain normal EweNote notes; edits write back to the mounted originals while the browser retains permission. When signed in, the room also follows EweNote's existing cross-device sync behavior.

## Validation

- Vitest: 30 files passed, 178 tests passed
- TypeScript type-check passed
- ESLint passed with zero warnings
- production Vite/PWA build passed
- repository pre-push verification passed
- tracked secret scan passed

## Review surfaces

Private Tailscale access is required.

- Interactive application: https://jacob-x99.tailf1b083.ts.net:15702/settings#sync
- Sanitized screenshot and test summary: https://jacob-x99.tailf1b083.ts.net:15703/

Both previews are signed out and contain only a fresh synthetic local room. They are scheduled to stop at approximately 08:06 CST on 2026-07-21.