### PR TITLE
Fix stale EweNote rooms after registry sync

### DIFF
--- a/.changeset/clean-rooms-after-registry-sync.md
+++ b/.changeset/clean-rooms-after-registry-sync.md
@@ -1,5 +1,6 @@
 ---
 '@eweser/db': patch
+'@eweser/shared': patch
 ---
 
-Remove stale loaded rooms after the signed-in server registry has removed them, while preserving rooms initialized by the current local app.
+Reconcile stale loaded rooms after registry sync without letting cached rooms recreate themselves server-side.

--- a/.changeset/clean-rooms-after-registry-sync.md
+++ b/.changeset/clean-rooms-after-registry-sync.md
@@ -1,0 +1,5 @@
+---
+'@eweser/db': patch
+---
+
+Remove stale loaded rooms after the signed-in server registry has removed them, while preserving rooms initialized by the current local app.

--- a/packages/auth-server-hono/src/routes/access-grant.test.ts
+++ b/packages/auth-server-hono/src/routes/access-grant.test.ts
@@ -116,13 +116,18 @@ describe('accessGrantRouter', () => {
           authorization: 'Bearer access-token',
           'content-type': 'application/json',
         },
-        body: JSON.stringify({ rooms: [{ id: 'room-1' }] }),
+        body: JSON.stringify({
+          rooms: [{ id: 'room-1' }],
+          newRoomIds: ['room-1'],
+        }),
       })
     );
 
-    expect(syncRoomsWithClientMock).toHaveBeenCalledWith('access-token', [
-      { id: 'room-1' },
-    ]);
+    expect(syncRoomsWithClientMock).toHaveBeenCalledWith(
+      'access-token',
+      [{ id: 'room-1' }],
+      ['room-1']
+    );
     expect(res.status).toBe(200);
   });
 

--- a/packages/auth-server-hono/src/routes/access-grant.ts
+++ b/packages/auth-server-hono/src/routes/access-grant.ts
@@ -49,7 +49,10 @@ accessGrantRouter.post('/sync-registry', async (c) => {
   if (!token) return c.json({ error: 'No token provided' }, 401);
 
   const body = (await c.req.json()) as RegistrySyncRequestBody;
-  const result = await syncRoomsWithClient(token, body.rooms);
+  const newRoomIds = Array.isArray(body.newRoomIds)
+    ? body.newRoomIds.filter((id): id is string => typeof id === 'string')
+    : [];
+  const result = await syncRoomsWithClient(token, body.rooms, newRoomIds);
   return c.json(result);
 });
 

--- a/packages/auth-server-hono/src/services/rooms/sync-rooms-with-client.test.ts
+++ b/packages/auth-server-hono/src/services/rooms/sync-rooms-with-client.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../db/drizzle.js', () => ({ db: {} }));
+vi.mock('../../env.js', () => ({ env: {} }));
+vi.mock('../../model/access_grants.js', () => ({
+  parseAccessGrantId: vi.fn(),
+  updateAccessGrant: vi.fn(),
+}));
+vi.mock('../../model/rooms/calls.js', () => ({
+  getRoomsFromAccessGrant: vi.fn(),
+  insertRooms: vi.fn(),
+  updateRoom: vi.fn(),
+}));
+
+const { getNewClientRooms } = await import('./sync-rooms-with-client.js');
+
+describe('getNewClientRooms', () => {
+  it('does not recreate cached rooms missing from the server grant', () => {
+    const staleRoom = {
+      id: 'stale-room',
+      name: 'Old notes',
+      collectionKey: 'notes',
+    };
+    const newRoom = {
+      id: 'new-room',
+      name: 'Current notes',
+      collectionKey: 'notes',
+    };
+
+    expect(
+      getNewClientRooms([staleRoom, newRoom], new Set(), [newRoom.id])
+    ).toEqual([newRoom]);
+  });
+
+  it('does not create a room that the client marked deleted', () => {
+    const deletedRoom = {
+      id: 'deleted-room',
+      name: 'Deleted notes',
+      collectionKey: 'notes',
+      _deleted: true,
+    };
+
+    expect(
+      getNewClientRooms([deletedRoom], new Set(), [deletedRoom.id])
+    ).toEqual([]);
+  });
+});

