### PR TITLE
Improve Ewe Note tree drag and layout

### DIFF
--- a/packages/ewe-note/src/app/components/EnhancedSidebar.test.tsx
+++ b/packages/ewe-note/src/app/components/EnhancedSidebar.test.tsx
@@ -12,6 +12,8 @@ const updateFolder = vi.fn();
 const deleteFolder = vi.fn();
 const addNote = vi.fn(() => ({ id: 'note-created' }));
 const moveNote = vi.fn();
+const useDrag = vi.fn((_spec: unknown) => [{ isDragging: false }, vi.fn()]);
+const useDrop = vi.fn((_spec: unknown) => [{ isOver: false }, vi.fn()]);
 const makeNote = (overrides: Partial<Record<string, unknown>> = {}) => ({
   id: 'note-1',
   roomId: 'room-1',
@@ -152,7 +154,8 @@ vi.mock('../../components/ui/tooltip', () => ({
 
 vi.mock('react-dnd', () => ({
   DndProvider: ({ children }: { children: ReactNode }) => children,
-  useDrop: () => [{ isOver: false }, vi.fn()],
+  useDrag: (spec: unknown) => useDrag(spec),
+  useDrop: (spec: unknown) => useDrop(spec),
 }));
 
 vi.mock('react-dnd-html5-backend', () => ({
@@ -166,6 +169,8 @@ describe('EnhancedSidebar', () => {
     deleteFolder.mockClear();
     addNote.mockClear();
     moveNote.mockClear();
+    useDrag.mockClear();
+    useDrop.mockClear();
     mockNavigate.mockClear();
     getDirectNotesInFolder.mockClear();
     getNotesInFolder.mockClear();
@@ -224,6 +229,44 @@ describe('EnhancedSidebar', () => {
     fireEvent.click(noteButton);
 
     expect(mockNavigate).toHaveBeenCalledWith('/editor/note-1');
+  });
+
+  it('makes each direct note a drag source with its current folder', () => {
+    render(<EnhancedSidebar onSearchClick={vi.fn()} activeView="recent" />);
+
+    expect(
+      document.querySelector('[data-cy="ewe-note-note-drag-source-note-1"]')
+    ).not.toBeNull();
+    expect(useDrag).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'note',
+        item: { noteId: 'note-1', folderId: 'root-folder' },
+      })
+    );
+  });
+
+  it('moves a dragged note when it is dropped on another folder', () => {
+    render(<EnhancedSidebar onSearchClick={vi.fn()} activeView="recent" />);
+
+    const childFolderDropSpec = useDrop.mock.calls
+      .map(
+        ([spec]) =>
+          spec as {
+            drop?: (item: { noteId: string; folderId: string }) => void;
+          }
+      )
+      .find((spec) => {
+        const item = { noteId: 'note-1', folderId: 'root-folder' };
+        moveNote.mockClear();
+        spec.drop?.(item);
+        return moveNote.mock.calls.some(
+          ([noteId, folderId]) =>
+            noteId === item.noteId && folderId === 'child-folder'
+        );
+      });
+
+    expect(childFolderDropSpec).toBeDefined();
+    expect(moveNote).toHaveBeenCalledWith('note-1', 'child-folder');
   });
 
   it('offers mobile folder actions that can create a subfolder', () => {

--- a/packages/ewe-note/src/app/components/EnhancedSidebar.tsx
+++ b/packages/ewe-note/src/app/components/EnhancedSidebar.tsx
@@ -38,7 +38,7 @@ import {
 import { Button } from './ui/button';
 import { Input } from './ui/input';
 import { getSyncStatusDotClass } from './sync-status-visual';
-import { DndProvider, useDrop } from 'react-dnd';
+import { DndProvider, useDrag, useDrop } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import {
   DropdownMenu,
@@ -559,27 +559,56 @@ function FolderBranch({
             />
           ))}
           {folderNotes.map((note) => (
-            <button
+            <DraggableNoteItem
               key={note.id}
-              type="button"
-              onClick={() => navigate(`/editor/${note.id}`)}
-              className={`flex w-full min-w-0 items-start gap-2 rounded-2xl px-3 py-2 text-left text-sm transition-colors ${
-                currentNoteId === note.id
-                  ? 'bg-sidebar-accent text-sidebar-foreground'
-                  : 'hover:bg-sidebar-accent/70'
-              }`}
-              title={formatTreeNoteTitle(note.title)}
-              aria-label={`Open note ${formatTreeNoteTitle(note.title)}`}
-            >
-              <FileText className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
-              <span className="min-w-0 flex-1 truncate leading-5">
-                {formatTreeNoteTitle(note.title)}
-              </span>
-            </button>
+              note={note}
+              isActive={currentNoteId === note.id}
+              onOpen={() => navigate(`/editor/${note.id}`)}
+            />
           ))}
         </div>
       ) : null}
     </div>
+  );
+}
+
+function DraggableNoteItem({
+  note,
+  isActive,
+  onOpen,
+}: {
+  note: NotesNote;
+  isActive: boolean;
+  onOpen: () => void;
+}) {
+  const [{ isDragging }, drag] = useDrag<
+    DraggedNoteItem,
+    unknown,
+    { isDragging: boolean }
+  >({
+    type: ItemTypes.NOTE,
+    item: { noteId: note.id, folderId: note.folder },
+    collect: (monitor) => ({ isDragging: monitor.isDragging() }),
+  });
+  const title = formatTreeNoteTitle(note.title);
+
+  return (
+    <button
+      ref={drag}
+      type="button"
+      onClick={onOpen}
+      data-cy={`ewe-note-note-drag-source-${note.id}`}
+      className={`flex w-full min-w-0 items-start gap-2 rounded-md py-1.5 pl-10 pr-3 text-left text-sm transition-colors ${
+        isActive
+          ? 'bg-sidebar-accent text-sidebar-foreground'
+          : 'hover:bg-sidebar-accent/70'
+      } ${isDragging ? 'cursor-grabbing opacity-50' : 'cursor-grab'}`}
+      title={`Drag to move • ${title}`}
+      aria-label={`Open note ${title}`}
+    >
+      <FileText className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+      <span className="min-w-0 flex-1 truncate leading-5">{title}</span>
+    </button>
   );
 }
 
@@ -631,8 +660,8 @@ function FolderItem({
   return (
     <div
       ref={drop}
-      className={`flex w-full min-w-0 items-center gap-1 rounded-2xl transition-colors ${
-        isOver ? 'border border-primary/30 bg-primary/10' : ''
+      className={`flex w-full min-w-0 items-center gap-1 rounded-md transition-colors ${
+        isOver ? 'bg-primary/15 ring-1 ring-primary/40' : ''
       }`}
     >
       <button
@@ -648,7 +677,7 @@ function FolderItem({
         )}
       </button>
       <button
-        className={`flex min-w-0 flex-1 items-center gap-2 rounded-2xl px-3 py-2 text-left transition-colors ${
+        className={`flex min-w-0 flex-1 items-center gap-2 rounded-md px-3 py-1.5 text-left transition-colors ${
           active
             ? 'bg-sidebar-accent text-sidebar-foreground'
             : 'hover:bg-sidebar-accent/70'
@@ -657,7 +686,7 @@ function FolderItem({
         title={folder.name}
       >
         <FolderOpen className="h-4 w-4 shrink-0 self-start text-muted-foreground" />
-        <span className="min-w-0 flex-1 text-sm leading-5 [overflow-wrap:anywhere]">
+        <span className="min-w-0 flex-1 truncate whitespace-nowrap text-sm leading-5">
           {folder.name}
         </span>
         <span className="shrink-0 self-center text-[11px] text-muted-foreground">

--- a/packages/ewe-note/src/app/contexts/NotesContext.test.tsx
+++ b/packages/ewe-note/src/app/contexts/NotesContext.test.tsx
@@ -321,10 +321,9 @@ describe('NotesContext parity behavior', () => {
       content: '# 2026-08-04 09:40 Untitled\n\nDraft',
     });
 
-    latestContext?.updateNote(
-      note?.id ?? '',
-      { content: '# Unsynced TODO\n\nDraft' }
-    );
+    latestContext?.updateNote(note?.id ?? '', {
+      content: '# Unsynced TODO\n\nDraft',
+    });
 
     await waitFor(() => {
       expect(
@@ -333,10 +332,9 @@ describe('NotesContext parity behavior', () => {
       ).toBe('Unsynced TODO');
     });
 
-    latestContext?.updateNote(
-      note?.id ?? '',
-      { content: '# Unsynced priorities\n\nDraft' }
-    );
+    latestContext?.updateNote(note?.id ?? '', {
+      content: '# Unsynced priorities\n\nDraft',
+    });
 
     await waitFor(() => {
       expect(
@@ -346,10 +344,9 @@ describe('NotesContext parity behavior', () => {
     });
 
     latestContext?.updateNote(note?.id ?? '', { title: 'Pinned title' });
-    latestContext?.updateNote(
-      note?.id ?? '',
-      { content: '# A different heading\n\nDraft' }
-    );
+    latestContext?.updateNote(note?.id ?? '', {
+      content: '# A different heading\n\nDraft',
+    });
 
     await waitFor(() => {
       expect(


### PR DESCRIPTION
## What changed

- Make note rows in the Ewe Note folder tree real drag sources, so a note can be dropped onto another folder.
- Add visible drag affordances and folder drop highlighting.
- Compact tree rows, indent notes beneath their folders, and truncate long folder names instead of wrapping them across lines.

## Why

The sidebar already had folder drop targets but no draggable note source. Its row layout also made nested notes and long folder names hard to scan.

## Validation

- `npm test --workspace @eweser/ewe-note -- --run src/app/components/EnhancedSidebar.test.tsx` (10 passing)
- `npm run lint --workspace @eweser/ewe-note -- --quiet src/app/components/EnhancedSidebar.tsx src/app/components/EnhancedSidebar.test.tsx`
- `git diff --check`

## Verification gap

Workspace type-check is currently blocked by pre-existing failures in `browser-vault-import.test.ts` and a missing `@tiptap/extension-collaboration-cursor` module. The local preview was also blocked by an existing `packages/db` compile error requiring `RegistrySyncRequestBody.newRoomIds`.