### PR TITLE
fix(ewe-note): prevent new-note editor spinner

### DIFF
--- a/.codex/skills/eweser-create-pr/SKILL.md
+++ b/.codex/skills/eweser-create-pr/SKILL.md
@@ -15,6 +15,10 @@ You create a GitHub pull request summarizing completed work on the EweserDB mono
 1. Confirm QA has passed.
 2. Ensure the working tree state is understood with `git status`.
 3. Confirm with the user before pushing or publishing a branch unless they already asked for PR creation.
+4. Treat `publish`, `open a PR`, `create a PR`, and equivalent requests as
+   authorization for a ready-for-review pull request by default. Use a draft
+   only when the user explicitly asks for one or a known blocker makes the PR
+   unreviewable. Pending CI alone is not a reason to create a draft.
 
 ## Workflow
 
@@ -64,5 +68,8 @@ git --no-pager log --oneline main..HEAD
 ## Rules
 
 - Base branch is always `main`.
-- Draft the PR if any checklist item is unresolved.
+- Open a ready-for-review PR by default when the user asks to publish or create
+  a PR. Never silently downgrade the request to a draft.
+- Use a draft only when the user explicitly requests one or a known blocker
+  makes the PR unreviewable; state that blocker in the handoff.
 - Never push directly to `main`.

--- a/packages/ewe-note/src/app/contexts/NotesContext.test.tsx
+++ b/packages/ewe-note/src/app/contexts/NotesContext.test.tsx
@@ -321,10 +321,9 @@ describe('NotesContext parity behavior', () => {
       content: '# 2026-08-04 09:40 Untitled\n\nDraft',
     });
 
