### PR TITLE
Fix overlapping EweNote registry syncs

### DIFF
--- a/.changeset/steady-registry-sync.md
+++ b/.changeset/steady-registry-sync.md
@@ -1,0 +1,5 @@
+---
+'@eweser/db': patch
+---
+
+Serialize registry sync requests and preserve rooms created while a sync is in flight.

--- a/packages/db/src/methods/connection/syncRegistry.test.ts
+++ b/packages/db/src/methods/connection/syncRegistry.test.ts
@@ -175,4 +175,127 @@ describe('syncRegistry', () => {
     );
     expect(db._pendingRegistryRoomIds).toEqual(new Set());
   });
+
+  it('serializes concurrent syncs and drains a room created mid-sync', async () => {
+    const firstRoom = {
+      id: 'first-room',
+      name: 'First notes room',
+      collectionKey: 'notes',
+    };
+    const secondRoom = {
+      id: 'second-room',
+      name: 'Second notes room',
+      collectionKey: 'notes',
+    };
+    let releaseFirstRequest = () => {};
+    const firstRequestGate = new Promise<void>((resolve) => {
+      releaseFirstRequest = resolve;
+    });
+    let requestCount = 0;
+    const serverFetch = vi.fn(async () => {
+      requestCount += 1;
+      if (requestCount === 1) {
+        await firstRequestGate;
+        return {
+          data: {
+            rooms: [firstRoom],
+            token: 'first-token',
+            userId: 'user-1',
+          },
+          error: null,
+        };
+      }
+      return {
+        data: {
+          rooms: [firstRoom, secondRoom],
+          token: 'second-token',
+          userId: 'user-1',
+        },
+        error: null,
+      };
+    });
+    const db = {
+      registry: [firstRoom],
+      _initialRoomIds: new Set(),
+      _pendingRegistryRoomIds: new Set([firstRoom.id]),
+      userId: '',
+      accessGrantToken: '',
+      getToken: () => 'token',
+      emit: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      serverFetch,
+    } as unknown as Database;
+    const runSync = syncRegistry(db);
+
+    const firstSync = runSync();
+    await vi.waitFor(() => expect(serverFetch).toHaveBeenCalledOnce());
+
+    db.registry.push(secondRoom as Database['registry'][number]);
+    db._pendingRegistryRoomIds.add(secondRoom.id);
+    const concurrentSync = runSync();
+
+    await Promise.resolve();
+    expect(serverFetch).toHaveBeenCalledOnce();
+
+    releaseFirstRequest();
+
+    await expect(Promise.all([firstSync, concurrentSync])).resolves.toEqual([
+      true,
+      true,
+    ]);
+    expect(serverFetch).toHaveBeenCalledTimes(2);
+    expect(serverFetch).toHaveBeenNthCalledWith(
+      2,
+      '/api/access-grant/sync-registry',
+      {
+        method: 'POST',
+        body: {
+          rooms: [firstRoom, secondRoom],
+          newRoomIds: [secondRoom.id],
+        },
+      }
+    );
+    expect(db.registry).toEqual([firstRoom, secondRoom]);
+    expect(db._pendingRegistryRoomIds).toEqual(new Set());
+  });
+
+  it('stops draining when the server does not accept a pending room', async () => {
+    const pendingRoom = {
+      id: 'pending-room',
+      name: 'Pending notes room',
+      collectionKey: 'notes',
+    };
+    const canonicalRoom = {
+      id: 'canonical-room',
+      name: 'Notes',
+      collectionKey: 'notes',
+    };
+    const serverFetch = vi.fn().mockResolvedValue({
+      data: {
+        rooms: [canonicalRoom],
+        token: 'next-token',
+        userId: 'user-1',
+      },
+      error: null,
+    });
+    const db = {
+      registry: [pendingRoom],
+      _initialRoomIds: new Set(),
+      _pendingRegistryRoomIds: new Set([pendingRoom.id]),
+      userId: '',
+      accessGrantToken: '',
+      getToken: () => 'token',
+      emit: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      serverFetch,
+    } as unknown as Database;
+
+    await expect(syncRegistry(db)()).resolves.toBe(false);
+
+    expect(serverFetch).toHaveBeenCalledOnce();
+    expect(db.registry).toEqual([canonicalRoom, pendingRoom]);
+    expect(db._pendingRegistryRoomIds).toEqual(new Set([pendingRoom.id]));
+  });
 });

--- a/packages/db/src/methods/connection/syncRegistry.ts
+++ b/packages/db/src/methods/connection/syncRegistry.ts
@@ -35,10 +35,11 @@ function unloadRoomsMissingFromRegistry(
   }
 }
 
