### PR TITLE
feat(ewe-note): prove lossless Markdown room transport

### DIFF
--- a/.changeset/openwiki-markdown-byte-transport.md
+++ b/.changeset/openwiki-markdown-byte-transport.md
@@ -1,0 +1,8 @@
+---
+'@eweser/db': patch
+'@eweser/shared': patch
+---
+
+Preserve exact source Markdown in vault-sync metadata while parsed note fields
+remain unchanged, allowing byte-identical filesystem materialization through
+Eweser rooms.

--- a/.prettierignore
+++ b/.prettierignore
@@ -21,3 +21,5 @@ packages/auth-server/supabase/.temp/**
 packages/landing/.astro/**
 # Changeset metadata files
 .changeset/**
+# Byte-exact upstream-generated transport fixtures
+packages/ewe-note/test-fixtures/openwiki-generated/openwiki/**

--- a/packages/ewe-note/src/cli/INDEX.md
+++ b/packages/ewe-note/src/cli/INDEX.md
@@ -20,6 +20,9 @@ Obsidian-compatible vault data with Ewe Note data shapes.
 - [`vault-sync.ts`](./vault-sync.ts): Local vault/state sync engine and
   Eweser notes-room sync mode, including remote attachment upload/materialize
   support through S3-compatible storage helpers.
+- [`openwiki-transport-dogfood.ts`](./openwiki-transport-dogfood.ts): Focused
+  two-directory proof that generic OpenWiki-generated Markdown crosses an
+  Eweser notes room with identical paths, bytes, frontmatter, and hashes.
 
 ## Children
 
@@ -44,3 +47,5 @@ Obsidian-compatible vault data with Ewe Note data shapes.
 
 - `npm test --workspace @eweser/ewe-note -- import-vault`: Runs import tests.
 - `npm test --workspace @eweser/ewe-note -- vault-sync`: Runs vault sync tests.
+- `npx tsx packages/ewe-note/src/cli/openwiki-transport-dogfood.ts`: Runs the
+  public-fixture Markdown transport proof.

--- a/packages/ewe-note/src/cli/import-vault.ts
+++ b/packages/ewe-note/src/cli/import-vault.ts
@@ -47,6 +47,8 @@ export interface ImportedNote {
   }>;
   /** Attachment file names referenced in this note */
   attachmentRefs: string[];
+  /** Exact source Markdown when the importer has direct file access. */
+  sourceMarkdown?: string;
 }
 
 export type VaultFileCategory =

--- a/packages/ewe-note/src/cli/openwiki-transport-dogfood.ts
+++ b/packages/ewe-note/src/cli/openwiki-transport-dogfood.ts
@@ -12,7 +12,7 @@ import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join, relative } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
-import { getDocuments, type GetDocuments, type Note } from '@eweser/shared';
+import { getDocuments, type Note } from '@eweser/shared';
 import * as Y from 'yjs';
 import { EweserRoomVaultSyncEngine } from './vault-sync';
 
@@ -43,13 +43,6 @@ function sha256(bytes: string | Buffer): string {
 
 function frontmatterBytes(markdown: string): string {
   return markdown.match(/^---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$)/u)?.[0] ?? '';
-}
-
-function attachNotes(
-  engine: EweserRoomVaultSyncEngine,
-  Notes: GetDocuments<Note>
-): void {
-  Object.assign(engine as unknown as { Notes: GetDocuments<Note> }, { Notes });
 }
 
 export async function runOpenWikiTransportDogfood(): Promise<OpenWikiTransportDogfoodResult> {
@@ -100,8 +93,10 @@ export async function runOpenWikiTransportDogfood(): Promise<OpenWikiTransportDo
     roomId,
     remoteSync: false,
   });
-  attachNotes(sourceEngine, sourceNotes);
-  attachNotes(destinationEngine, destinationNotes);
+  sourceEngine.attachDocumentsForInMemoryHarness({ notes: sourceNotes });
+  destinationEngine.attachDocumentsForInMemoryHarness({
+    notes: destinationNotes,
+  });
 
   await sourceEngine.onFileChange(FIXTURE_RELATIVE_PATH);
   Y.applyUpdate(destinationYDoc, Y.encodeStateAsUpdate(sourceYDoc));