--- a/packages/auth-server-hono/src/services/rooms/sync-rooms-with-client.ts
+++ b/packages/auth-server-hono/src/services/rooms/sync-rooms-with-client.ts
@@ -19,13 +19,29 @@ export interface AccessGrantJWT {
   roomIds: string[];
 }
 
+export function getNewClientRooms(
+  clientRooms: ServerRoom[],
+  serverRoomIds: Set<string>,
+  newRoomIds: string[]
+) {
+  const pendingRoomIds = new Set(newRoomIds);
+
+  return clientRooms.filter(
+    (room) =>
+      pendingRoomIds.has(room.id) &&
+      !serverRoomIds.has(room.id) &&
+      !room._deleted
+  );
+}
+
 /**
  * Syncs client rooms with server.
  * Hard cutover: uses syncUrl/syncBaseUrl directly.
  */
 export async function syncRoomsWithClient(
   token: string,
-  clientRooms: ServerRoom[]
+  clientRooms: ServerRoom[],
+  newRoomIds: string[]
 ): Promise<RegistrySyncResponse> {
   const secret = env.SERVER_SECRET;
   const decoded = jwt.verify(token, secret) as AccessGrantJWT;
@@ -52,9 +68,13 @@ export async function syncRoomsWithClient(
     const serverRoomIdSet = new Set(serverRoomIds);
     const serverRoomsById = new Map(serverRooms.map((room) => [room.id, room]));
 
-    // Identify new rooms from client
-    const newClientRooms = clientRooms.filter(
-      (r) => !serverRoomIdSet.has(r.id)
+    // Only rooms explicitly created by this client may be added to the
+    // authoritative server registry. Cached rooms omitted from a grant must
+    // remain omitted so a stale device cannot recreate them.
+    const newClientRooms = getNewClientRooms(
+      clientRooms,
+      serverRoomIdSet,
+      newRoomIds
     );
 
     if (newClientRooms.length > 0) {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -101,6 +101,9 @@ export class Database extends TypedEventEmitter<DatabaseEvents> {
   collectionKeys: CollectionKey[] = collectionKeys;
   collections: Collections = collections;
   registry: Registry = [];
+  /** @internal Rooms supplied by this app instance remain available locally
+   * even when the signed-in server registry does not contain them. */
+  _initialRoomIds = new Set<string>();
   accessGrantToken = '';
 
   // METHODS
@@ -277,7 +280,9 @@ export class Database extends TypedEventEmitter<DatabaseEvents> {
     if (options.initialRooms) {
       const registryRoomIds = this.registry.map((r) => r.id);
       for (const room of options.initialRooms) {
-        const registryRoom = roomToServerRoom(this.newRoom<EweDocument>(room));
+        const initializedRoom = this.newRoom<EweDocument>(room);
+        this._initialRoomIds.add(initializedRoom.id);
+        const registryRoom = roomToServerRoom(initializedRoom);
         if (room.id && !registryRoomIds.includes(room.id)) {
           this.registry.push(registryRoom);
         }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -104,6 +104,8 @@ export class Database extends TypedEventEmitter<DatabaseEvents> {
   /** @internal Rooms supplied by this app instance remain available locally
    * even when the signed-in server registry does not contain them. */
   _initialRoomIds = new Set<string>();
+  /** @internal Locally created rooms that still need server registration. */
+  _pendingRegistryRoomIds = new Set<string>();
   accessGrantToken = '';
 
   // METHODS

--- a/packages/db/src/methods/connection/syncRegistry.test.ts
+++ b/packages/db/src/methods/connection/syncRegistry.test.ts
@@ -73,4 +73,69 @@ describe('syncRegistry', () => {
     expect(db.accessGrantToken).toBe('next-token');
     expect(db.registry).toEqual(rooms);
   });
+
+  it('unloads stale rooms after the server removes them while preserving current initial rooms', async () => {
+    const staleRoom = {
+      id: 'stale-room',
+      name: 'Old synced notes',
+      collectionKey: 'notes',
+    };
+    const localRoom = {
+      id: 'local-room',
+      name: 'Current local notes',
+      collectionKey: 'notes',
+    };
+    const canonicalRoom = {
+      id: 'canonical-room',
+      name: 'Notes',
+      collectionKey: 'notes',
+    };
+    const staleDisconnect = vi.fn();
+    const localDisconnect = vi.fn();
+    const canonicalDisconnect = vi.fn();
+    const notes = {
+      [staleRoom.id]: { ...staleRoom, disconnect: staleDisconnect },
+      [localRoom.id]: { ...localRoom, disconnect: localDisconnect },
+      [canonicalRoom.id]: {
+        ...canonicalRoom,
+        disconnect: canonicalDisconnect,
+      },
+    };
+    let staleRoomPresentWhenSuccessEmitted = true;
+
+    const db = {
+      registry: [staleRoom, localRoom, canonicalRoom],
+      collections: { notes },
+      _initialRoomIds: new Set([localRoom.id]),
+      userId: '',
+      accessGrantToken: '',
+      getToken: () => 'token',
+      emit: vi.fn((event: string, status: string) => {
+        if (event === 'registrySync' && status === 'success') {
+          staleRoomPresentWhenSuccessEmitted = staleRoom.id in notes;
+        }
+      }),
+      info: vi.fn(),
+      debug: vi.fn(),
+      serverFetch: vi.fn().mockResolvedValue({
+        data: {
+          rooms: [canonicalRoom],
+          token: 'next-token',
+          userId: 'user-1',
+        },
+        error: null,
+      }),
+    } as unknown as Database;
+
+    const result = await syncRegistry(db)();
+
+    expect(result).toBe(true);
+    expect(staleDisconnect).toHaveBeenCalledOnce();
+    expect(notes).not.toHaveProperty(staleRoom.id);
+    expect(localDisconnect).not.toHaveBeenCalled();
+    expect(notes).toHaveProperty(localRoom.id);
+    expect(canonicalDisconnect).not.toHaveBeenCalled();
+    expect(notes).toHaveProperty(canonicalRoom.id);
+    expect(staleRoomPresentWhenSuccessEmitted).toBe(false);
+  });
 });

--- a/packages/db/src/methods/connection/syncRegistry.test.ts
+++ b/packages/db/src/methods/connection/syncRegistry.test.ts
@@ -18,6 +18,7 @@ describe('syncRegistry', () => {
   it('returns false when token is missing', async () => {
     const db = {
       registry: [],
+      _pendingRegistryRoomIds: new Set(),
       getToken: () => '',
       emit: vi.fn(),
       serverFetch: vi.fn(),
@@ -32,6 +33,7 @@ describe('syncRegistry', () => {
   it('returns false when server fetch returns error', async () => {
     const db = {
       registry: [],
+      _pendingRegistryRoomIds: new Set(),
       userId: '',
       accessGrantToken: '',
       getToken: () => 'token',
@@ -52,6 +54,7 @@ describe('syncRegistry', () => {
 
     const db = {
       registry: [],
+      _pendingRegistryRoomIds: new Set(),
       userId: '',
       accessGrantToken: '',
       getToken: () => 'token',
@@ -107,6 +110,7 @@ describe('syncRegistry', () => {
       registry: [staleRoom, localRoom, canonicalRoom],
       collections: { notes },
       _initialRoomIds: new Set([localRoom.id]),
+      _pendingRegistryRoomIds: new Set(),
       userId: '',
       accessGrantToken: '',
       getToken: () => 'token',
@@ -137,5 +141,38 @@ describe('syncRegistry', () => {
     expect(canonicalDisconnect).not.toHaveBeenCalled();
     expect(notes).toHaveProperty(canonicalRoom.id);
     expect(staleRoomPresentWhenSuccessEmitted).toBe(false);
+  });
+
+  it('sends only locally created rooms as pending registrations', async () => {
+    const newRoom = {
+      id: 'new-room',
+      name: 'New notes',
+      collectionKey: 'notes',
+    };
+    const db = {
+      registry: [newRoom],
+      _pendingRegistryRoomIds: new Set([newRoom.id]),
+      userId: '',
+      accessGrantToken: '',
+      getToken: () => 'token',
+      emit: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      serverFetch: vi.fn().mockResolvedValue({
+        data: { rooms: [newRoom], token: 'next-token', userId: 'user-1' },
+        error: null,
+      }),
+    } as unknown as Database;
+
+    await syncRegistry(db)();
+
+    expect(db.serverFetch).toHaveBeenCalledWith(
+      '/api/access-grant/sync-registry',
+      {
+        method: 'POST',
+        body: { rooms: [newRoom], newRoomIds: [newRoom.id] },
+      }
+    );
+    expect(db._pendingRegistryRoomIds).toEqual(new Set());
   });
 });

--- a/packages/db/src/methods/connection/syncRegistry.ts
+++ b/packages/db/src/methods/connection/syncRegistry.ts
@@ -41,8 +41,10 @@ export const syncRegistry =
   async () => {
     db.emit('registrySync', 'syncing');
     const previousRooms = [...db.registry];
+    const newRoomIds = [...db._pendingRegistryRoomIds];
     const body: RegistrySyncRequestBody = {
       rooms: db.registry,
+      newRoomIds,
     };
     if (!db.getToken()) {
       return false;
@@ -82,6 +84,9 @@ export const syncRegistry =
       unloadRoomsMissingFromRegistry(db, previousRooms, rooms);
       setLocalRegistry(db)(rooms);
       db.registry = rooms;
+      for (const roomId of newRoomIds) {
+        db._pendingRegistryRoomIds.delete(roomId);
+      }
     } else {
       return false;
     }

--- a/packages/db/src/methods/connection/syncRegistry.ts
+++ b/packages/db/src/methods/connection/syncRegistry.ts
@@ -8,11 +8,39 @@ import {
 } from '../../utils/localStorageService.js';
 import type { Database } from '../../index.js';
 
+function unloadRoomsMissingFromRegistry(
+  db: Database,
+  previousRooms: Database['registry'],
+  serverRooms: Database['registry']
+) {
+  const serverRoomIds = new Set(serverRooms.map((room) => room.id));
+
+  for (const previousRoom of previousRooms) {
+    if (
+      serverRoomIds.has(previousRoom.id) ||
+      db._initialRoomIds.has(previousRoom.id)
+    ) {
+      continue;
+    }
+
+    const loadedRoom =
+      db.collections[previousRoom.collectionKey][previousRoom.id];
+    if (!loadedRoom) continue;
+
+    loadedRoom.disconnect();
+    Reflect.deleteProperty(
+      db.collections[previousRoom.collectionKey],
+      previousRoom.id
+    );
+  }
+}
+
 export const syncRegistry =
   (db: Database) =>
   /** sends the registry to the server to check for additions/subtractions on either side */
   async () => {
     db.emit('registrySync', 'syncing');
+    const previousRooms = [...db.registry];
     const body: RegistrySyncRequestBody = {
       rooms: db.registry,
     };
@@ -28,7 +56,6 @@ export const syncRegistry =
       db.emit('registrySync', 'error', error);
       return false;
     }
-    db.emit('registrySync', 'success');
     db.info('syncResult', syncResult);
 
     const { rooms, token, userId } = syncResult ?? {};
@@ -52,11 +79,13 @@ export const syncRegistry =
     ) {
       db.debug('setting new rooms', rooms);
       // TODO: if a new room was created locally before the sync finishes, this might overwrite it
+      unloadRoomsMissingFromRegistry(db, previousRooms, rooms);
       setLocalRegistry(db)(rooms);
       db.registry = rooms;
     } else {
       return false;
     }
 
+    db.emit('registrySync', 'success');
     return true;
   };

--- a/packages/db/src/methods/newRoom.test.ts
+++ b/packages/db/src/methods/newRoom.test.ts
@@ -17,6 +17,7 @@ describe('newRoom', () => {
     const db = {
       collections: { notes: {}, flashcards: {}, profiles: {} },
       registry: [],
+      _pendingRegistryRoomIds: new Set<string>(),
       online: false,
       debug: vi.fn(),
       loadRoom: vi.fn(),
@@ -33,6 +34,7 @@ describe('newRoom', () => {
     expect(db.collections.notes['room-1']).toBeDefined();
     expect(db.registry).toHaveLength(1);
     expect(db.registry[0]?.id).toBe('room-1');
+    expect(db._pendingRegistryRoomIds).toEqual(new Set(['room-1']));
     expect(setLocalRegistryMock).toHaveBeenCalledWith(db.registry);
     expect(db.loadRoom).toHaveBeenCalledWith(created);
     expect(db.syncRegistry).not.toHaveBeenCalled();
@@ -42,6 +44,7 @@ describe('newRoom', () => {
     const db = {
       collections: { notes: {}, flashcards: {}, profiles: {} },
       registry: [],
+      _pendingRegistryRoomIds: new Set<string>(),
       online: true,
       debug: vi.fn(),
       loadRoom: vi.fn(),

--- a/packages/db/src/methods/newRoom.ts
+++ b/packages/db/src/methods/newRoom.ts
@@ -23,6 +23,7 @@ export const newRoom =
 
     const registryRoom = roomToServerRoom(room);
     db.registry.push(registryRoom);
+    db._pendingRegistryRoomIds.add(room.id);
     setLocalRegistry(db)(db.registry);
 
     db.loadRoom(room as unknown as Room<EweDocument>);

--- a/packages/shared/src/api/registry-sync.ts
+++ b/packages/shared/src/api/registry-sync.ts
@@ -2,6 +2,8 @@ import type { ServerRoom } from '../index.js';
 
 export type RegistrySyncRequestBody = {
   rooms: ServerRoom[];
+  /** Room IDs created locally since the last successful registry sync. */
+  newRoomIds: string[];
 };
 
 export type RegistrySyncResponse = {


### PR DESCRIPTION
## What changed

- Treat the signed-in server registry as authoritative for cached rooms.
- Register only room IDs created locally since the last successful sync; a stale cache cannot recreate removed rooms.
- Disconnect and unload rooms no longer granted, while keeping the current app-local initial room available.
- Emit registry-sync success only after reconciliation finishes.
- Add regression coverage for the client request, server admission policy, stale-room cleanup, and local-room preservation.

## Root cause

The sync endpoint treated every client room missing from the grant as a creation request. A device with a stale cache therefore recreated its old rooms before receiving the server registry, so client-side cleanup alone could not work.

## Sync flow

```mermaid
flowchart LR
    A[Cached device registry] --> B[Send registry plus pending local creations]
    B --> C[Server returns authoritative granted rooms]
    C --> D[Unload cached rooms not granted]
    D --> E[Emit sync success]
    E --> F[EweNote sidebar shows current rooms]
```

## Verification

- `npm test --workspace @eweser/db` — 111 passed, 1 todo.
- `npm test --workspace @eweser/auth-server-hono` — 195 passed.
- Type checks passed for `@eweser/shared`, `@eweser/db`, and `@eweser/auth-server-hono`.
- Lint passed for `@eweser/db`, `@eweser/auth-server-hono`, and all changed files.
- Builds passed for `@eweser/shared`, `@eweser/db`, `@eweser/auth-server-hono`, and `@eweser/mcp`.
- Pre-commit and pre-push formatting and secret scans passed.

## Review surfaces

- Interactive fixture app: https://pursuant-characterization-coverage-spa.trycloudflare.com/
- Evidence gallery/test summary: https://pursuant-characterization-coverage-spa.trycloudflare.com/review/
- Tested route: `/?delay=10000` (three stale rooms shown before reconciliation, then removed).
- Data/auth mode: synthetic fixture data only; no production bindings, credentials, or customer data.
- Visual assessment: the sidebar remains aligned and unclipped; long room labels wrap inside the fixed width, and removing rows leaves no gaps or overflow.
- Lifetime: this review session (up to two hours).
- Cleanup: `pkill -f "ewenote-pr66-review|cloudflared tunnel --url http://127.0.0.1:5294"`.