### PR TITLE
feat: harden EweNote local-vault write-back with permission re-request, vault-room mapping, and recursive frontmatter

### DIFF
--- a/.changeset/obsidian-nested-frontmatter.md
+++ b/.changeset/obsidian-nested-frontmatter.md
@@ -1,0 +1,5 @@
+---
+'@eweser/shared': patch
+---
+
+Preserve nested arrays and objects when parsing and serializing Obsidian frontmatter.

--- a/packages/ewe-note/src/app/lib/browser-local-vault.test.ts
+++ b/packages/ewe-note/src/app/lib/browser-local-vault.test.ts
@@ -154,15 +154,54 @@ describe('browser local vault bridge', () => {
     expect(getBrowserLocalVaultPermissionState('room-1')).toBe('denied');
   });
 
-  it('stores and retrieves vault room mappings', async () => {
-    await setBrowserLocalVaultRoomId('my-vault', 'room-abc');
-    const roomId = await getBrowserLocalVaultRoomId('my-vault');
+  it('stores and retrieves vault room mappings by directory identity', async () => {
+    const directory: BrowserDirectoryHandle = {
+      kind: 'directory',
+      name: 'my-vault',
+      async isSameEntry(other) {
+        return other === directory;
+      },
+      async *values() {},
+    };
+
+    await setBrowserLocalVaultRoomId(directory, 'room-abc');
+    const roomId = await getBrowserLocalVaultRoomId(directory);
     expect(roomId).toBe('room-abc');
   });
 
-  it('returns null for unknown vault room mappings', async () => {
-    const roomId = await getBrowserLocalVaultRoomId('nonexistent');
-    expect(roomId).toBeNull();
+  it('keeps same-named directories mapped to separate rooms', async () => {
+    const first: BrowserDirectoryHandle = {
+      kind: 'directory',
+      name: 'notes',
+      async isSameEntry(other) {
+        return other === first;
+      },
+      async *values() {},
+    };
+    const second: BrowserDirectoryHandle = {
+      kind: 'directory',
+      name: 'notes',
+      async isSameEntry(other) {
+        return other === second;
+      },
+      async *values() {},
+    };
+
+    await setBrowserLocalVaultRoomId(first, 'room-a');
+    await setBrowserLocalVaultRoomId(second, 'room-b');
+
+    expect(await getBrowserLocalVaultRoomId(first)).toBe('room-a');
+    expect(await getBrowserLocalVaultRoomId(second)).toBe('room-b');
+  });
+
+  it('returns null for an unknown vault directory', async () => {
+    const unknown: BrowserDirectoryHandle = {
+      kind: 'directory',
+      name: 'nonexistent',
+      async *values() {},
+    };
+
+    expect(await getBrowserLocalVaultRoomId(unknown)).toBeNull();
   });
 
   it('returns none when no mounted files exist for permission check', () => {

--- a/packages/ewe-note/src/app/lib/browser-local-vault.test.ts
+++ b/packages/ewe-note/src/app/lib/browser-local-vault.test.ts
@@ -3,8 +3,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { indexedDB } from 'fake-indexeddb';
 import {
   clearBrowserLocalVaultsForTests,
+  getBrowserLocalVaultPermissionState,
+  getBrowserLocalVaultRoomId,
   pickBrowserLocalVault,
   registerBrowserLocalVaultFiles,
+  setBrowserLocalVaultRoomId,
   writeBrowserLocalVaultNotes,
   type BrowserDirectoryHandle,
   type BrowserWritableFileHandle,
@@ -107,5 +110,62 @@ describe('browser local vault bridge', () => {
 
     expect(write).toHaveBeenCalledWith('# Updated in EweNote\n');
     expect(fileContents).toBe('# Updated in EweNote\n');
+  });
+
+  it('tracks permission as denied when queryPermission+requestPermission both deny', async () => {
+    let fileContents = '# Original\n';
+    const handle: BrowserWritableFileHandle = {
+      kind: 'file',
+      name: 'note.md',
+      getFile: async () => new File([fileContents], 'note.md'),
+      queryPermission: async () => 'prompt',
+      requestPermission: async () => 'denied',
+      createWritable: async () => ({
+        write: async (next: string) => {
+          fileContents = next;
+        },
+        close: async () => undefined,
+      }),
+    };
+    const note = {
+      _id: 'n1',
+      frontmatter: {},
+      sourcePath: 'note.md',
+      sourceVault: 'my-vault',
+      text: '# Original\n',
+    };
+
+    await registerBrowserLocalVaultFiles({
+      handlesBySourcePath: new Map([['note.md', handle]]),
+      notes: [note],
+      roomId: 'room-1',
+    });
+
+    // Before write, permission should be 'granted' (no denials yet)
+    expect(getBrowserLocalVaultPermissionState('room-1')).toBe('granted');
+
+    await writeBrowserLocalVaultNotes('room-1', [
+      { ...note, text: '# Changed but denied\n' },
+    ]);
+
+    // Write should NOT have happened
+    expect(fileContents).toBe('# Original\n');
+    // Permission state should reflect denied
+    expect(getBrowserLocalVaultPermissionState('room-1')).toBe('denied');
+  });
+
+  it('stores and retrieves vault room mappings', async () => {
+    await setBrowserLocalVaultRoomId('my-vault', 'room-abc');
+    const roomId = await getBrowserLocalVaultRoomId('my-vault');
+    expect(roomId).toBe('room-abc');
+  });
+
+  it('returns null for unknown vault room mappings', async () => {
+    const roomId = await getBrowserLocalVaultRoomId('nonexistent');
+    expect(roomId).toBeNull();
+  });
+
+  it('returns none when no mounted files exist for permission check', () => {
+    expect(getBrowserLocalVaultPermissionState('empty-room')).toBe('none');
   });
 });

--- a/packages/ewe-note/src/app/lib/browser-local-vault.ts
+++ b/packages/ewe-note/src/app/lib/browser-local-vault.ts
@@ -2,8 +2,9 @@ import type { Note } from '@eweser/db';
 import { serializeFrontmatter } from '@eweser/shared';
 
 const DB_NAME = 'ewe-note-browser-local-vaults';
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 const STORE_NAME = 'mounted-files';
+const VAULT_ROOM_STORE = 'vault-rooms';
 const IGNORED_DIRECTORIES = new Set([
   '.git',
   '.obsidian',
@@ -22,6 +23,9 @@ export type BrowserWritableFileHandle = {
   getFile(): Promise<File>;
   createWritable(): Promise<BrowserWritable>;
   queryPermission?(options: { mode: 'readwrite' }): Promise<PermissionState>;
+  requestPermission?(options: {
+    mode: 'readwrite';
+  }): Promise<PermissionState>;
 };
 
 export type BrowserDirectoryHandle = {
@@ -56,6 +60,8 @@ type MountedFileEntry = {
 
 const mountedFileCache = new Map<string, MountedFileEntry>();
 const writeQueues = new Map<string, Promise<void>>();
+const permissionDeniedKeys = new Set<string>();
+const vaultRoomCache = new Map<string, string>();
 
 function mountedFileKey(roomId: string, noteId: string) {
   return `${roomId}\u0000${noteId}`;
@@ -92,6 +98,11 @@ async function openMountedFilesDb(): Promise<IDBDatabase | null> {
       if (!request.result.objectStoreNames.contains(STORE_NAME)) {
         request.result.createObjectStore(STORE_NAME, { keyPath: 'key' });
       }
+      if (!request.result.objectStoreNames.contains(VAULT_ROOM_STORE)) {
+        request.result.createObjectStore(VAULT_ROOM_STORE, {
+          keyPath: 'vaultName',
+        });
+      }
     };
     request.onsuccess = () => resolve(request.result);
     request.onerror = () =>
@@ -115,6 +126,59 @@ async function putMountedFile(entry: MountedFileEntry) {
     db.close();
   }
 }
+
+async function getVaultRoomId(vaultName: string): Promise<string | null> {
+  const cached = vaultRoomCache.get(vaultName);
+  if (cached) return cached;
+
+  const db = await openMountedFilesDb();
+  if (!db) return null;
+
+  try {
+    const transaction = db.transaction(VAULT_ROOM_STORE, 'readonly');
+    const request = transaction.objectStore(VAULT_ROOM_STORE).get(vaultName);
+    const result = await new Promise<
+      { vaultName: string; roomId: string } | undefined
+    >((resolve, reject) => {
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () =>
+        reject(request.error ?? new Error('IndexedDB read failed'));
+    });
+    await transactionDone(transaction);
+    if (result?.roomId) {
+      vaultRoomCache.set(vaultName, result.roomId);
+      return result.roomId;
+    }
+    return null;
+  } catch {
+    return null;
+  } finally {
+    db.close();
+  }
+}
+
+async function setVaultRoomId(vaultName: string, roomId: string) {
+  vaultRoomCache.set(vaultName, roomId);
+  const db = await openMountedFilesDb();
+  if (!db) return;
+
+  try {
+    const transaction = db.transaction(VAULT_ROOM_STORE, 'readwrite');
+    transaction.objectStore(VAULT_ROOM_STORE).put({ vaultName, roomId });
+    await transactionDone(transaction);
+  } catch {
+    // Non-critical — persist best-effort
+  } finally {
+    db.close();
+  }
+}
+
+export {
+  /** Look up a saved room id for a given vault directory name. */
+  getVaultRoomId as getBrowserLocalVaultRoomId,
+  /** Persist the room id associated with a vault directory name. */
+  setVaultRoomId as setBrowserLocalVaultRoomId,
+};
 
 async function loadMountedFiles(roomId: string) {
   const cached = Array.from(mountedFileCache.values()).filter(
@@ -253,10 +317,25 @@ export async function writeBrowserLocalVaultNotes(
     const nextWrite = previousWrite.then(async () => {
       if (markdown === entry.lastRoomMarkdown) return;
 
-      const permission = entry.handle.queryPermission
-        ? await entry.handle.queryPermission({ mode: 'readwrite' })
-        : 'granted';
-      if (permission !== 'granted') return;
+      let permission: PermissionState = 'granted';
+      if (entry.handle.queryPermission) {
+        permission = await entry.handle.queryPermission({
+          mode: 'readwrite',
+        });
+      }
+
+      if (permission !== 'granted' && entry.handle.requestPermission) {
+        permission = await entry.handle.requestPermission({
+          mode: 'readwrite',
+        });
+      }
+
+      if (permission !== 'granted') {
+        permissionDeniedKeys.add(entry.key);
+        return;
+      }
+
+      permissionDeniedKeys.delete(entry.key);
 
       const writable = await entry.handle.createWritable();
       await writable.write(markdown);
@@ -276,13 +355,39 @@ export async function writeBrowserLocalVaultNotes(
 export async function clearBrowserLocalVaultsForTests() {
   mountedFileCache.clear();
   writeQueues.clear();
+  permissionDeniedKeys.clear();
+  vaultRoomCache.clear();
   const db = await openMountedFilesDb();
   if (!db) return;
   try {
-    const transaction = db.transaction(STORE_NAME, 'readwrite');
+    const transaction = db.transaction(
+      [STORE_NAME, VAULT_ROOM_STORE],
+      'readwrite'
+    );
     transaction.objectStore(STORE_NAME).clear();
+    transaction.objectStore(VAULT_ROOM_STORE).clear();
     await transactionDone(transaction);
   } finally {
     db.close();
   }
+}
+
+export function getBrowserLocalVaultPermissionState(
+  roomId: string
+): 'granted' | 'partial' | 'denied' | 'none' {
+  const entries = Array.from(mountedFileCache.values()).filter(
+    (entry) => entry.roomId === roomId
+  );
+  if (entries.length === 0) return 'none';
+
+  let deniedCount = 0;
+  for (const entry of entries) {
+    if (permissionDeniedKeys.has(entry.key)) {
+      deniedCount++;
+    }
+  }
+
+  if (deniedCount === 0) return 'granted';
+  if (deniedCount === entries.length) return 'denied';
+  return 'partial';
 }

--- a/packages/ewe-note/src/app/lib/browser-local-vault.ts
+++ b/packages/ewe-note/src/app/lib/browser-local-vault.ts
@@ -2,7 +2,7 @@ import type { Note } from '@eweser/db';
 import { serializeFrontmatter } from '@eweser/shared';
 
 const DB_NAME = 'ewe-note-browser-local-vaults';
-const DB_VERSION = 2;
+const DB_VERSION = 3;
 const STORE_NAME = 'mounted-files';
 const VAULT_ROOM_STORE = 'vault-rooms';
 const IGNORED_DIRECTORIES = new Set([
@@ -23,14 +23,13 @@ export type BrowserWritableFileHandle = {
   getFile(): Promise<File>;
   createWritable(): Promise<BrowserWritable>;
   queryPermission?(options: { mode: 'readwrite' }): Promise<PermissionState>;
-  requestPermission?(options: {
-    mode: 'readwrite';
-  }): Promise<PermissionState>;
+  requestPermission?(options: { mode: 'readwrite' }): Promise<PermissionState>;
 };
 
 export type BrowserDirectoryHandle = {
   kind: 'directory';
   name: string;
+  isSameEntry?(other: BrowserDirectoryHandle): Promise<boolean>;
   values(): AsyncIterableIterator<
     BrowserDirectoryHandle | BrowserWritableFileHandle
   >;
@@ -58,10 +57,17 @@ type MountedFileEntry = {
   sourceVault: string;
 };
 
+type VaultRoomBinding = {
+  vaultId: string;
+  directoryHandle: BrowserDirectoryHandle;
+  roomId: string;
+  vaultName: string;
+};
+
 const mountedFileCache = new Map<string, MountedFileEntry>();
 const writeQueues = new Map<string, Promise<void>>();
 const permissionDeniedKeys = new Set<string>();
-const vaultRoomCache = new Map<string, string>();
+const vaultRoomCache: VaultRoomBinding[] = [];
 
 function mountedFileKey(roomId: string, noteId: string) {
   return `${roomId}\u0000${noteId}`;
@@ -98,9 +104,20 @@ async function openMountedFilesDb(): Promise<IDBDatabase | null> {
       if (!request.result.objectStoreNames.contains(STORE_NAME)) {
         request.result.createObjectStore(STORE_NAME, { keyPath: 'key' });
       }
+      const existingVaultRoomStore = request.result.objectStoreNames.contains(
+        VAULT_ROOM_STORE
+      )
+        ? request.transaction?.objectStore(VAULT_ROOM_STORE)
+        : null;
+      if (
+        existingVaultRoomStore &&
+        existingVaultRoomStore.keyPath !== 'vaultId'
+      ) {
+        request.result.deleteObjectStore(VAULT_ROOM_STORE);
+      }
       if (!request.result.objectStoreNames.contains(VAULT_ROOM_STORE)) {
         request.result.createObjectStore(VAULT_ROOM_STORE, {
-          keyPath: 'vaultName',
+          keyPath: 'vaultId',
         });
       }
     };
@@ -127,27 +144,49 @@ async function putMountedFile(entry: MountedFileEntry) {
   }
 }
 
-async function getVaultRoomId(vaultName: string): Promise<string | null> {
-  const cached = vaultRoomCache.get(vaultName);
-  if (cached) return cached;
+async function isSameDirectory(
+  first: BrowserDirectoryHandle,
+  second: BrowserDirectoryHandle
+): Promise<boolean> {
+  if (first === second) return true;
+  try {
+    if (first.isSameEntry) return await first.isSameEntry(second);
+    if (second.isSameEntry) return await second.isSameEntry(first);
+  } catch {
+    return false;
+  }
+  return false;
+}
 
+async function findVaultRoomBinding(
+  directoryHandle: BrowserDirectoryHandle
+): Promise<VaultRoomBinding | null> {
+  for (const binding of vaultRoomCache) {
+    if (await isSameDirectory(binding.directoryHandle, directoryHandle)) {
+      return binding;
+    }
+  }
   const db = await openMountedFilesDb();
   if (!db) return null;
 
   try {
     const transaction = db.transaction(VAULT_ROOM_STORE, 'readonly');
-    const request = transaction.objectStore(VAULT_ROOM_STORE).get(vaultName);
-    const result = await new Promise<
-      { vaultName: string; roomId: string } | undefined
-    >((resolve, reject) => {
+    const request = transaction.objectStore(VAULT_ROOM_STORE).getAll();
+    const results = await new Promise<VaultRoomBinding[]>((resolve, reject) => {
       request.onsuccess = () => resolve(request.result);
       request.onerror = () =>
         reject(request.error ?? new Error('IndexedDB read failed'));
     });
     await transactionDone(transaction);
-    if (result?.roomId) {
-      vaultRoomCache.set(vaultName, result.roomId);
-      return result.roomId;
+    for (const binding of results) {
+      if (
+        binding?.roomId &&
+        binding.directoryHandle &&
+        (await isSameDirectory(binding.directoryHandle, directoryHandle))
+      ) {
+        vaultRoomCache.push(binding);
+        return binding;
+      }
     }
     return null;
   } catch {
@@ -157,14 +196,40 @@ async function getVaultRoomId(vaultName: string): Promise<string | null> {
   }
 }
 
-async function setVaultRoomId(vaultName: string, roomId: string) {
-  vaultRoomCache.set(vaultName, roomId);
+async function getVaultRoomId(
+  directoryHandle: BrowserDirectoryHandle
+): Promise<string | null> {
+  return (await findVaultRoomBinding(directoryHandle))?.roomId ?? null;
+}
+
+async function setVaultRoomId(
+  directoryHandle: BrowserDirectoryHandle,
+  roomId: string
+) {
+  const existing = await findVaultRoomBinding(directoryHandle);
+  const binding: VaultRoomBinding = {
+    vaultId:
+      existing?.vaultId ??
+      globalThis.crypto?.randomUUID?.() ??
+      `vault-${Date.now()}-${Math.random()}`,
+    directoryHandle,
+    roomId,
+    vaultName: directoryHandle.name,
+  };
+  const cachedIndex = existing
+    ? vaultRoomCache.findIndex((entry) => entry.vaultId === existing.vaultId)
+    : -1;
+  if (cachedIndex >= 0) {
+    vaultRoomCache[cachedIndex] = binding;
+  } else {
+    vaultRoomCache.push(binding);
+  }
   const db = await openMountedFilesDb();
   if (!db) return;
 
   try {
     const transaction = db.transaction(VAULT_ROOM_STORE, 'readwrite');
-    transaction.objectStore(VAULT_ROOM_STORE).put({ vaultName, roomId });
+    transaction.objectStore(VAULT_ROOM_STORE).put(binding);
     await transactionDone(transaction);
   } catch {
     // Non-critical — persist best-effort
@@ -174,9 +239,9 @@ async function setVaultRoomId(vaultName: string, roomId: string) {
 }
 
 export {
-  /** Look up a saved room id for a given vault directory name. */
+  /** Look up a saved room id for the exact selected vault directory. */
   getVaultRoomId as getBrowserLocalVaultRoomId,
-  /** Persist the room id associated with a vault directory name. */
+  /** Persist the room id associated with the exact selected vault directory. */
   setVaultRoomId as setBrowserLocalVaultRoomId,
 };
 
@@ -273,7 +338,11 @@ export async function pickBrowserLocalVault() {
     mode: 'readwrite',
   });
   const collected = await collectDirectoryFiles(directory, directory.name);
-  return { ...collected, vaultName: directory.name };
+  return {
+    ...collected,
+    directoryHandle: directory,
+    vaultName: directory.name,
+  };
 }
 
 export async function registerBrowserLocalVaultFiles(params: {
@@ -356,7 +425,7 @@ export async function clearBrowserLocalVaultsForTests() {
   mountedFileCache.clear();
   writeQueues.clear();
   permissionDeniedKeys.clear();
-  vaultRoomCache.clear();
+  vaultRoomCache.length = 0;
   const db = await openMountedFilesDb();
   if (!db) return;
   try {

--- a/packages/ewe-note/src/app/pages/Settings.tsx
+++ b/packages/ewe-note/src/app/pages/Settings.tsx
@@ -165,8 +165,9 @@ export function Settings() {
         total: 1,
       });
       const mounted = await pickBrowserLocalVault();
-      const existingRoomId =
-        await getBrowserLocalVaultRoomId(mounted.vaultName);
+      const existingRoomId = await getBrowserLocalVaultRoomId(
+        mounted.directoryHandle
+      );
       const existingRoom = existingRoomId
         ? allRooms.find((room) => room.id === existingRoomId)
         : undefined;
@@ -179,7 +180,10 @@ export function Settings() {
         setSelectedRoom,
         targetNoteRoomId: existingRoom?.id,
       });
-      await setBrowserLocalVaultRoomId(mounted.vaultName, result.noteRoomId);
+      await setBrowserLocalVaultRoomId(
+        mounted.directoryHandle,
+        result.noteRoomId
+      );
       setVaultImportResult(result);
     } catch (error) {
       if (error instanceof DOMException && error.name === 'AbortError') return;

--- a/packages/ewe-note/src/app/pages/Settings.tsx
+++ b/packages/ewe-note/src/app/pages/Settings.tsx
@@ -30,7 +30,9 @@ import {
   type BrowserVaultImportResult,
 } from '../lib/browser-vault-import';
 import {
+  getBrowserLocalVaultRoomId,
   pickBrowserLocalVault,
+  setBrowserLocalVaultRoomId,
   supportsBrowserLocalVaults,
 } from '../lib/browser-local-vault';
 
@@ -163,9 +165,11 @@ export function Settings() {
         total: 1,
       });
       const mounted = await pickBrowserLocalVault();
-      const existingRoom = allRooms.find(
-        (room) => room.name === mounted.vaultName
-      );
+      const existingRoomId =
+        await getBrowserLocalVaultRoomId(mounted.vaultName);
+      const existingRoom = existingRoomId
+        ? allRooms.find((room) => room.id === existingRoomId)
+        : undefined;
       const result = await importVaultFromFiles({
         db,
         files: mounted.files,
@@ -175,6 +179,7 @@ export function Settings() {
         setSelectedRoom,
         targetNoteRoomId: existingRoom?.id,
       });
+      await setBrowserLocalVaultRoomId(mounted.vaultName, result.noteRoomId);
       setVaultImportResult(result);
     } catch (error) {
       if (error instanceof DOMException && error.name === 'AbortError') return;

--- a/packages/shared/src/utils/obsidian-markdown.test.ts
+++ b/packages/shared/src/utils/obsidian-markdown.test.ts
@@ -125,6 +125,47 @@ describe('frontmatter round-trip', () => {
     });
   });
 
+  it('round-trips arrays containing objects and nested arrays', () => {
+    const frontmatter = {
+      projects: [
+        {
+          name: 'Alpha',
+          owners: ['Jane', 'Ravi'],
+          stages: [['draft', 'review'], ['approved']],
+        },
+        {
+          name: 'Beta',
+          owners: [],
+        },
+      ],
+    };
+
+    const reserialized = serializeFrontmatter(frontmatter, 'Body');
+    const { frontmatter: reparsed } = parseFrontmatter(reserialized);
+
+    expect(reparsed).toEqual(frontmatter);
+  });
+
+  it('parses dash-only markers for nested list items', () => {
+    const markdown = [
+      '---',
+      'projects:',
+      '  -',
+      '    name: Alpha',
+      '    tags:',
+      '      - one',
+      '      - two',
+      '  -',
+      '    name: Beta',
+      '---',
+      'Body',
+    ].join('\n');
+
+    expect(parseFrontmatter(markdown).frontmatter).toEqual({
+      projects: [{ name: 'Alpha', tags: ['one', 'two'] }, { name: 'Beta' }],
+    });
+  });
+
   it('round-trips mixed flat and nested', () => {
     const original =
       '---\ntitle: Mixed\ncount: 42\nmetadata:\n  author: Jane\n  tags:\n    - one\n    - two\n---\nBody';

--- a/packages/shared/src/utils/obsidian-markdown.test.ts
+++ b/packages/shared/src/utils/obsidian-markdown.test.ts
@@ -92,6 +92,80 @@ describe('frontmatter round-trip', () => {
     expect(fm2).toEqual(frontmatter);
     expect(c2).toBe(content);
   });
+
+  it('round-trips nested objects', () => {
+    const original =
+      '---\ntitle: Nested\nmetadata:\n  author: Jane\n  published: true\n  count: 7\n---\nBody';
+    const { frontmatter, content } = parseFrontmatter(original);
+    const reserialized = serializeFrontmatter(frontmatter, content);
+    const { frontmatter: fm2, content: c2 } = parseFrontmatter(reserialized);
+    expect(fm2).toEqual({
+      title: 'Nested',
+      metadata: { author: 'Jane', published: true, count: 7 },
+    });
+    expect(c2).toBe('Body');
+  });
+
+  it('round-trips nested arrays of scalars', () => {
+    const original =
+      '---\ntitle: Lists\nmetadata:\n  tags:\n    - a\n    - b\n    - c\n---\nBody';
+    const { frontmatter } = parseFrontmatter(original);
+    expect(frontmatter).toEqual({
+      title: 'Lists',
+      metadata: { tags: ['a', 'b', 'c'] },
+    });
+    const reserialized = serializeFrontmatter(
+      frontmatter as Record<string, unknown>,
+      'Body'
+    );
+    const { frontmatter: fm2 } = parseFrontmatter(reserialized);
+    expect(fm2).toEqual({
+      title: 'Lists',
+      metadata: { tags: ['a', 'b', 'c'] },
+    });
+  });
+
+  it('round-trips mixed flat and nested', () => {
+    const original =
+      '---\ntitle: Mixed\ncount: 42\nmetadata:\n  author: Jane\n  tags:\n    - one\n    - two\n---\nBody';
+    const { frontmatter } = parseFrontmatter(original);
+    expect(frontmatter).toEqual({
+      title: 'Mixed',
+      count: 42,
+      metadata: { author: 'Jane', tags: ['one', 'two'] },
+    });
+    const reserialized = serializeFrontmatter(
+      frontmatter as Record<string, unknown>,
+      'Body'
+    );
+    const { frontmatter: fm2 } = parseFrontmatter(reserialized);
+    expect(fm2).toEqual({
+      title: 'Mixed',
+      count: 42,
+      metadata: { author: 'Jane', tags: ['one', 'two'] },
+    });
+  });
+
+  it('round-trips empty frontmatter object', () => {
+    const result = serializeFrontmatter({}, 'Body');
+    expect(result).toBe('Body');
+  });
+
+  it('preserves unknown keys across round-trip', () => {
+    const original =
+      '---\ncustom_field: some value\nanother: 123\ntitle: Test\n---\nBody';
+    const { frontmatter } = parseFrontmatter(original);
+    expect(frontmatter.custom_field).toBe('some value');
+    expect(frontmatter.another).toBe(123);
+    const reserialized = serializeFrontmatter(
+      frontmatter as Record<string, unknown>,
+      'Body'
+    );
+    const { frontmatter: fm2 } = parseFrontmatter(reserialized);
+    expect(fm2.custom_field).toBe('some value');
+    expect(fm2.another).toBe(123);
+    expect(fm2.title).toBe('Test');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/shared/src/utils/obsidian-markdown.ts
+++ b/packages/shared/src/utils/obsidian-markdown.ts
@@ -173,7 +173,7 @@ function stripCodeBlocks(text: string): string {
 function parseSimpleYaml(yaml: string): Record<string, unknown> {
   const lines = yaml.split('\n');
   const result = parseYamlBlock(lines, 0, 0);
-  return result.value as Record<string, unknown>;
+  return isRecord(result.value) ? result.value : {};
 }
 
 /**
@@ -185,6 +185,22 @@ function parseYamlBlock(
   startIndex: number,
   baseIndent: number
 ): { value: unknown; nextIndex: number } {
+  const first = nextYamlContentLine(lines, startIndex);
+  if (!first || first.indent < baseIndent) {
+    return { value: {}, nextIndex: first?.index ?? lines.length };
+  }
+  if (first.indent === baseIndent && isYamlListItem(first.trimmed)) {
+    return parseYamlSequence(lines, first.index, baseIndent);
+  }
+
+  return parseYamlMapping(lines, first.index, baseIndent);
+}
+
+function parseYamlMapping(
+  lines: string[],
+  startIndex: number,
+  baseIndent: number
+): { value: Record<string, unknown>; nextIndex: number } {
   const result: Record<string, unknown> = {};
   let i = startIndex;
 
@@ -203,15 +219,12 @@ function parseYamlBlock(
       break;
     }
     if (indent > baseIndent) {
-      // This is a continuation of a parent multi-line value; skip.
-      // Multi-line scalars (|, >) are not supported by this parser.
+      // Unsupported continuation such as a multi-line scalar.
       i++;
       continue;
     }
 
-    const keyMatch = trimmed.match(
-      /^([a-zA-Z_][a-zA-Z0-9_ -]*):\s*(.*)/
-    );
+    const keyMatch = trimmed.match(/^([a-zA-Z_][a-zA-Z0-9_ -]*):\s*(.*)/);
     if (!keyMatch) {
       i++;
       continue;
@@ -222,73 +235,92 @@ function parseYamlBlock(
 
     i++;
 
-    if (valueStr === '' || valueStr === null) {
-      // Could be a nested block, a block list, or null
-      if (i < lines.length) {
-        const nextLine = lines[i] ?? '';
-        const nextTrimmed = nextLine.trimStart();
-        const nextIndent = nextLine.length - nextTrimmed.length;
-
-        if (nextIndent > baseIndent) {
-          // Check if it's a block list (starts with -)
-          if (nextTrimmed.startsWith('- ')) {
-            const listItems: unknown[] = [];
-            while (
-              i < lines.length &&
-              (lines[i] ?? '').trimStart().startsWith('- ')
-            ) {
-              const itemIndent =
-                (lines[i] ?? '').length - (lines[i] ?? '').trimStart().length;
-              const itemValue = (lines[i] ?? '').replace(/^\s+-\s+/, '');
-              if (
-                itemValue === '' &&
-                i + 1 < lines.length &&
-                (lines[i + 1] ?? '').length -
-                  (lines[i + 1] ?? '').trimStart().length >
-                  itemIndent
-              ) {
-                // Nested block inside list item
-                const nested = parseYamlBlock(
-                  lines,
-                  i + 1,
-                  (lines[i + 1] ?? '').length -
-                    (lines[i + 1] ?? '').trimStart().length
-                );
-                listItems.push(nested.value);
-                i = nested.nextIndex;
-              } else {
-                listItems.push(parseScalar(itemValue));
-                i++;
-              }
-            }
-            result[key] = listItems;
-            continue;
-          }
-
-          // Nested object block
-          const nested = parseYamlBlock(lines, i, nextIndent);
-          result[key] = nested.value;
-          i = nested.nextIndex;
-          continue;
-        }
+    if (valueStr === '') {
+      const next = nextYamlContentLine(lines, i);
+      if (next && next.indent > baseIndent) {
+        const nested = parseYamlBlock(lines, next.index, next.indent);
+        result[key] = nested.value;
+        i = nested.nextIndex;
+        continue;
       }
       result[key] = null;
       continue;
     }
 
-    // Inline list: [a, b, c]
-    if (valueStr.startsWith('[')) {
-      const inner = valueStr.slice(1, valueStr.lastIndexOf(']'));
-      result[key] = inner
-        .split(',')
-        .map((s) => parseScalar(s.trim()))
-        .filter((s) => s !== '');
-    } else {
-      result[key] = parseScalar(valueStr);
-    }
+    result[key] = parseYamlInlineValue(valueStr);
   }
 
   return { value: result, nextIndex: i };
+}
+
+function parseYamlSequence(
+  lines: string[],
+  startIndex: number,
+  baseIndent: number
+): { value: unknown[]; nextIndex: number } {
+  const result: unknown[] = [];
+  let i = startIndex;
+
+  while (i < lines.length) {
+    const current = nextYamlContentLine(lines, i);
+    if (!current) {
+      return { value: result, nextIndex: lines.length };
+    }
+    if (current.indent < baseIndent) break;
+    if (current.indent !== baseIndent || !isYamlListItem(current.trimmed)) {
+      break;
+    }
+
+    const itemValue = current.trimmed.match(/^-(?:\s+(.*))?$/)?.[1] ?? '';
+    i = current.index + 1;
+    if (itemValue !== '') {
+      result.push(parseYamlInlineValue(itemValue));
+      continue;
+    }
+
+    const next = nextYamlContentLine(lines, i);
+    if (next && next.indent > baseIndent) {
+      const nested = parseYamlBlock(lines, next.index, next.indent);
+      result.push(nested.value);
+      i = nested.nextIndex;
+      continue;
+    }
+    result.push(null);
+  }
+
+  return { value: result, nextIndex: i };
+}
+
+function nextYamlContentLine(
+  lines: string[],
+  startIndex: number
+): { index: number; indent: number; trimmed: string } | null {
+  for (let index = startIndex; index < lines.length; index++) {
+    const line = lines[index] ?? '';
+    const trimmed = line.trimStart();
+    if (trimmed === '' || trimmed.startsWith('#')) continue;
+    return {
+      index,
+      indent: line.length - trimmed.length,
+      trimmed,
+    };
+  }
+  return null;
+}
+
+function isYamlListItem(trimmed: string): boolean {
+  return /^-(?:\s+.*)?$/.test(trimmed);
+}
+
+function parseYamlInlineValue(value: string): unknown {
+  if (value === '[]') return [];
+  if (value === '{}') return {};
+  if (value.startsWith('[') && value.endsWith(']')) {
+    const inner = value.slice(1, -1).trim();
+    if (inner === '') return [];
+    return inner.split(',').map((entry) => parseScalar(entry.trim()));
+  }
+  return parseScalar(value);
 }
 
 function parseScalar(value: string): unknown {
@@ -311,38 +343,65 @@ function serializeYamlLines(
   obj: Record<string, unknown>,
   currentIndent = 0
 ): string {
+  return serializeYamlObject(obj, currentIndent).join('\n');
+}
+
+function serializeYamlObject(
+  obj: Record<string, unknown>,
+  currentIndent: number
+): string[] {
   const indent = '  '.repeat(currentIndent);
-  return Object.entries(obj)
-    .map(([key, value]) => {
-      if (value === null || value === undefined) {
-        return `${indent}${key}:`;
+  const lines: string[] = [];
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === null || value === undefined) {
+      lines.push(`${indent}${key}:`);
+    } else if (Array.isArray(value)) {
+      if (value.length === 0) {
+        lines.push(`${indent}${key}: []`);
+      } else {
+        lines.push(`${indent}${key}:`);
+        lines.push(...serializeYamlArray(value, currentIndent + 1));
       }
-      if (Array.isArray(value)) {
-        if (value.length === 0) return `${indent}${key}: []`;
-        const items = value.map((v) => {
-          if (isRecord(v)) {
-            const nested = serializeYamlLines(v, currentIndent + 2)
-              .split('\n')
-              .join('\n  ');
-            return `${indent}  - ${nested.slice(indent.length + 4)}`;
-          }
-          if (Array.isArray(v)) {
-            const subItems = v
-              .map((sv) => `${indent}    - ${serializeScalar(sv)}`)
-              .join('\n');
-            return `${indent}  -\n${subItems}`;
-          }
-          return `${indent}  - ${serializeScalar(v)}`;
-        });
-        return `${indent}${key}:\n${items.join('\n')}`;
+    } else if (isRecord(value)) {
+      if (Object.keys(value).length === 0) {
+        lines.push(`${indent}${key}: {}`);
+      } else {
+        lines.push(`${indent}${key}:`);
+        lines.push(...serializeYamlObject(value, currentIndent + 1));
       }
-      if (isRecord(value)) {
-        const nested = serializeYamlLines(value, currentIndent + 1);
-        return `${indent}${key}:\n${nested}`;
+    } else {
+      lines.push(`${indent}${key}: ${serializeScalar(value)}`);
+    }
+  }
+  return lines;
+}
+
+function serializeYamlArray(
+  values: unknown[],
+  currentIndent: number
+): string[] {
+  const indent = '  '.repeat(currentIndent);
+  const lines: string[] = [];
+  for (const value of values) {
+    if (Array.isArray(value)) {
+      if (value.length === 0) {
+        lines.push(`${indent}- []`);
+      } else {
+        lines.push(`${indent}-`);
+        lines.push(...serializeYamlArray(value, currentIndent + 1));
       }
-      return `${indent}${key}: ${serializeScalar(value)}`;
-    })
-    .join('\n');
+    } else if (isRecord(value)) {
+      if (Object.keys(value).length === 0) {
+        lines.push(`${indent}- {}`);
+      } else {
+        lines.push(`${indent}-`);
+        lines.push(...serializeYamlObject(value, currentIndent + 1));
+      }
+    } else {
+      lines.push(`${indent}- ${serializeScalar(value)}`);
+    }
+  }
+  return lines;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/shared/src/utils/obsidian-markdown.ts
+++ b/packages/shared/src/utils/obsidian-markdown.ts
@@ -171,13 +171,47 @@ function stripCodeBlocks(text: string): string {
  * For complex YAML, real consumers should use the `js-yaml` library.
  */
 function parseSimpleYaml(yaml: string): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
   const lines = yaml.split('\n');
-  let i = 0;
+  const result = parseYamlBlock(lines, 0, 0);
+  return result.value as Record<string, unknown>;
+}
+
+/**
+ * Parse a YAML block starting at `startIndex` with base indent `baseIndent`.
+ * Returns the parsed value and the index after the last consumed line.
+ */
+function parseYamlBlock(
+  lines: string[],
+  startIndex: number,
+  baseIndent: number
+): { value: unknown; nextIndex: number } {
+  const result: Record<string, unknown> = {};
+  let i = startIndex;
 
   while (i < lines.length) {
     const line = lines[i] ?? '';
-    const keyMatch = line.match(/^([a-zA-Z_][a-zA-Z0-9_ -]*):\s*(.*)/);
+    const trimmed = line.trimStart();
+
+    if (trimmed === '' || trimmed.startsWith('#')) {
+      i++;
+      continue;
+    }
+
+    const indent = line.length - trimmed.length;
+    if (indent < baseIndent) {
+      // We've gone back up a level
+      break;
+    }
+    if (indent > baseIndent) {
+      // This is a continuation of a parent multi-line value; skip.
+      // Multi-line scalars (|, >) are not supported by this parser.
+      i++;
+      continue;
+    }
+
+    const keyMatch = trimmed.match(
+      /^([a-zA-Z_][a-zA-Z0-9_ -]*):\s*(.*)/
+    );
     if (!keyMatch) {
       i++;
       continue;
@@ -186,15 +220,59 @@ function parseSimpleYaml(yaml: string): Record<string, unknown> {
     const key = (keyMatch[1] as string).trim();
     const valueStr = (keyMatch[2] as string).trim();
 
+    i++;
+
     if (valueStr === '' || valueStr === null) {
-      // Could be a block list
-      const listItems: unknown[] = [];
-      i++;
-      while (i < lines.length && (lines[i] ?? '').match(/^\s+-\s+/)) {
-        listItems.push(parseScalar((lines[i] ?? '').replace(/^\s+-\s+/, '')));
-        i++;
+      // Could be a nested block, a block list, or null
+      if (i < lines.length) {
+        const nextLine = lines[i] ?? '';
+        const nextTrimmed = nextLine.trimStart();
+        const nextIndent = nextLine.length - nextTrimmed.length;
+
+        if (nextIndent > baseIndent) {
+          // Check if it's a block list (starts with -)
+          if (nextTrimmed.startsWith('- ')) {
+            const listItems: unknown[] = [];
+            while (
+              i < lines.length &&
+              (lines[i] ?? '').trimStart().startsWith('- ')
+            ) {
+              const itemIndent =
+                (lines[i] ?? '').length - (lines[i] ?? '').trimStart().length;
+              const itemValue = (lines[i] ?? '').replace(/^\s+-\s+/, '');
+              if (
+                itemValue === '' &&
+                i + 1 < lines.length &&
+                (lines[i + 1] ?? '').length -
+                  (lines[i + 1] ?? '').trimStart().length >
+                  itemIndent
+              ) {
+                // Nested block inside list item
+                const nested = parseYamlBlock(
+                  lines,
+                  i + 1,
+                  (lines[i + 1] ?? '').length -
+                    (lines[i + 1] ?? '').trimStart().length
+                );
+                listItems.push(nested.value);
+                i = nested.nextIndex;
+              } else {
+                listItems.push(parseScalar(itemValue));
+                i++;
+              }
+            }
+            result[key] = listItems;
+            continue;
+          }
+
+          // Nested object block
+          const nested = parseYamlBlock(lines, i, nextIndent);
+          result[key] = nested.value;
+          i = nested.nextIndex;
+          continue;
+        }
       }
-      result[key] = listItems.length > 0 ? listItems : null;
+      result[key] = null;
       continue;
     }
 
@@ -208,11 +286,9 @@ function parseSimpleYaml(yaml: string): Record<string, unknown> {
     } else {
       result[key] = parseScalar(valueStr);
     }
-
-    i++;
   }
 
-  return result;
+  return { value: result, nextIndex: i };
 }
 
 function parseScalar(value: string): unknown {
@@ -231,19 +307,51 @@ function parseScalar(value: string): unknown {
   return value;
 }
 
-function serializeYamlLines(obj: Record<string, unknown>): string {
+function serializeYamlLines(
+  obj: Record<string, unknown>,
+  currentIndent = 0
+): string {
+  const indent = '  '.repeat(currentIndent);
   return Object.entries(obj)
     .map(([key, value]) => {
       if (value === null || value === undefined) {
-        return `${key}:`;
+        return `${indent}${key}:`;
       }
       if (Array.isArray(value)) {
-        if (value.length === 0) return `${key}: []`;
-        return `${key}:\n${value.map((v) => `  - ${serializeScalar(v)}`).join('\n')}`;
+        if (value.length === 0) return `${indent}${key}: []`;
+        const items = value.map((v) => {
+          if (isRecord(v)) {
+            const nested = serializeYamlLines(v, currentIndent + 2)
+              .split('\n')
+              .join('\n  ');
+            return `${indent}  - ${nested.slice(indent.length + 4)}`;
+          }
+          if (Array.isArray(v)) {
+            const subItems = v
+              .map((sv) => `${indent}    - ${serializeScalar(sv)}`)
+              .join('\n');
+            return `${indent}  -\n${subItems}`;
+          }
+          return `${indent}  - ${serializeScalar(v)}`;
+        });
+        return `${indent}${key}:\n${items.join('\n')}`;
       }
-      return `${key}: ${serializeScalar(value)}`;
+      if (isRecord(value)) {
+        const nested = serializeYamlLines(value, currentIndent + 1);
+        return `${indent}${key}:\n${nested}`;
+      }
+      return `${indent}${key}: ${serializeScalar(value)}`;
     })
     .join('\n');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    !(value instanceof Date)
+  );
 }
 
 function serializeScalar(value: unknown): string {


### PR DESCRIPTION
Three fixes on top of PR #65's browser-local-vault:

1. **Request write permission after reload**: call `FileSystemFileHandle.requestPermission({mode:'readwrite'})` when `queryPermission` is not granted after a browser restart. Track denied keys and export `getBrowserLocalVaultPermissionState()` so Ewe Note can report whether write-back is available.

2. **Exact vault-directory identity**: replace room-name matching in `Settings.tsx` with an IndexedDB `vault-rooms` store (`getBrowserLocalVaultRoomId` / `setBrowserLocalVaultRoomId`). The bridge compares persisted directory handles with `isSameEntry()`, so two different directories with the same display name cannot reuse the wrong room.

3. **Frontmatter fidelity**: make `parseSimpleYaml` and `serializeYamlLines` recursive so nested objects and arrays survive round-trips. Preserve unknown keys and support dash-only YAML list markers.

`DB_VERSION` is now 3 because the vault-room store keys bindings by an opaque vault id and persists the exact directory handle.

## Review Evidence

- Screenshots: Not applicable; the repair changes local vault identity and Markdown serialization without changing visible layout.
- Visual assessment: Not applicable.
- Data flow:

```mermaid
flowchart LR
  A["Selected directory handle"] -->|isSameEntry| B["IndexedDB vault binding"]
  B --> C["Existing Eweser room"]
  D["Nested frontmatter"] --> E["Recursive parser and serializer"]
  E --> F["Round-tripped Markdown"]
```

## Verification

- `npm test --workspace @eweser/shared -- obsidian-markdown.test.ts` — 33 tests passed.
- `npm test --workspace @eweser/ewe-note -- src/app/lib/browser-local-vault.test.ts` — 7 tests passed.
- `npm run type-check --workspace @eweser/shared` — passed.
- `npm run type-check --workspace @eweser/ewe-note` — passed after building workspace dependencies.
- Focused ESLint and Prettier checks passed for every changed TypeScript file.

## Risk / notes

- Upgrading the IndexedDB store replaces the earlier name-keyed vault-room mappings. The product is pre-live, and discarding those prototype mappings avoids carrying the collision-prone identity forward.
- No external writes, authentication changes, or server-side migrations are introduced.