--- a/packages/ewe-note/src/cli/openwiki-transport-dogfood.ts
+++ b/packages/ewe-note/src/cli/openwiki-transport-dogfood.ts
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/**
+ * Purpose: Prove byte-identical Markdown transport through an Eweser notes room.
+ * Exports: runOpenWikiTransportDogfood and its structured result.
+ * Touches: Public OpenWiki fixture Markdown and two isolated temporary vaults.
+ * Read before editing: packages/ewe-note/src/cli/INDEX.md.
+ */
+/* eslint-disable no-console -- CLI proof reports structured evidence */
+
+import { createHash } from 'node:crypto';
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { getDocuments, type GetDocuments, type Note } from '@eweser/shared';
+import * as Y from 'yjs';
+import { EweserRoomVaultSyncEngine } from './vault-sync';
+
+const FIXTURE_RELATIVE_PATH = 'openwiki/index.md';
+const FIXTURE_PATH = fileURLToPath(
+  new URL(
+    '../../test-fixtures/openwiki-generated/openwiki/index.md',
+    import.meta.url
+  )
+);
+
+export interface OpenWikiTransportDogfoodResult {
+  sourceRoot: string;
+  destinationRoot: string;
+  sourceRelativePath: string;
+  destinationRelativePath: string;
+  sourceSha256: string;
+  destinationSha256: string;
+  sourceFrontmatterSha256: string;
+  destinationFrontmatterSha256: string;
+  byteIdentical: boolean;
+  frontmatterByteIdentical: boolean;
+}
+
+function sha256(bytes: string | Buffer): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function frontmatterBytes(markdown: string): string {
+  return markdown.match(/^---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$)/u)?.[0] ?? '';
+}
+
+function attachNotes(
+  engine: EweserRoomVaultSyncEngine,
+  Notes: GetDocuments<Note>
+): void {
+  Object.assign(engine as unknown as { Notes: GetDocuments<Note> }, { Notes });
+}
+
+export async function runOpenWikiTransportDogfood(): Promise<OpenWikiTransportDogfoodResult> {
+  const proofRoot = await mkdtemp(join(tmpdir(), 'eweser-openwiki-transport-'));
+  const sourceRoot = join(proofRoot, 'source');
+  const destinationRoot = join(proofRoot, 'destination');
+  const sourcePath = join(sourceRoot, FIXTURE_RELATIVE_PATH);
+  const destinationPath = join(destinationRoot, FIXTURE_RELATIVE_PATH);
+  await Promise.all([
+    mkdir(dirname(sourcePath), { recursive: true }),
+    mkdir(destinationRoot, { recursive: true }),
+  ]);
+
+  const fixture = await readFile(FIXTURE_PATH, 'utf8');
+  await writeFile(sourcePath, fixture, 'utf8');
+
+  const changedMarkdown = fixture.replace(
+    '# Files\n',
+    '# Files\n\nTransport proof update: exact Markdown bytes matter.\n'
+  );
+  if (changedMarkdown === fixture) {
+    throw new Error('OpenWiki fixture update marker could not be applied.');
+  }
+  await writeFile(sourcePath, changedMarkdown, 'utf8');
+
+  const roomId = 'openwiki-markdown-transport-proof';
+  const sourceYDoc = new Y.Doc();
+  const destinationYDoc = new Y.Doc();
+  const sourceNotes = getDocuments(
+    'http://local.invalid',
+    'notes',
+    roomId
+  )<Note>(sourceYDoc);
+  const destinationNotes = getDocuments(
+    'http://local.invalid',
+    'notes',
+    roomId
+  )<Note>(destinationYDoc);
+  const sourceEngine = new EweserRoomVaultSyncEngine({
+    vaultPath: sourceRoot,
+    vaultName: 'OpenWiki fixture',
+    roomId,
+    remoteSync: false,
+  });
+  const destinationEngine = new EweserRoomVaultSyncEngine({
+    vaultPath: destinationRoot,
+    vaultName: 'OpenWiki fixture',
+    roomId,
+    remoteSync: false,
+  });
+  attachNotes(sourceEngine, sourceNotes);
+  attachNotes(destinationEngine, destinationNotes);
+
+  await sourceEngine.onFileChange(FIXTURE_RELATIVE_PATH);
+  Y.applyUpdate(destinationYDoc, Y.encodeStateAsUpdate(sourceYDoc));
+
+  const [transportedNote] = destinationNotes.getUndeletedToArray();
+  if (!transportedNote) {
+    throw new Error('No Markdown note arrived in the destination room.');
+  }
+  if (transportedNote.sourcePath !== FIXTURE_RELATIVE_PATH) {
+    throw new Error(
+      `Destination room path changed to "${transportedNote.sourcePath ?? ''}".`
+    );
+  }
+  await destinationEngine.materializeNote(transportedNote);
+
+  const [sourceBytes, destinationBytes] = await Promise.all([
+    readFile(sourcePath),
+    readFile(destinationPath),
+  ]);
+  const sourceMarkdown = sourceBytes.toString('utf8');
+  const destinationMarkdown = destinationBytes.toString('utf8');
+
+  return {
+    sourceRoot,
+    destinationRoot,
+    sourceRelativePath: relative(sourceRoot, sourcePath).replace(/\\/gu, '/'),
+    destinationRelativePath: relative(destinationRoot, destinationPath).replace(
+      /\\/gu,
+      '/'
+    ),
+    sourceSha256: sha256(sourceBytes),
+    destinationSha256: sha256(destinationBytes),
+    sourceFrontmatterSha256: sha256(frontmatterBytes(sourceMarkdown)),
+    destinationFrontmatterSha256: sha256(frontmatterBytes(destinationMarkdown)),
+    byteIdentical: sourceBytes.equals(destinationBytes),
+    frontmatterByteIdentical:
+      frontmatterBytes(sourceMarkdown) ===
+      frontmatterBytes(destinationMarkdown),
+  };
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  runOpenWikiTransportDogfood()
+    .then((result) => {
+      console.log(JSON.stringify(result, null, 2));
+      if (
+        !result.byteIdentical ||
+        !result.frontmatterByteIdentical ||
+        result.sourceRelativePath !== result.destinationRelativePath
+      ) {
+        process.exitCode = 1;
+      }
+    })
+    .catch((error: unknown) => {
+      console.error(error);
+      process.exitCode = 1;
+    });
+}

