### PR TITLE
Fix EweNote vault attachment room IDs

### DIFF
--- a/.changeset/fresh-vault-attachments.md
+++ b/.changeset/fresh-vault-attachments.md
@@ -1,0 +1,5 @@
+---
+'@eweser/ewe-note': patch
+---
+
+Create browser vault attachment rooms with valid UUID identifiers.

--- a/packages/ewe-note/src/app/lib/browser-vault-import.test.ts
+++ b/packages/ewe-note/src/app/lib/browser-vault-import.test.ts
@@ -120,6 +120,12 @@ describe('importVaultFromFiles', () => {
     ].join('');
 
     expect(notes).toHaveLength(1);
+    expect(result.attachmentsRoomId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    );
+    expect(result.attachmentsRoomId).not.toBe(
+      `${result.noteRoomId}-attachments`
+    );
     expect(result.attachmentsUploaded).toBe(0);
     expect(result.attachmentsSkipped).toBe(0);
     expect(attachments).toHaveLength(1);

--- a/packages/ewe-note/src/app/lib/browser-vault-import.ts
+++ b/packages/ewe-note/src/app/lib/browser-vault-import.ts
@@ -537,7 +537,7 @@ export async function importVaultFromFiles(params: {
   });
 
   const noteRoomId = params.targetNoteRoomId ?? crypto.randomUUID();
-  const attachmentsRoomId = `${noteRoomId}-attachments`;
+  const attachmentsRoomId = crypto.randomUUID();
 
   if (!params.db.getRoom<Note>('notes', noteRoomId)) {
     params.db.newRoom<Note>({


### PR DESCRIPTION
## Summary

- generate a standards-compliant UUID for the browser vault attachment room
- keep the note room and attachment room independently addressable
- add a regression assertion and patch changeset

```mermaid
flowchart LR
  Picker[Local Markdown vault] --> Import[EweNote browser import]
  Import --> Note[Notes room UUID]
  Import --> Attach[Attachment room UUID]
  Note --> Registry[Auth registry sync]
  Attach --> Registry
  Registry --> Postgres[(UUID room IDs)]
```

## Why

The browser importer derived the attachment room ID as `<note UUID>-attachments`. The auth server stores room IDs in a PostgreSQL UUID column, so notes-room registration succeeded while attachment-room registration failed with HTTP 500.

## Verification

- `npm run test --workspace @eweser/ewe-note -- --run src/app/lib/browser-vault-import.test.ts` — 2 passed
- `npm run lint --workspace @eweser/ewe-note` — passed
- Prettier and `git diff --check` — passed
- staged/tracked secret scans — passed
- Full EweNote typecheck is still blocked by the existing workstation dependency cache (`@tiptap/extension-collaboration-cursor` missing) plus the pre-existing `BlobPart`/`Uint8Array<ArrayBufferLike>` fixture mismatch; neither is changed here.

## UI review

No visual styling or layout changed. The production-visible proof is the same vault picker completing successfully once this data fix deploys.
