### PR TITLE
Fix Ewe Note title sync with first heading

### DIFF
--- a/packages/ewe-note/src/app/contexts/NotesContext.test.ts
+++ b/packages/ewe-note/src/app/contexts/NotesContext.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
 import { collectFolderTreeIds } from './folder-tree';
-import { buildDefaultUntitledNoteTitle } from './note-titles';
+import {
+  buildDefaultUntitledNoteTitle,
+  getFirstHeading,
+  getSyncedTitle,
+  isDefaultUntitledNoteTitle,
+} from './note-titles';
 
 describe('collectFolderTreeIds', () => {
   it('includes the selected folder and all descendants', () => {
@@ -32,5 +37,24 @@ describe('collectFolderTreeIds', () => {
     expect(buildDefaultUntitledNoteTitle(new Date('2026-05-04T09:07:00'))).toBe(
       '2026-05-04 09:07 Untitled'
     );
+  });
+
+  it('recognizes timestamped untitled note titles', () => {
+    expect(isDefaultUntitledNoteTitle('2026-05-04 09:07 Untitled')).toBe(true);
+    expect(isDefaultUntitledNoteTitle('Project brief')).toBe(false);
+  });
+
+  it('syncs generated and heading-backed titles without replacing explicit titles', () => {
+    expect(getFirstHeading('# Unsynced TODO\n\nDraft')).toBe('Unsynced TODO');
+    expect(
+      getSyncedTitle(
+        '2026-08-04 09:40 Untitled',
+        '# 2026-08-04 09:40 Untitled',
+        '# Unsynced TODO'
+      )
+    ).toBe('Unsynced TODO');
+    expect(
+      getSyncedTitle('Pinned title', '# Unsynced TODO', '# A different heading')
+    ).toBeNull();
   });
 });

--- a/packages/ewe-note/src/app/contexts/NotesContext.test.tsx
+++ b/packages/ewe-note/src/app/contexts/NotesContext.test.tsx
@@ -313,6 +313,52 @@ describe('NotesContext parity behavior', () => {
     );
   });
 
+  it('synchronizes an automatic title with first-heading edits', async () => {
+    await renderProviderWithFixtures(['01 Markdown Syntax.md']);
+
+    const note = latestContext?.addNote({
+      title: '2026-08-04 09:40 Untitled',
+      content: '# 2026-08-04 09:40 Untitled\n\nDraft',
+    });
+
+    latestContext?.updateNote(
+      note?.id ?? '',
+      { content: '# Unsynced TODO\n\nDraft' }
+    );
+
+    await waitFor(() => {
+      expect(
+        latestContext?.notes.find((candidate) => candidate.id === note?.id)
+          ?.title
+      ).toBe('Unsynced TODO');
+    });
+
+    latestContext?.updateNote(
+      note?.id ?? '',
+      { content: '# Unsynced priorities\n\nDraft' }
+    );
+
+    await waitFor(() => {
+      expect(
+        latestContext?.notes.find((candidate) => candidate.id === note?.id)
+          ?.title
+      ).toBe('Unsynced priorities');
+    });
+
+    latestContext?.updateNote(note?.id ?? '', { title: 'Pinned title' });
+    latestContext?.updateNote(
+      note?.id ?? '',
+      { content: '# A different heading\n\nDraft' }
+    );
+
+    await waitFor(() => {
+      expect(
+        latestContext?.notes.find((candidate) => candidate.id === note?.id)
+          ?.title
+      ).toBe('Pinned title');
+    });
+  });
+
   it('resolves fixture links, backlinks, title derivation, and unlinked mention conversion', async () => {
     await renderProviderWithFixtures([
       '01 Markdown Syntax.md',

--- a/packages/ewe-note/src/app/contexts/NotesContext.tsx
+++ b/packages/ewe-note/src/app/contexts/NotesContext.tsx
@@ -5,7 +5,12 @@ import { useDb } from '@/db';
 import { useFolders } from '@/notes-room';
 import { collectFolderTreeIds } from './folder-tree';
 import { writeBrowserLocalVaultNotes } from '../lib/browser-local-vault';
-import { buildDefaultUntitledNoteTitle, UNTITLED_TITLE } from './note-titles';
+import {
+  buildDefaultUntitledNoteTitle,
+  getFirstHeading,
+  getSyncedTitle,
+  UNTITLED_TITLE,
+} from './note-titles';
 import {
   extractWikiLinkTargets,
   extractUnlinkedMentions,
@@ -156,9 +161,9 @@ function deriveTitle(note: DbNote) {
     return fmTitle.trim();
   }
 
-  const headingMatch = note.text.match(/^#\s+(.+)$/m);
-  if (headingMatch?.[1]) {
-    return headingMatch[1].trim();
+  const heading = getFirstHeading(note.text);
+  if (heading) {
+    return heading;
   }
 
   const plain = removeMarkdown(note.text).trim();
@@ -650,6 +655,16 @@ export function NotesProvider({ children }: { children: React.ReactNode }) {
 
     if (updates.content !== undefined) {
       next.text = updates.content;
+      const currentTitle = deriveTitle(found.source);
+      const syncedTitle = getSyncedTitle(
+        currentTitle,
+        found.source.text,
+        updates.content
+      );
+
+      if (syncedTitle) {
+        nextFrontmatter.title = syncedTitle;
+      }
     }
 
     if (updates.title !== undefined) {

--- a/packages/ewe-note/src/app/contexts/note-titles.ts
+++ b/packages/ewe-note/src/app/contexts/note-titles.ts
@@ -9,3 +9,26 @@ export function buildDefaultUntitledNoteTitle(date = new Date()) {
 
   return `${year}-${month}-${day} ${hours}:${minutes} ${UNTITLED_TITLE}`;
 }
+
+export function isDefaultUntitledNoteTitle(title: string) {
+  return /^\d{4}-\d{2}-\d{2} \d{2}:\d{2} Untitled$/.test(title);
+}
+
+export function getFirstHeading(text: string) {
+  const headingMatch = text.match(/^#\s+(.+)$/m);
+  return headingMatch?.[1]?.trim() || null;
+}
+
+export function getSyncedTitle(
+  currentTitle: string,
+  previousText: string,
+  nextText: string
+) {
+  const nextHeading = getFirstHeading(nextText);
+  if (!nextHeading) return null;
+
+  return isDefaultUntitledNoteTitle(currentTitle) ||
+    currentTitle === getFirstHeading(previousText)
+    ? nextHeading
+    : null;
+}

--- a/packages/ewe-note/src/notes-room.tsx
+++ b/packages/ewe-note/src/notes-room.tsx
@@ -15,6 +15,7 @@ import {
   isDefaultTutorialDismissalChecked,
   markDefaultTutorialDismissed,
 } from './default-tutorial';
+import { getFirstHeading, getSyncedTitle } from './app/contexts/note-titles';
 
 export type NotesRoomType = {
   room: Room<Note> | null;
@@ -114,7 +115,19 @@ export const useNotesRoom = (
     if (!note) return;
     if (dismissDefaultTutorialIfChecked(text, note)) return;
 
+    const frontmatterTitle = note.frontmatter?.title;
+    const currentTitle =
+      typeof frontmatterTitle === 'string' && frontmatterTitle.trim()
+        ? frontmatterTitle.trim()
+        : getFirstHeading(note.text);
+    const syncedTitle = currentTitle
+      ? getSyncedTitle(currentTitle, note.text, text)
+      : null;
+
     note.text = text;
+    if (syncedTitle) {
+      note.frontmatter = { ...note.frontmatter, title: syncedTitle };
+    }
     Notes.set(note);
   };
 


### PR DESCRIPTION
## What

Keeps an automatically generated Ewe Note title in sync with edits to the document first H1. A title deliberately set to a different value remains independent.

## Changes

- packages/ewe-note/src/notes-room.tsx - synchronize the title in the editor persisted save path.
- packages/ewe-note/src/app/contexts/NotesContext.tsx - apply the same rule to redesigned-context saves.
- packages/ewe-note/src/app/contexts/note-titles.ts - centralize heading/title synchronization helpers.
- packages/ewe-note/src/app/contexts tests - cover generated, synchronized, and explicit title cases.

## Review Evidence

- Screenshots: Not available. The worktree has no installed frontend dependencies, so a safe local UI runtime could not be started.
- Visual assessment: Not applicable; this is a title-data synchronization change with no layout or style delta.
- Diagrams: Not applicable.

## Testing

- [ ] Unit tests pass - blocked: vitest not found.
- [ ] Types clean - not run because dependencies are absent.
- [ ] Build succeeds - not run because dependencies are absent.
- [x] git diff --check
- [x] Pre-push tracked-secret scan

## Checklist

- [x] Changeset not needed; no published package API changed.
- [x] No secrets committed.
- [x] No direct Yjs mutations introduced.
- [x] No database migrations involved.
- [ ] UI-visible changes include screenshots; unavailable because dependencies are absent.
- [x] UI screenshot assessment is not applicable; no visual layout change.
- [x] Backend/data-flow diagram not applicable.