### PR TITLE
fix(ewe-note): surface delete actions

### DIFF
--- a/e2e/cypress/tests/ewe-note.cy.ts
+++ b/e2e/cypress/tests/ewe-note.cy.ts
@@ -114,6 +114,23 @@ describe('ewe-note app', () => {
     cy.contains(folderName).should('exist');
   });
 
+  it('deletes a folder from its visible sidebar action', () => {
+    const folderName = `Delete Folder ${Date.now()}`;
+    visitHome();
+
+    cy.getBySel('ewe-note-new-folder-trigger').click();
+    cy.getBySel('ewe-note-folder-name-input').type(folderName);
+    cy.getBySel('ewe-note-folder-submit').click();
+    cy.contains(folderName).should('exist');
+
+    cy.window().then((win) => {
+      cy.stub(win, 'confirm').returns(true);
+    });
+
+    cy.get(`button[aria-label="Delete folder ${folderName}"]`).click();
+    cy.contains(folderName).should('not.exist');
+  });
+
   it('moves an open note to a folder from visible note actions', () => {
     const folderName = `Move Target ${Date.now()}`;
     const noteTitle = `Move me ${Date.now()}`;
@@ -201,7 +218,7 @@ describe('ewe-note app', () => {
     cy.getBySel('ewe-note-sidebar').should('not.exist');
   });
 
-  it('deletes a note from the editor menu and returns home', () => {
+  it('deletes a note from the visible editor action and returns home', () => {
     visitHome();
 
     createNote('# Delete me');
@@ -210,8 +227,7 @@ describe('ewe-note app', () => {
       cy.stub(win, 'confirm').returns(true);
     });
 
-    cy.getBySel('ewe-note-editor-menu-trigger').click();
-    cy.getBySel('ewe-note-delete-note').click();
+    cy.getBySel('ewe-note-delete-note-button').click();
 
     cy.url({ timeout: 10000 }).should('not.include', '/editor/');
     cy.getBySel('ewe-note-sidebar').should('exist');

--- a/packages/ewe-note/src/app/components/EnhancedSidebar.test.tsx
+++ b/packages/ewe-note/src/app/components/EnhancedSidebar.test.tsx
@@ -178,6 +178,7 @@ describe('EnhancedSidebar', () => {
 
   afterEach(() => {
     cleanup();
+    vi.restoreAllMocks();
   });
 
   it('renders nested folders from parentId relationships', () => {
@@ -224,8 +225,6 @@ describe('EnhancedSidebar', () => {
     expect(
       screen.queryByRole('button', { name: 'Open note **Child note**' })
     ).toBeNull();
-    expect(screen.getAllByText('1 direct')).toHaveLength(2);
-
     fireEvent.click(noteButton);
 
     expect(mockNavigate).toHaveBeenCalledWith('/editor/note-1');
@@ -283,6 +282,21 @@ describe('EnhancedSidebar', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Create' }));
 
     expect(addFolder).toHaveBeenCalledWith('Mobile Archive', 'root-folder');
+  });
+
+  it('exposes folder deletion without opening the overflow menu', () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    render(<EnhancedSidebar onSearchClick={vi.fn()} activeView="recent" />);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Delete folder Projects' })
+    );
+
+    expect(confirmSpy).toHaveBeenCalledWith(
+      'Delete "Projects" and move 2 notes plus keep 1 subfolder?'
+    );
+    expect(deleteFolder).toHaveBeenCalledWith('root-folder');
   });
 
   it('exposes a pinned notes filter in the rail', () => {

--- a/packages/ewe-note/src/app/components/EnhancedSidebar.tsx
+++ b/packages/ewe-note/src/app/components/EnhancedSidebar.tsx
@@ -683,16 +683,25 @@ function FolderItem({
             : 'hover:bg-sidebar-accent/70'
         }`}
         onClick={onClick}
-        title={folder.name}
+        title={`${folder.name} (${folderNotes.length} direct)`}
       >
         <FolderOpen className="h-4 w-4 shrink-0 self-start text-muted-foreground" />
         <span className="min-w-0 flex-1 truncate whitespace-nowrap text-sm leading-5">
           {folder.name}
         </span>
-        <span className="shrink-0 self-center text-[11px] text-muted-foreground">
-          {folderNotes.length} direct
-        </span>
       </button>
+      {folder.kind === 'folder' ? (
+        <button
+          type="button"
+          aria-label={`Delete folder ${folder.name}`}
+          title={`Delete folder ${folder.name}`}
+          onClick={onDelete}
+          className="shrink-0 self-center rounded-full p-1 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          data-cy={`ewe-note-delete-folder-${folder.id}`}
+        >
+          <Trash2 className="h-4 w-4" />
+        </button>
+      ) : null}
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <button

--- a/packages/ewe-note/src/app/pages/EnhancedEditor.tsx
+++ b/packages/ewe-note/src/app/pages/EnhancedEditor.tsx
@@ -15,6 +15,7 @@ import {
   FolderInput,
   FileCode,
   Eye,
+  Trash2,
 } from 'lucide-react';
 import { RightPanel } from '../components/RightPanel';
 import { useNotes } from '../contexts/NotesContext';
@@ -369,6 +370,16 @@ function EditorWorkspace({
               />
             </button>
           ) : null}
+          <button
+            type="button"
+            aria-label="Delete note"
+            data-cy="ewe-note-delete-note-button"
+            onClick={onDelete}
+            className="rounded-full p-2 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            title="Delete note"
+          >
+            <Trash2 className="w-4 h-4" />
+          </button>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <button


### PR DESCRIPTION
## Summary

- put a visible delete action in the note editor toolbar while retaining the existing overflow action
- put a visible delete action on ordinary folder rows while retaining folder overflow actions
- truncate long folder names and move the direct-note count into the folder tooltip so the added control does not create wrapped or cramped rows
- cover the visible note and folder actions in component/browser specs

## Review surfaces

- Interactive app: https://ryan-glow-rosa-favor.trycloudflare.com/notes/
- Screenshot gallery: https://studio-radical-breed-produced.trycloudflare.com/
- Route: `/notes/`
- Data/auth mode: signed-out, synthetic local-only fixture data; no production credentials or data
- Lifetime: bounded to two hours from 2026-08-04 10:24 Asia/Shanghai
- Cleanup: `kill 1207726 1208714 1209322 1209944`

## Verification

- `npm test --workspace @eweser/ewe-note` — 33 files, 198 tests passed
- targeted ESLint for all four changed files — passed
- `npm run build --workspace @eweser/shared` — passed
- `npm run type-check --workspace @eweser/ewe-note` — passed
- `npm run build --workspace @eweser/ewe-note` — passed
- `npm run check` — full repository lint, formatting, type-check, and unit suite passed
- production-build browser review at 1280 × 800 and 390 × 844 — passed
- direct note and folder actions each opened the existing confirmation dialog — passed
- external app and gallery URLs — HTTP 200 and browser-usable
- pre-commit and pre-push secret/staged verification — passed

## Known verification gaps

- The Cypress spec could not execute on this host because the system does not provide Xvfb. The changed flows were exercised with Playwright against the production build instead.

No changeset is needed because this is an internal app-only UI change.
