### PR TITLE
Prioritize EweNote room sync

### DIFF
--- a/packages/ewe-note/src/INDEX.md
+++ b/packages/ewe-note/src/INDEX.md
@@ -19,6 +19,8 @@ helpers.
 - [`default-tutorial.ts`](./default-tutorial.ts): Starter tutorial note content
   and dismissal helpers.
 - [`notes-room.tsx`](./notes-room.tsx): React hook for note room state and CRUD.
+- [`prioritized-room-sync.ts`](./prioritized-room-sync.ts): Authenticates and
+  starts note-room sync before loading other account rooms in the background.
 - [`components/INDEX.md`](./components/): Editor, layout, sidebar, and UI
   component map.
 - [`cli/INDEX.md`](./cli/): Vault import, export, and sync CLI map.

--- a/packages/ewe-note/src/db.tsx
+++ b/packages/ewe-note/src/db.tsx
@@ -14,6 +14,7 @@ import {
 import { logger } from './utils';
 import { useGetUserFromDb } from './user';
 import { getDefaultNoteText } from './default-tutorial';
+import { loginWithPrioritizedNoteSync } from './prioritized-room-sync';
 
 /** to make sure that we only have one default room created, make a new uuid v4 for the default room, but if there is already one in localStorage use that*/
 const randomRoomId = crypto.randomUUID();
@@ -421,8 +422,11 @@ export const DbProvider = ({ children }: { children: ReactNode }) => {
       return;
     }
     async function login() {
-      const loginRes = await db.login({ loadAllRooms: true }); // beware this could be way too many if you have a lot of rooms. Better to call db.loadRooms() on the ones you actually need.
+      const loginRes = await loginWithPrioritizedNoteSync(db, (error) => {
+        logger('Error loading non-note rooms in the background', error);
+      });
       if (loginRes) {
+        setAllRooms(db.getRooms('notes'));
         setLoggedIn(true);
       }
     }

--- a/packages/ewe-note/src/prioritized-room-sync.test.ts
+++ b/packages/ewe-note/src/prioritized-room-sync.test.ts
@@ -1,0 +1,123 @@
+import type { Database, ServerRoom } from '@eweser/db';
+import { describe, expect, it, vi } from 'vitest';
+import { loginWithPrioritizedNoteSync } from './prioritized-room-sync';
+
+function makeRegistryRoom(
+  id: string,
+  collectionKey: ServerRoom['collectionKey'] = 'notes'
+) {
+  return { id, collectionKey } as ServerRoom;
+}
+
+function makeDatabase({
+  loginResult = true,
+  registry = [],
+  loadRoom = vi.fn().mockResolvedValue(undefined),
+  loadRooms = vi.fn().mockResolvedValue(undefined),
+}: {
+  loginResult?: boolean;
+  registry?: ServerRoom[];
+  loadRoom?: ReturnType<typeof vi.fn>;
+  loadRooms?: ReturnType<typeof vi.fn>;
+} = {}) {
+  return {
+    login: vi.fn().mockResolvedValue(loginResult),
+    loadRoom,
+    loadRooms,
+    registry,
+  } as unknown as Database;
+}
+
+describe('loginWithPrioritizedNoteSync', () => {
+  it('starts every note room before loading the full registry', async () => {
+    const events: string[] = [];
+    const firstRoom = makeRegistryRoom('first-note');
+    const secondRoom = makeRegistryRoom('second-note');
+    const profileRoom = makeRegistryRoom('profile', 'profiles');
+    const loadRoom = vi.fn().mockImplementation(async (room: ServerRoom) => {
+      events.push(room.id);
+    });
+    const loadRooms = vi.fn().mockImplementation(async () => {
+      events.push('registry');
+    });
+    const database = makeDatabase({
+      registry: [profileRoom, firstRoom, secondRoom],
+      loadRoom,
+      loadRooms,
+    });
+
+    await expect(loginWithPrioritizedNoteSync(database, vi.fn())).resolves.toBe(
+      true
+    );
+
+    expect(database.login).toHaveBeenCalledWith({ loadAllRooms: false });
+    expect(loadRoom).toHaveBeenCalledTimes(2);
+    expect(loadRoom).toHaveBeenNthCalledWith(1, firstRoom, {
+      loadRemote: true,
+      awaitLoadRemote: false,
+    });
+    expect(loadRoom).toHaveBeenNthCalledWith(2, secondRoom, {
+      loadRemote: true,
+      awaitLoadRemote: false,
+    });
+    expect(events).toEqual(['first-note', 'second-note', 'registry']);
+    expect(loadRooms).toHaveBeenCalledWith(database.registry, true);
+  });
+
+  it('continues when one note room fails to start', async () => {
+    const failedRoom = makeRegistryRoom('failed-note');
+    const availableRoom = makeRegistryRoom('available-note');
+    const loadRoom = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('room unavailable'))
+      .mockResolvedValueOnce(undefined);
+    const loadRooms = vi.fn().mockResolvedValue(undefined);
+    const database = makeDatabase({
+      registry: [failedRoom, availableRoom],
+      loadRoom,
+      loadRooms,
+    });
+
+    await expect(loginWithPrioritizedNoteSync(database, vi.fn())).resolves.toBe(
+      true
+    );
+
+    expect(loadRoom).toHaveBeenCalledTimes(2);
+    expect(loadRoom).toHaveBeenLastCalledWith(
+      availableRoom,
+      expect.any(Object)
+    );
+    expect(loadRooms).toHaveBeenCalledOnce();
+  });
+
+  it('does not load rooms when authentication fails', async () => {
+    const loadRoom = vi.fn();
+    const loadRooms = vi.fn();
+    const database = makeDatabase({
+      loginResult: false,
+      registry: [makeRegistryRoom('note')],
+      loadRoom,
+      loadRooms,
+    });
+
+    await expect(loginWithPrioritizedNoteSync(database, vi.fn())).resolves.toBe(
+      false
+    );
+
+    expect(loadRoom).not.toHaveBeenCalled();
+    expect(loadRooms).not.toHaveBeenCalled();
+  });
+
+  it('reports a background registry load failure', async () => {
+    const error = new Error('registry unavailable');
+    const onError = vi.fn();
+    const database = makeDatabase({
+      loadRooms: vi.fn().mockRejectedValue(error),
+    });
+
+    await loginWithPrioritizedNoteSync(database, onError);
+    await Promise.resolve();
+
+    expect(onError).toHaveBeenCalledWith(error);
+  });
+});