-    latestContext?.updateNote(
-      note?.id ?? '',
-      { content: '# Unsynced TODO\n\nDraft' }
-    );
+    latestContext?.updateNote(note?.id ?? '', {
+      content: '# Unsynced TODO\n\nDraft',
+    });
 
     await waitFor(() => {
       expect(
@@ -333,10 +332,9 @@ describe('NotesContext parity behavior', () => {
       ).toBe('Unsynced TODO');
     });
 
-    latestContext?.updateNote(
-      note?.id ?? '',
-      { content: '# Unsynced priorities\n\nDraft' }
-    );
+    latestContext?.updateNote(note?.id ?? '', {
+      content: '# Unsynced priorities\n\nDraft',
+    });
 
     await waitFor(() => {
       expect(
@@ -346,10 +344,9 @@ describe('NotesContext parity behavior', () => {
     });
 
     latestContext?.updateNote(note?.id ?? '', { title: 'Pinned title' });
-    latestContext?.updateNote(
-      note?.id ?? '',
-      { content: '# A different heading\n\nDraft' }
-    );
+    latestContext?.updateNote(note?.id ?? '', {
+      content: '# A different heading\n\nDraft',
+    });
 
     await waitFor(() => {
       expect(

--- a/packages/ewe-note/src/notes-room.test.tsx
+++ b/packages/ewe-note/src/notes-room.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { render, waitFor } from '@testing-library/react';
+import type { GetDocuments, Note, Room } from '@eweser/db';
+import { describe, expect, it, vi } from 'vitest';
+import { useNotesRoom } from './notes-room';
+
+const mockUseDb = vi.fn();
+
+vi.mock('./db', () => ({
+  defaultNoteId: 'default-note',
+  useDb: () => mockUseDb(),
+}));
+
+function buildNote(id: string): Note {
+  const now = Date.now();
+  return {
+    _id: id,
+    _ref: `local|notes|room-notes|${id}`,
+    _created: now,
+    _updated: now,
+    _deleted: false,
+    text: `# ${id}`,
+  };
+}
+
+describe('useNotesRoom', () => {
+  it('refreshes notes after subscribing so a creation during mount is not missed', async () => {
+    const existingNote = buildNote('existing-note');
+    const createdNote = buildNote('created-during-subscription');
+    let records: Record<string, Note> = {
+      [existingNote._id]: existingNote,
+    };
+    const unobserve = vi.fn();
+    const documents = {
+      unobserve,
+    };
+
+    const Notes = {
+      documents,
+      getUndeleted: () => records,
+      sortByRecent: (notes: Record<string, Note>) => notes,
+      onChange: vi.fn(() => {
+        records = { ...records, [createdNote._id]: createdNote };
+      }),
+    } as unknown as GetDocuments<Note>;
+    const room = {
+      id: 'room-notes',
+      getDocuments: () => Notes,
+      on: vi.fn(),
+      off: vi.fn(),
+    } as unknown as Room<Note>;
+
+    mockUseDb.mockReturnValue({
+      db: { getRoom: () => room },
+      setSelectedNoteId: vi.fn(),
+    });
+
+    let visibleNotes: Record<string, Note> | null = null;
+    function Probe() {
+      visibleNotes = useNotesRoom(room.id).notes;
+      return null;
+    }
+
+    const view = render(<Probe />);
+
+    await waitFor(() => {
+      expect(visibleNotes?.[createdNote._id]).toEqual(createdNote);
+    });
+
+    view.unmount();
+    expect(unobserve).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/ewe-note/src/notes-room.test.tsx
+++ b/packages/ewe-note/src/notes-room.test.tsx
@@ -34,11 +34,12 @@ describe('useNotesRoom', () => {
     const documents = {
       unobserve,
     };
+    const sortByRecent = vi.fn((notes: Record<string, Note>) => notes);
 
     const Notes = {
       documents,
       getUndeleted: () => records,
-      sortByRecent: (notes: Record<string, Note>) => notes,
+      sortByRecent,
       onChange: vi.fn(() => {
         records = { ...records, [createdNote._id]: createdNote };
       }),
@@ -66,6 +67,7 @@ describe('useNotesRoom', () => {
     await waitFor(() => {
       expect(visibleNotes?.[createdNote._id]).toEqual(createdNote);
     });
+    expect(sortByRecent).toHaveBeenLastCalledWith(records);
 
     view.unmount();
     expect(unobserve).toHaveBeenCalledOnce();

--- a/packages/ewe-note/src/notes-room.tsx
+++ b/packages/ewe-note/src/notes-room.tsx
@@ -68,6 +68,7 @@ export const useNotesRoom = (
       setNotes(Notes.getUndeleted());
     };
     Notes.onChange(handleNotesChange);
+    handleNotesChange();
     return () => {
       Notes.documents.unobserve(handleNotesChange);
     };

--- a/packages/ewe-note/src/notes-room.tsx
+++ b/packages/ewe-note/src/notes-room.tsx
@@ -66,7 +66,7 @@ export const useNotesRoom = (
   // listen for changes to the ydoc and update the state
   useEffect(() => {
     const handleNotesChange = () => {
-      setNotes(Notes.getUndeleted());
+      setNotes(Notes.sortByRecent(Notes.getUndeleted()));
     };
     Notes.onChange(handleNotesChange);
     handleNotesChange();


### PR DESCRIPTION
## What

Fix Ewe Note's new-note route getting stuck on an indefinite editor spinner even though the note was successfully created and persisted.

The editor hook could render its initial room snapshot, then miss a document creation before its effect subscribed. Re-reading and recent-ordering the room immediately after subscription closes that race.

## Changes

- `packages/ewe-note/src/notes-room.tsx` — refresh and normalize the current document snapshot immediately after registering the Yjs observer.
- `packages/ewe-note/src/notes-room.test.tsx` — reproduce a note created during subscription setup and verify it becomes visible and recent-ordered.
- `packages/ewe-note/src/app/contexts/NotesContext.test.tsx` — format current-main generated-title coverage so the final integrated branch passes repository formatting.
- `.codex/skills/eweser-create-pr/SKILL.md` — make ready-for-review PRs the default for publish/create-PR requests.

## Review Evidence

- Screenshot: synthetic local-only after-state captured and visually inspected in the originating Codex review.
- Interactive application: https://bright-regulated-outcome-thin.trycloudflare.com/
  - Route: `/` → **New note** → `/editor/:noteId`
  - Mode: synthetic browser-local data, signed out, no production credentials
  - Review lifetime: supervised until approximately 2026-08-04 11:53 CST
- Visual assessment: pass. The new note title/editor renders immediately; panes and title remain aligned, list truncation is contained, and no clipping, overflow, or density regression was observed.
- Diagram: not applicable; this is a one-hook subscription timing fix and does not alter data-flow architecture.

## Verification

- [x] Focused regression test passed red → green
- [x] Ewe Note suite passed: 31 files, 179 tests
- [x] Local focused regression passed after final review adjustment
- [x] Pre-commit lint/format and tracked secret scan passed
- [x] Production Vite build succeeded
- [x] GitHub checks passed on final head `924a840`: pre-deploy sanity, changed-area detection, lint/format, typecheck/unit, and E2E smoke
- [x] Automated review finding addressed and thread resolved
- [x] Changeset not required: Ewe Note is unpublished and no public package API changed
- [x] No secrets, direct Yjs mutation, database migration, auth, or permission change