### PR TITLE
Fix remote sync for newly registered local rooms

### DIFF
--- a/.changeset/registered-local-room-sync.md
+++ b/.changeset/registered-local-room-sync.md
@@ -1,0 +1,5 @@
+---
+'@eweser/db': patch
+---
+
+Connect newly registered local rooms after the server assigns their sync URL.

--- a/packages/db/src/methods/connection/loadRoom.test.ts
+++ b/packages/db/src/methods/connection/loadRoom.test.ts
@@ -196,6 +196,67 @@ describe('loadRoom', () => {
     expect(db.emit).toHaveBeenCalledWith('roomLoaded', room);
   });
 
+  it('hydrates server sync metadata onto an already-loaded local room', async () => {
+    const refreshSyncToken = vi.fn().mockResolvedValue({
+      syncUrl: 'ws://localhost:8080',
+      syncToken: 'sync-token',
+      tokenExpiry: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
+    });
+    const db = {
+      collections: {
+        notes: {},
+        flashcards: {},
+        profiles: {},
+      },
+      indexedDBProviderPolyfill: undefined,
+      getToken: () => 'access-grant-token',
+      useSync: true,
+      refreshSyncToken,
+      emit: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      error: vi.fn(),
+    } as unknown as Database;
+    const localRoom: ServerRoom = {
+      id: 'room-registered',
+      name: 'Registered Room',
+      collectionKey: 'notes',
+      tokenExpiry: null,
+      syncUrl: null,
+      publicAccess: 'private',
+      readAccess: [],
+      writeAccess: [],
+      adminAccess: [],
+      createdAt: null,
+      updatedAt: null,
+      _deleted: false,
+      _ttl: null,
+      encryption: null,
+    };
+
+    const room = await loadRoom(db)(localRoom, {
+      loadRemote: false,
+      awaitLoadRemote: false,
+    });
+    const localYdoc = room.ydoc;
+    const registeredRoom = {
+      ...localRoom,
+      syncUrl: 'ws://localhost:8080',
+    };
+
+    const loadedRoom = await loadRoom(db)(registeredRoom, {
+      loadRemote: true,
+      awaitLoadRemote: false,
+    });
+
+    expect(loadedRoom).toBe(room);
+    expect(loadedRoom.ydoc).toBe(localYdoc);
+    expect(loadedRoom.syncUrl).toBe('ws://localhost:8080');
+    expect(loadedRoom.syncProvider).toBe(providerInstances[0]);
+    expect(providerInstances).toHaveLength(1);
+    expect(initializeDocAndLocalProviderMock).toHaveBeenCalledTimes(1);
+  });
+
   it('returns an already loaded room without rebuilding local state', async () => {
     const refreshSyncToken = vi.fn().mockResolvedValue({
       syncUrl: 'ws://localhost:8080',

--- a/packages/db/src/methods/connection/loadRoom.ts
+++ b/packages/db/src/methods/connection/loadRoom.ts
@@ -216,8 +216,17 @@ export const loadRoom =
 
     const { roomId, collectionKey } = validate(serverRoom);
 
-    const room = (db.collections[collectionKey][roomId] ??
+    const existingRoom = db.collections[collectionKey][roomId];
+    const room = (existingRoom ??
       new Room({ db, ...serverRoom })) as unknown as Room<EweDocument>;
+
+    // A new local room is loaded before its first registry sync, so it does not
+    // have the server-assigned sync URL yet. Hydrate that connection metadata
+    // on the next load while preserving the room's existing local Y.Doc.
+    if (existingRoom) {
+      room.syncUrl = serverRoom.syncUrl;
+      room.tokenExpiry = serverRoom.tokenExpiry;
+    }
     db.info('loading room', { room, serverRoom });
 
     const { localLoaded, syncLoaded, shouldLoadSync } = checkLoadedState(db)(


### PR DESCRIPTION
## Summary

- hydrate the server-assigned sync URL when reloading an already-loaded local room
- preserve the local Y.Doc while attaching the remote provider
- add a focused regression test and patch changeset

## User flow

```mermaid
flowchart LR
  A[Create local room] --> B[Register room]
  B --> C[Server assigns sync URL]
  C --> D[Reload existing room]
  D --> E[Hydrate sync metadata]
  E --> F[Connect remote provider]
```

## Verification

- focused loadRoom test: 4 passing
- TypeScript no-emit check for packages/db
- ESLint and Prettier checks
- pre-commit and pre-push verification
- secret scan clean