--- a/packages/ewe-note/src/prioritized-room-sync.ts
+++ b/packages/ewe-note/src/prioritized-room-sync.ts
@@ -1,0 +1,37 @@
+import type { Database } from '@eweser/db';
+
+export type BackgroundSyncErrorHandler = (error: unknown) => void;
+
+/**
+ * Authenticate without blocking the notes UI behind every room in the account.
+ *
+ * EweNote needs all note rooms immediately, while profile and other collection
+ * rooms can continue loading in the background.
+ */
+export async function loginWithPrioritizedNoteSync(
+  database: Database,
+  onBackgroundSyncError: BackgroundSyncErrorHandler
+): Promise<boolean> {
+  const loginResult = await database.login({ loadAllRooms: false });
+  if (!loginResult) {
+    return false;
+  }
+
+  const noteRooms = database.registry.filter(
+    (room) => room.collectionKey === 'notes'
+  );
+  await Promise.allSettled(
+    noteRooms.map((room) =>
+      database.loadRoom(room, {
+        loadRemote: true,
+        // Start every notes connection now instead of serially waiting for each
+        // websocket before beginning the next one.
+        awaitLoadRemote: false,
+      })
+    )
+  );
+
+  void database.loadRooms(database.registry, true).catch(onBackgroundSyncError);
+
+  return true;
+}


### PR DESCRIPTION
## What changed

- authenticate without serially waiting for every account room
- start all `notes` room remote connections in parallel immediately after registry sync
- refresh EweNote's room list as soon as prioritized note loading begins
- continue loading profile and other collection rooms in the background
- add focused coverage for ordering, partial failures, auth failure, and background errors

## Root cause

EweNote called `db.login({ loadAllRooms: true })`. The SDK deliberately staggers remote room connections by one second and waits for each connection, so a Git-backed room such as `priorities-vault` could remain visibly empty behind unrelated historical rooms even though its remote Yjs document was present and healthy.

## User impact

After a fresh load, EweNote now begins every notes-room connection immediately. Other collections still load, but no longer block note hydration.

## Validation

- `npm run type-check --workspace @eweser/ewe-note`
- `npm test --workspace @eweser/ewe-note` — 32 files, 191 tests passed
- `npm run lint --workspace @eweser/ewe-note`
- `npm run build --workspace @eweser/ewe-note`
- clean-browser smoke against the real auth and sync services: `priorities-vault` changed from `0 direct` to `1 direct` in about 2.5 seconds, then the existing `Priorities.md` opened with its complete content
- staged and tracked secret scans passed