--- a/packages/ewe-note/src/cli/vault-sync.test.ts
+++ b/packages/ewe-note/src/cli/vault-sync.test.ts
@@ -73,13 +73,10 @@ function createRoomHarness(vaultPath: string, vaultName = 'Test Vault') {
     'fileAttachments',
     attachmentsRoomId
   )<FileAttachment>(new Y.Doc());
-  Object.assign(
-    engine as unknown as {
-      Notes: typeof Notes;
-      Attachments: typeof Attachments;
-    },
-    { Notes, Attachments }
-  );
+  engine.attachDocumentsForInMemoryHarness({
+    notes: Notes,
+    attachments: Attachments,
+  });
   return { Attachments, engine, Notes, roomId, vaultName };
 }
 
@@ -235,6 +232,21 @@ describe('EweserRoomVaultSyncEngine', () => {
     const materialized = await readFile(join(vaultPath, 'Edited.md'), 'utf8');
     expect(materialized).toContain('Edited in Eweser');
     expect(materialized).not.toBe(sourceMarkdown);
+  });
+
+  it('does not duplicate canonical Markdown in room metadata', async () => {
+    const vaultPath = await createTempVault();
+    await writeFile(
+      join(vaultPath, 'Canonical.md'),
+      'Canonical body\n',
+      'utf8'
+    );
+    const { engine } = createRoomHarness(vaultPath);
+
+    await engine.onFileChange('Canonical.md');
+
+    const [imported] = engine.getNotes();
+    expect(imported?.vaultSync).not.toHaveProperty('sourceMarkdown');
   });
 
   it('bootstraps existing vault notes into the notes room', async () => {

--- a/packages/ewe-note/src/cli/vault-sync.test.ts
+++ b/packages/ewe-note/src/cli/vault-sync.test.ts
@@ -9,6 +9,7 @@ import {
   VaultSyncEngine,
   waitForRemoteSyncProviderReady,
 } from './vault-sync';
+import { runOpenWikiTransportDogfood } from './openwiki-transport-dogfood';
 import { generateNoteId } from './import-vault';
 
 function createProvider(initialSynced = false) {
@@ -202,6 +203,40 @@ describe('VaultSyncEngine', () => {
 });
 
 describe('EweserRoomVaultSyncEngine', () => {
+  it('transports changed OpenWiki Markdown byte-for-byte between isolated directories', async () => {
+    const result = await runOpenWikiTransportDogfood();
+    tempRoots.push(join(result.sourceRoot, '..'));
+
+    expect(result.sourceRelativePath).toBe('openwiki/index.md');
+    expect(result.destinationRelativePath).toBe(result.sourceRelativePath);
+    expect(result.destinationSha256).toBe(result.sourceSha256);
+    expect(result.destinationFrontmatterSha256).toBe(
+      result.sourceFrontmatterSha256
+    );
+    expect(result.byteIdentical).toBe(true);
+    expect(result.frontmatterByteIdentical).toBe(true);
+  });
+
+  it('stops using retained source Markdown after Eweser note fields change', async () => {
+    const vaultPath = await createTempVault();
+    const sourceMarkdown =
+      '---\ntitle: "Quoted source title"\n---\nOriginal body\n';
+    await writeFile(join(vaultPath, 'Edited.md'), sourceMarkdown, 'utf8');
+    const { engine, Notes } = createRoomHarness(vaultPath);
+    await engine.onFileChange('Edited.md');
+
+    const [imported] = engine.getNotes();
+    if (!imported) throw new Error('Expected imported note.');
+    Notes.set({ ...imported, text: 'Edited in Eweser\n' });
+    const edited = Notes.get(imported._id);
+    if (!edited) throw new Error('Expected edited note.');
+    await engine.materializeNote(edited);
+
+    const materialized = await readFile(join(vaultPath, 'Edited.md'), 'utf8');
+    expect(materialized).toContain('Edited in Eweser');
+    expect(materialized).not.toBe(sourceMarkdown);
+  });
+
   it('bootstraps existing vault notes into the notes room', async () => {
     const vaultPath = await createTempVault();
     await writeFile(join(vaultPath, 'One.md'), 'First #alpha\n', 'utf-8');

--- a/packages/ewe-note/src/cli/vault-sync.ts
+++ b/packages/ewe-note/src/cli/vault-sync.ts
@@ -396,6 +396,7 @@ async function noteFromFile(
       return entry;
     }),
     attachmentRefs: [],
+    sourceMarkdown: rawContent,
   };
 }
 
@@ -1021,6 +1022,7 @@ export class EweserRoomVaultSyncEngine {
       sourceMtimeMs: mtime?.getTime(),
       lastFileHash: currentFileHash,
       lastEweserHash: hashMarkdown(markdown),
+      sourceMarkdown: imported.sourceMarkdown,
       lastSyncedAt: new Date().toISOString(),
     };
   }
@@ -1065,7 +1067,7 @@ export class EweserRoomVaultSyncEngine {
 
     await mkdir(dirname(conflictFullPath), { recursive: true });
     await writeFile(conflictFullPath, incomingContent, 'utf-8');
-    await this.writeNoteToFile(existing);
+    await this.materializeNote(existing);
     await this.upsertFileIntoRoom(conflictPath, false);
 
     console.log(
@@ -1085,7 +1087,7 @@ export class EweserRoomVaultSyncEngine {
     const Notes = this.requireNotes();
     this.roomChangeHandler = () => {
       for (const note of Notes.getUndeletedToArray()) {
-        void this.writeNoteToFile(note);
+        void this.materializeNote(note);
       }
     };
     Notes.onChange(this.roomChangeHandler);
@@ -1188,10 +1190,15 @@ export class EweserRoomVaultSyncEngine {
     );
   }
 
-  private async writeNoteToFile(note: Note): Promise<void> {
+  async materializeNote(note: Note): Promise<void> {
     const imported = noteToImported(note);
     const fullPath = join(this.vaultPath, imported.sourcePath);
-    const content = noteToMarkdown(imported);
+    const serialized = noteToMarkdown(imported);
+    const content =
+      note.vaultSync?.sourceMarkdown &&
+      note.vaultSync.lastEweserHash === hashMarkdown(serialized)
+        ? note.vaultSync.sourceMarkdown
+        : serialized;
 
     let existing: string | null = null;
     try {

--- a/packages/ewe-note/src/cli/vault-sync.ts
+++ b/packages/ewe-note/src/cli/vault-sync.ts
@@ -887,6 +887,24 @@ export class EweserRoomVaultSyncEngine {
     return this.requireAttachments();
   }
 
+  /**
+   * Attach isolated in-memory documents without starting storage or sync.
+   *
+   * @internal Intended only for deterministic CLI proofs and unit harnesses.
+   */
+  attachDocumentsForInMemoryHarness(documents: {
+    notes: GetDocuments<Note>;
+    attachments?: GetDocuments<FileAttachment>;
+  }): void {
+    if (this.db || this.watcher || this.Notes || this.Attachments) {
+      throw new Error(
+        'In-memory documents must be attached before the room sync starts.'
+      );
+    }
+    this.Notes = documents.notes;
+    this.Attachments = documents.attachments ?? null;
+  }
+
   async onFileChange(relPath: string): Promise<void> {
     if (this.writing.has(relPath)) return;
 
@@ -1022,7 +1040,10 @@ export class EweserRoomVaultSyncEngine {
       sourceMtimeMs: mtime?.getTime(),
       lastFileHash: currentFileHash,
       lastEweserHash: hashMarkdown(markdown),
-      sourceMarkdown: imported.sourceMarkdown,
+      ...(typeof imported.sourceMarkdown === 'string' &&
+      imported.sourceMarkdown !== markdown
+        ? { sourceMarkdown: imported.sourceMarkdown }
+        : {}),
       lastSyncedAt: new Date().toISOString(),
     };
   }
@@ -1195,7 +1216,7 @@ export class EweserRoomVaultSyncEngine {
     const fullPath = join(this.vaultPath, imported.sourcePath);
     const serialized = noteToMarkdown(imported);
     const content =
-      note.vaultSync?.sourceMarkdown &&
+      typeof note.vaultSync?.sourceMarkdown === 'string' &&
       note.vaultSync.lastEweserHash === hashMarkdown(serialized)
         ? note.vaultSync.sourceMarkdown
         : serialized;

--- a/packages/ewe-note/test-fixtures/openwiki-generated/README.md
+++ b/packages/ewe-note/test-fixtures/openwiki-generated/README.md
@@ -1,0 +1,10 @@
+# OpenWiki-generated Markdown fixture
+
+This public fixture is a small excerpt of the documentation generated in
+[`langchain-ai/openwiki`](https://github.com/langchain-ai/openwiki) at commit
+`d29b61b85e3f58986f85f4b463badc82c8537789`.
+
+`openwiki/index.md` is copied byte-for-byte from the upstream generated wiki.
+
+The fixture exists only to exercise generic Markdown transport. EweserDB does
+not interpret OpenWiki concepts or own an OpenWiki-specific schema.

--- a/packages/ewe-note/test-fixtures/openwiki-generated/openwiki/index.md
+++ b/packages/ewe-note/test-fixtures/openwiki-generated/openwiki/index.md
@@ -1,0 +1,15 @@
+---
+okf_version: "0.1"
+---
+
+# Files
+
+- [OpenWiki Quickstart](quickstart.md) - Quickstart reference for the OpenWiki TypeScript CLI, including documentation-generation workflows, supported model providers, and the primary source files. Use it to navigate the repository's architecture, commands, agent runtime, operations, and connectors.
+
+# Directories
+
+- [agent](agent/)
+- [architecture](architecture/)
+- [cli](cli/)
+- [integrations](integrations/)
+- [operations](operations/)

--- a/packages/shared/src/collections/note.ts
+++ b/packages/shared/src/collections/note.ts
@@ -11,6 +11,14 @@ export type NoteVaultSyncMetadata = {
   lastFileHash?: string;
   /** SHA-256 hash of the last Eweser note content materialized to disk. */
   lastEweserHash?: string;
+  /**
+   * Exact Markdown bytes last read from the source file.
+   *
+   * The vault bridge uses this only while the parsed note fields still match
+   * lastEweserHash. Once the note changes in Eweser, normal serialization
+   * replaces this source representation.
+   */
+  sourceMarkdown?: string;
   /** ISO timestamp for the last successful vault sync operation. */
   lastSyncedAt?: string;
 };

--- a/packages/shared/src/collections/note.ts
+++ b/packages/shared/src/collections/note.ts
@@ -12,7 +12,7 @@ export type NoteVaultSyncMetadata = {
   /** SHA-256 hash of the last Eweser note content materialized to disk. */
   lastEweserHash?: string;
   /**
-   * Exact Markdown bytes last read from the source file.
+   * Exact UTF-8 Markdown text last read from the source file.
    *
    * The vault bridge uses this only while the parsed note fields still match
    * lastEweserHash. Once the note changes in Eweser, normal serialization


### PR DESCRIPTION
## What

Dogfood a public, checked-in OpenWiki-generated Markdown fixture through the existing Ewe Note vault / Eweser notes-room path. The bridge now retains the exact source Markdown representation while parsed note fields remain unchanged, allowing the destination vault to reproduce the same relative path, bytes, frontmatter, and SHA-256 hash. No OpenWiki-specific schema or memory behavior is added.

## Changes

- `packages/ewe-note/src/cli/vault-sync.ts` — retain and safely materialize exact source Markdown; fall back to normal serialization after Eweser-side edits.
- `packages/ewe-note/src/cli/openwiki-transport-dogfood.ts` — run the two-directory, two-Y.Doc transport proof and print structured evidence.
- `packages/ewe-note/test-fixtures/openwiki-generated/` — public fixture pinned and attributed to upstream commit `d29b61b85e3f58986f85f4b463badc82c8537789`.
- `packages/shared/src/collections/note.ts` — add optional source Markdown to vault-sync metadata.
- `.changeset/openwiki-markdown-byte-transport.md` — patch changeset for the published shared/DB contracts.

## Review Evidence

- Screenshots: Not applicable; this is a CLI/storage transport change with no UI-visible delta.
- Visual assessment: Not applicable.
- Standalone proof: `npx tsx packages/ewe-note/src/cli/openwiki-transport-dogfood.ts`
- Relative path: source `openwiki/index.md` = destination `openwiki/index.md`
- Full-file SHA-256: source = destination = `af1af341467933b344a979efe794ca9adda58771a8c5097f20b4b2958016365a`
- Frontmatter SHA-256: source = destination = `7e790ac3f8d6c443761ae5377c4267950800c427dbefba27ace43ddb0639ca8d`
- `cmp` result: byte-identical

```mermaid
flowchart LR
  A[Source directory<br/>openwiki/index.md] -->|vault engine parses + retains exact Markdown| B[Eweser notes room<br/>Y.Doc A]
  B -->|Yjs state update| C[Eweser notes room<br/>Y.Doc B]
  C -->|vault engine materializes unchanged source representation| D[Destination directory<br/>openwiki/index.md]
```

## Testing

- [x] Full repository gate passes (`npm run check`)
- [x] Focused vault sync tests pass (12 tests)
- [x] Ewe Note suite passes (180 tests)
- [x] Shared suite passes (67 tests)
- [x] Code index check passes (`npm run code-index:check`)
- [x] Standalone two-directory proof passes with matching path, bytes, frontmatter, and hashes

## Checklist

- [x] Changeset added for published package API changes
- [x] No secrets or personal/machine-specific content committed
- [x] No direct Yjs mutations introduced
- [x] Database migrations not applicable
- [x] UI screenshots not applicable (no UI change)
- [x] Data-flow diagram included