### PR TITLE
fix(ewe-note): share collaboration plugin key

### DIFF
--- a/packages/ewe-note/src/components/tiptap-collaboration.test.ts
+++ b/packages/ewe-note/src/components/tiptap-collaboration.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+
+import { Editor } from '@tiptap/core';
+import Collaboration from '@tiptap/extension-collaboration';
+import CollaborationCursor from '@tiptap/extension-collaboration-cursor';
+import StarterKit from '@tiptap/starter-kit';
+import { Awareness } from 'y-protocols/awareness';
+import * as Y from 'yjs';
+import { describe, expect, it } from 'vitest';
+
+describe('TipTap collaboration dependency graph', () => {
+  it('initializes collaboration and cursor plugins against the same Yjs plugin key', () => {
+    const doc = new Y.Doc();
+    const fragment = doc.getXmlFragment('tiptap:note');
+    const awareness = new Awareness(doc);
+    let editor: Editor | undefined;
+
+    try {
+      expect(() => {
+        editor = new Editor({
+          extensions: [
+            StarterKit.configure({ history: false }),
+            Collaboration.configure({ fragment }),
+            CollaborationCursor.configure({
+              provider: { awareness },
+              user: { name: 'Test user', color: '#123456' },
+            }),
+          ],
+        });
+      }).not.toThrow();
+    } finally {
+      editor?.destroy();
+      awareness.destroy();
+      doc.destroy();
+    }
+  });
+});

--- a/packages/ewe-note/vite.config.ts
+++ b/packages/ewe-note/vite.config.ts
@@ -41,6 +41,9 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, './src'),
     },
+    // TipTap collaboration and cursor currently resolve different versions.
+    // They must share y-prosemirror's singleton ProseMirror PluginKeys.
+    dedupe: ['y-prosemirror'],
   },
   server: {
     port: devPort,

--- a/packages/ewe-note/vitest.config.ts
+++ b/packages/ewe-note/vitest.config.ts
@@ -8,11 +8,24 @@ export default defineConfig({
       '@eweser/db': path.resolve(__dirname, './src/test/mocks/eweser-db.ts'),
       '@eweser/shared': path.resolve(__dirname, '../shared/src/index.ts'),
     },
+    // Match the production bundle's y-prosemirror singleton.
+    dedupe: ['y-prosemirror'],
   },
   test: {
     env: {
       // Prevent dev environment variables from leaking into tests
       VITE_AUTH_SERVER: '',
+    },
+    server: {
+      deps: {
+        // Exercise Vite's resolver so this test detects duplicate
+        // y-prosemirror PluginKey instances across the TipTap extensions.
+        inline: [
+          '@tiptap/extension-collaboration',
+          '@tiptap/extension-collaboration-cursor',
+          'y-prosemirror',
+        ],
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary

- force TipTap collaboration and collaboration-cursor to resolve one `y-prosemirror` module
- add a regression test that initializes both extensions against one Yjs document
- run the regression through Vite's resolver so duplicate ProseMirror plugin keys remain detectable

## Why

EweNote's lockfile installs `y-prosemirror@1.2.13` for collaboration and
`y-prosemirror@1.3.7` for collaboration-cursor. On the first SPA open of a
synced note, the cursor plugin could therefore look up editor state using a
different `PluginKey`, crashing with `Cannot read properties of undefined
(reading 'doc')`. A reload happened to avoid that initialization path.

```mermaid
flowchart LR
  A[TipTap Collaboration] --> Y[Single y-prosemirror module]
  B[Collaboration Cursor] --> Y
  Y --> P[Shared ProseMirror plugin state]
```

## Verification

- red/green regression: disabling only `resolve.dedupe` reproduces `reading 'doc'`; restoring it passes
- `npm exec -- vitest run --config packages/ewe-note/vitest.config.ts packages/ewe-note/src/components/tiptap-editor.test.ts packages/ewe-note/src/components/tiptap-editor-refresh.test.ts packages/ewe-note/src/components/tiptap-collaboration.test.ts`
- `npm run lint --workspace @eweser/ewe-note`
- `npm run type-check --workspace @eweser/ewe-note`
- `npm run build --workspace @eweser/ewe-note`
- `npm run code-index:check`
- `npm exec -- prettier --check packages/ewe-note/vite.config.ts packages/ewe-note/vitest.config.ts packages/ewe-note/src/components/tiptap-collaboration.test.ts`