-export const syncRegistry =
-  (db: Database) =>
-  /** sends the registry to the server to check for additions/subtractions on either side */
-  async () => {
+export const syncRegistry = (db: Database) => {
+  let inFlightSync: Promise<boolean> | null = null;
+
+  /** Sends one registry snapshot to the server. */
+  const syncOnce = async () => {
     db.emit('registrySync', 'syncing');
     const previousRooms = [...db.registry];
     const newRoomIds = [...db._pendingRegistryRoomIds];
@@ -80,12 +81,20 @@ export const syncRegistry =
       rooms.length >= 1
     ) {
       db.debug('setting new rooms', rooms);
-      // TODO: if a new room was created locally before the sync finishes, this might overwrite it
-      unloadRoomsMissingFromRegistry(db, previousRooms, rooms);
-      setLocalRegistry(db)(rooms);
-      db.registry = rooms;
+      const serverRoomIds = new Set(rooms.map((room) => room.id));
+      const roomsCreatedDuringSync = db.registry.filter(
+        (room) =>
+          db._pendingRegistryRoomIds.has(room.id) && !serverRoomIds.has(room.id)
+      );
+      const nextRooms = [...rooms, ...roomsCreatedDuringSync];
+
+      unloadRoomsMissingFromRegistry(db, previousRooms, nextRooms);
+      setLocalRegistry(db)(nextRooms);
+      db.registry = nextRooms;
       for (const roomId of newRoomIds) {
-        db._pendingRegistryRoomIds.delete(roomId);
+        if (serverRoomIds.has(roomId)) {
+          db._pendingRegistryRoomIds.delete(roomId);
+        }
       }
     } else {
       return false;
@@ -94,3 +103,39 @@ export const syncRegistry =
     db.emit('registrySync', 'success');
     return true;
   };
+
+  /** Sends the registry to the server and drains rooms created mid-sync. */
+  return async () => {
+    if (inFlightSync) {
+      return inFlightSync;
+    }
+
+    inFlightSync = (async () => {
+      do {
+        const pendingBefore = new Set(db._pendingRegistryRoomIds);
+        const synced = await syncOnce();
+        if (!synced) {
+          return false;
+        }
+
+        if (
+          db._pendingRegistryRoomIds.size > 0 &&
+          pendingBefore.size === db._pendingRegistryRoomIds.size &&
+          [...pendingBefore].every((roomId) =>
+            db._pendingRegistryRoomIds.has(roomId)
+          )
+        ) {
+          return false;
+        }
+      } while (db._pendingRegistryRoomIds.size > 0);
+
+      return true;
+    })();
+
+    try {
+      return await inFlightSync;
+    } finally {
+      inFlightSync = null;
+    }
+  };
+};


### PR DESCRIPTION
## What changed

- coalesce concurrent `syncRegistry()` callers onto one in-flight operation
- preserve locally created rooms that appear while a registry request is awaiting the server
- drain those pending registrations in a follow-up serialized request
- stop and report failure if the server makes no progress on a pending room
- add regression coverage for a room created mid-sync and for a rejected pending room

## Root cause and impact

EweNote's browser-vault import creates a notes room and an attachment room back-to-back. Each `newRoom()` could start its own registry request while the import also explicitly synchronized the registry. In production this produced overlapping requests: the first room registered successfully, then duplicate concurrent registrations for the second room returned HTTP 500 and the vault import aborted.

The SDK now serializes that boundary, so the vault room pair is registered deterministically without overwriting a room created during an in-flight request.

```mermaid
flowchart LR
  N[Create notes room] --> Q[Single registry sync queue]
  A[Create attachment room] --> Q
  Q --> S1[Register current snapshot]
  S1 --> P{Pending rooms remain?}
  P -- yes --> S2[Register next snapshot]
  P -- no --> R[Import resolves rooms]
```

## Validation

- `npm test --workspace @eweser/db` — 16 files passed, 113 tests passed, 1 todo
- `npm run type-check --workspace @eweser/db` — passed
- `npm run lint --workspace @eweser/db` — passed
- `npm run build --workspace @eweser/db` — passed
- `npm test --workspace @eweser/ewe-note -- src/app/lib/browser-vault-import.test.ts` — 2 tests passed
- pre-commit and pre-push formatting/secrets checks — passed

No UI styling changed, so there is no meaningful visual delta to screenshot. A full local EweNote build was additionally attempted, but the reused workstation dependency cache lacks the already-declared `@tiptap/extension-collaboration-cursor` package and exposes an unrelated Node type mismatch; clean CI remains the authoritative app build gate.