### PR TITLE
feat(ewe-note): add safe vault deletion

### DIFF
--- a/.changeset/calm-vaults-leave.md
+++ b/.changeset/calm-vaults-leave.md
@@ -1,0 +1,5 @@
+---
+'@eweser/db': minor
+---
+
+Add safe local-first room deletion with eligibility reasons, persistent tombstones, and authoritative server reconciliation.

--- a/docs/ai/plans/2026-08-04-safe-vault-room-deletion.md
+++ b/docs/ai/plans/2026-08-04-safe-vault-room-deletion.md
@@ -1,0 +1,218 @@
+# Plan: Safe Ewe Note Vault-Room Deletion
+
+## Goal
+
+Make the top-level vault rows shown in Ewe Note expose a clear, safe deletion action, so an eligible empty vault such as an empty secure vault can be removed without permitting recursive note loss or unauthorized room deletion.
+
+## Scope
+
+- In: empty top-level Ewe Note note-room deletion, visible vault deletion UI, destructive confirmation, local-first persistence, admin enforcement for synced rooms, protected/default-room handling, focused automated tests, synthetic browser QA, and release verification.
+- In: keep the existing ordinary nested-folder delete behavior unchanged.
+- Out: recursive deletion of notes or subfolders, deletion of non-empty vaults, deletion of mounted filesystem files, hard deletion of sync-relay persistence, cleanup of real production rooms, and automatic duplicate-name cleanup.
+
+## Assumptions / Open Questions
+
+- Assumption: the rows in the supplied screenshot are top-level note rooms represented as vaults, not ordinary nested folders.
+- Assumption: user-facing copy uses `vault` for top-level room-backed workspaces and `folder` only for the hierarchy inside a vault.
+- Assumption: an encrypted vault must be unlocked before emptiness can be trusted and deletion enabled.
+- Assumption: a synced room may be deleted only by a room admin; a locally created, not-yet-synced room may be deleted locally.
+- Assumption: an eligible delete is effective in Ewe Note and room access state, while any mounted filesystem vault remains untouched.
+- Approved behavior: empty-vault-only deletion; non-empty vaults show a disabled `Delete vault` item with the reason rather than offering recursive deletion.
+
+## Domain Language
+
+- Glossary docs: `GLOSSARY.md`, `packages/db/GLOSSARY.md`, `packages/auth-server-hono/GLOSSARY.md`, and `packages/ewe-note/GLOSSARY.md`.
+- New terms: none.
+- Changed terms: none. The existing canonical terms `vault`, `note room`, `room ACL`, and `local persistence` cover this work.
+- ADR candidates: none. This applies the existing room soft-delete and local-first model rather than introducing a new persistence decision.
+
+## Deletion Flow
+
+```mermaid
+flowchart LR
+  Menu[Delete vault action] --> Eligibility{Empty, unlocked, unprotected, admin or local?}
+  Eligibility -->|No| Disabled[Show disabled action and reason]
+  Eligibility -->|Yes| Confirm[Explicit destructive confirmation]
+  Confirm --> SDK[Database.deleteRoom]
+  SDK --> Local[Hide room, persist tombstone, clear empty local cache]
+  SDK -->|when authenticated| Registry[Sync registry tombstone]
+  Registry --> Auth[Auth server verifies room admin]
+  Auth --> Server[Soft-delete room and remove it from granted registry]
+  Server --> Refresh[Refresh token, room list, and selected-room fallback]
+```
+
+## Runs
+
+## Run Order And Manual Test Handoffs
+
+Run order: sequential. The auth guard must land before the client starts sending room-deletion tombstones; UI work depends on the SDK deletion contract. After every run, Coder updates the Execution Summary and records the focused manual handoff.
+
+### Run 1: Enforce Authorized Room Tombstones
+
+- **Id**: `run-1`
+- **Title**: `Enforce Authorized Room Tombstones`
+- **UI classification**: `ui: false`
+- **Browser checkpoint**: `none`
+- **Deliverable**:
+  - Registry sync honors a client room tombstone only when the access-grant owner is an admin of that room.
+  - Read/write collaborators cannot delete a shared room by submitting `_deleted: true`.
+- **Files**:
+  - `packages/auth-server-hono/src/services/rooms/sync-rooms-with-client.ts`: add admin authorization to the existing client tombstone handling.
+  - `packages/auth-server-hono/src/services/rooms/sync-rooms-with-client.test.ts`: cover admin deletion and collaborator rejection.
+- **Steps**:
+  - [x] Derive deletable room IDs from the authoritative server-room ACL, not client-provided ACL fields.
+  - [x] Ignore or reject unauthorized tombstones without removing the room from the authoritative registry.
+  - [x] Preserve the existing access-grant and refreshed-token behavior for successfully deleted rooms.
+- **Tests**:
+  - `npm test --workspace @eweser/auth-server-hono -- sync-rooms-with-client`
+- **Verification**:
+  - Confirm an admin tombstone soft-deletes the room and a non-admin tombstone leaves it available.
+- **Manual test handoff**:
+  - Not needed: this run is covered at the service boundary and becomes user-visible only through Run 3.
+- **Dependencies**:
+  - None.
+- **Model tier**: `strong`
+- **Risk level**: `high`
+
+### Run 2: Add Local-First Safe Room Deletion To The SDK
+
+- **Id**: `run-2`
+- **Title**: `Add Local-First Safe Room Deletion To The SDK`
+- **UI classification**: `ui: false`
+- **Browser checkpoint**: `none`
+- **Deliverable**:
+  - A public `Database.deleteRoom` operation refuses protected, locked, or non-empty rooms; removes an eligible empty room from the loaded collection; persists a tombstone while offline; and completes server registry sync when available.
+  - Deleted tombstones do not reload or reappear after refresh while awaiting sync.
+- **Files**:
+  - `packages/db/src/methods/deleteRoom.ts`: implement safe room eligibility checks and deletion lifecycle.
+  - `packages/db/src/methods/deleteRoom.test.ts`: cover empty, non-empty, protected, locked, offline, online, and rejected deletion cases.
+  - `packages/db/src/index.ts`: expose the method and skip loading deleted registry tombstones.
+  - `packages/db/src/methods/connection/syncRegistry.ts`: preserve or restore correct local state based on the authoritative sync result.
+  - `packages/db/src/methods/connection/syncRegistry.test.ts`: verify tombstone persistence and authoritative reconciliation.
+  - `.changeset/<generated-name>.md`: record the new public SDK behavior.
+- **Steps**:
+  - [x] Validate emptiness using undeleted documents from the actual room Y.Doc.
+  - [x] Refuse deletion for `Database._initialRoomIds`, locked encrypted rooms, and known non-admin remote rooms.
+  - [x] Disconnect and remove the eligible room from loaded collections without deleting any non-empty data.
+  - [x] Persist `_deleted: true` in the local registry until an authenticated registry sync confirms server removal.
+  - [x] Ensure startup skips tombstoned rooms while retaining enough registry state to sync later.
+  - [x] Reconcile server rejection by restoring the authoritative room and returning an actionable error.
+- **Tests**:
+  - `npm test --workspace @eweser/db -- deleteRoom syncRegistry`
+  - `npm run type-check --workspace @eweser/db`
+- **Verification**:
+  - Recreate a database from the same fake local storage and verify the deleted empty room remains absent before and after registry sync.
+- **Manual test handoff**:
+  - Not needed: the SDK behavior is exercised through synthetic browser flows in Run 3.
+- **Dependencies**:
+  - `run-1`.
+- **Model tier**: `strong`
+- **Risk level**: `high`
+
+### Run 3: Expose Delete Vault In Ewe Note
+
+- **Id**: `run-3`
+- **Title**: `Expose Delete Vault In Ewe Note`
+- **UI classification**: `ui: true`
+- **Browser checkpoint**: `full`
+- **Deliverable**:
+  - Every top-level vault action menu visibly includes `Delete vault`.
+  - Eligible empty vaults also show the compact direct trash action used by ordinary folders.
+  - Non-empty, protected, locked, and non-admin vaults keep the menu item visible but disabled with a specific reason.
+  - Successful deletion selects a safe fallback room, leaves the editor route if needed, and stays deleted after refresh.
+- **Files**:
+  - `packages/ewe-note/src/db.tsx`: expose room-deletion eligibility and invoke the SDK while keeping `allRooms`, selected room, and selected note coherent.
+  - `packages/ewe-note/src/app/contexts/NotesContext.tsx`: expose the room identity/count data needed by the vault action without treating a room as an ordinary folder.
+  - `packages/ewe-note/src/app/components/EnhancedSidebar.tsx`: add the direct eligible action, always-visible menu item, reasoned disabled states, and destructive alert dialog.
+  - `packages/ewe-note/src/app/components/EnhancedSidebar.test.tsx`: cover eligible, non-empty, protected, locked, and non-admin vault UI states.
+  - `e2e/cypress/tests/ewe-note.cy.ts` or `e2e/cypress/tests/ewe-note-secure-room.cy.ts`: delete an empty synthetic vault, verify confirmation, refresh persistence, and verify a non-empty vault cannot be deleted.
+- **Steps**:
+  - [x] Centralize vault deletion eligibility so direct action, menu state, and the SDK call cannot disagree.
+  - [x] Use `Delete vault` for top-level room-backed rows and retain `Delete folder` for ordinary hierarchy folders.
+  - [x] Confirm with copy that synced Ewe Note access is removed, mounted filesystem files are untouched, and the operation cannot be undone through the UI.
+  - [x] Keep the destructive control visually consistent with the existing compact toolbar and folder-row actions.
+  - [x] Surface SDK/server failures in the dialog without optimistically removing an authoritative room.
+- **Tests**:
+  - `npm test --workspace @eweser/ewe-note -- EnhancedSidebar`
+  - focused Cypress spec against a production build.
+- **Verification**:
+  - Desktop and 390px mobile screenshots for enabled empty vault, disabled non-empty vault, confirmation, and post-refresh absence.
+  - Inspect spacing, alignment, balance, truncation, overflow, density, and responsive fit.
+- **Manual test handoff**:
+  - Run the production build with synthetic signed-out data, create an empty secure vault and a non-empty vault, verify the former deletes after confirmation and refresh while the latter explains why deletion is disabled. Do not test against real production rooms.
+- **Dependencies**:
+  - `run-2`.
+- **Model tier**: `strong`
+- **Risk level**: `high`
+
+### Run 4: Cross-Package QA And Publication
+
+- **Id**: `run-4`
+- **Title**: `Cross-Package QA And Publication`
+- **UI classification**: `ui: true`
+- **Browser checkpoint**: `full`
+- **Deliverable**:
+  - Reviewable PR with a room-deletion data-flow diagram, screenshots, a sanitized gallery, an isolated interactive HTTPS preview, green checks, and verified live production behavior after merge.
+- **Files**:
+  - `docs/ai/plans/2026-08-04-safe-vault-room-deletion.md`: execution summary and manual handoffs.
+  - PR description/evidence only; no unrelated product changes.
+- **Steps**:
+  - [x] Run package tests first, then root `npm run check` and relevant builds.
+  - [x] Run secret scan and inspect all staged docs/evidence for personal or machine-specific content.
+  - [x] Review the final diff for recursive deletion, filesystem deletion, ACL bypass, default-room deletion, and stale-room resurrection risks.
+  - [x] Capture final synthetic screenshots and publish separate bounded HTTPS app-preview and evidence-gallery links.
+  - [ ] Open a focused PR, address review findings, merge only after required checks pass, and verify the active production bundle and live synthetic flow.
+- **Tests**:
+  - `npm test --workspace @eweser/auth-server-hono`
+  - `npm test --workspace @eweser/db`
+  - `npm test --workspace @eweser/ewe-note`
+  - `npm run build --workspace @eweser/ewe-note`
+  - `npm run check`
+- **Verification**:
+  - Trace merge commit to successful release and confirm `note.eweser.com` exposes `Delete vault` for a synthetic eligible room while refusing deletion of a synthetic non-empty room.
+- **Manual test handoff**:
+  - Provide the production route, fixture/auth mode, screenshot gallery, interactive preview lifetime, cleanup command, and any remaining verification gap.
+- **Dependencies**:
+  - `run-3`.
+- **Model tier**: `strong`
+- **Risk level**: `high`
+
+## Stop Conditions
+
+Stop and ask for user approval if:
+
+- Implementation would delete notes, nested folders, attachment bytes, mounted filesystem files, or a real production room.
+- The current access-grant identity cannot prove room-admin authority from authoritative server data.
+- Supporting offline deletion requires silently discarding a non-empty or unreadable Y.Doc.
+- A default/initial room would be left without a safe replacement or recreated after deletion.
+- A PostgreSQL migration, new hard-delete endpoint, sync-relay persistence deletion, or broader account/grant redesign becomes necessary.
+- Verification exposes a blocking issue outside this plan's empty-vault deletion boundary.
+
+## Approval Boundary
+
+Approval of this plan authorizes Coder to implement the four runs above, add the required public SDK changeset, write and run focused tests, perform synthetic destructive browser QA, open a focused PR, address in-scope review findings, merge after green checks, and verify the published production UI.
+
+Approval does not authorize deleting or modifying any real production room, note, mounted filesystem vault, credential, migration, or unrelated data; recursive deletion; direct pushes to `main`; or broader auth/grant behavior outside admin enforcement for room tombstones.
+
+## Execution Summary
+
+| Run     | Status      | Files Changed                                                            | Verification                                                                                        | Notes                                                                                                                                                                                             |
+| ------- | ----------- | ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `run-1` | Complete    | Auth room-registry sync service and focused tests                        | 5 focused tests and package type-check passed                                                       | Server-authoritative admin ACLs now gate tombstones; client-forged admin fields are ignored.                                                                                                      |
+| `run-2` | Complete    | DB deletion method/tests, registry reconciliation, public API, changeset | 16 focused tests, package type-check, and package build passed                                      | Uses real Y.Doc contents, keeps offline tombstones, and restores rooms rejected by the server.                                                                                                    |
+| `run-3` | Complete    | Ewe Note DB context, sidebar UI/tests, and secure-room Cypress spec      | 13 component tests, package type-check/build, and full synthetic desktop/mobile browser flow passed | Browser QA also found and fixed the secure-vault badge initially showing `Standard`; the focused Cypress CLI run is blocked locally by missing Xvfb and remains covered by the committed CI spec. |
+| `run-4` | In progress | Plan/evidence and publication metadata                                   | Root check, secret scan, code-index check, and diff check passed                                    | Final sanitized screenshots are captured; PR, CI, deployment, and live verification remain.                                                                                                       |
+
+## Manual Test Result
+
+- **Plan / runs**: `2026-08-04-safe-vault-room-deletion`; Runs 3 and 4.
+- **Result**: Pass with one environment note.
+- **Coverage**: In a production build with signed-out synthetic local data, created an empty secure vault, confirmed the E2EE state, verified both the direct trash action and `Delete vault` menu item, canceled once, created a note, verified deletion became disabled with `Move or delete its 1 note first.`, removed the note, confirmed deletion, refreshed, and verified the vault stayed absent.
+- **Responsive coverage**: Repeated the blocked state and confirmation at a narrow mobile viewport.
+- **Visual assessment**: The direct action aligns with existing row controls; the menu remains compact and unclipped; the disabled reason wraps legibly; the destructive confirmation has clear hierarchy and safe button placement; desktop and mobile layouts have no overflow or cramped controls.
+- **Environment note**: The local Cypress binary could not start because this machine lacks Xvfb (`spawn Xvfb ENOENT`). The equivalent flow passed manually in the visible browser, and the Cypress regression spec is committed for CI.
+
+## Self-Reflection / Instruction Improvements
+
+- The original delete-action work should have distinguished ordinary folders from top-level vault rooms during scope validation and included both fixture kinds in the initial browser checkpoint.
+- Future action-menu changes should test every row kind with both enabled and blocked fixtures, plus an immediate post-create state check; that is what caught the stale `Standard` badge before publication.

--- a/e2e/cypress/tests/ewe-note-secure-room.cy.ts
+++ b/e2e/cypress/tests/ewe-note-secure-room.cy.ts
@@ -85,6 +85,54 @@ describe('ewe-note secure room UI', () => {
     );
   });
 
+  it('cancels and then deletes an empty secure vault, which stays absent after reload', () => {
+    visitHome();
+
+    cy.getBySel('secure-room-create-button').click();
+    cy.getBySel('secure-room-recovery-phrase', { timeout: 10000 }).should(
+      'exist'
+    );
+    cy.getBySel('secure-room-phrase-dismiss').click();
+
+    cy.get('button[data-cy^="ewe-note-delete-vault-"]')
+      .should('have.attr', 'aria-label', 'Delete vault 🔒 Secure Notes')
+      .click();
+    cy.getBySel('ewe-note-delete-vault-dialog')
+      .should('be.visible')
+      .and('contain.text', 'mounted filesystem vault are not deleted');
+    cy.contains('button', 'Cancel').click();
+    cy.getBySel('ewe-note-delete-vault-dialog').should('not.exist');
+    cy.contains('🔒 Secure Notes').should('exist');
+
+    cy.get('button[data-cy^="ewe-note-delete-vault-"]').click();
+    cy.getBySel('ewe-note-confirm-delete-vault').click();
+    cy.contains('🔒 Secure Notes').should('not.exist');
+
+    cy.reload();
+    cy.getBySel('ewe-note-sidebar', { timeout: 10000 }).should('exist');
+    cy.contains('🔒 Secure Notes').should('not.exist');
+  });
+
+  it('explains why a non-empty secure vault cannot be deleted', () => {
+    visitHome();
+
+    cy.getBySel('secure-room-create-button').click();
+    cy.getBySel('secure-room-recovery-phrase', { timeout: 10000 }).should(
+      'exist'
+    );
+    cy.getBySel('secure-room-phrase-dismiss').click();
+
+    cy.get('button[aria-label="Vault actions for 🔒 Secure Notes"]').click();
+    cy.contains('[role="menuitem"]', 'New note').click();
+    cy.getBySel('ewe-note-editor', { timeout: 10000 }).should('exist');
+
+    cy.get('button[data-cy^="ewe-note-delete-vault-"]').should('not.exist');
+    cy.get('button[aria-label="Vault actions for 🔒 Secure Notes"]').click();
+    cy.get('[data-cy^="ewe-note-delete-vault-menu-"]')
+      .should('have.attr', 'data-disabled')
+      .and('contain.text', 'Move or delete its 1 note first.');
+  });
+
   it('locks and unlocks a secure room', () => {
     visitHome();
 

--- a/packages/auth-server-hono/src/services/rooms/sync-rooms-with-client.test.ts
+++ b/packages/auth-server-hono/src/services/rooms/sync-rooms-with-client.test.ts
@@ -12,7 +12,8 @@ vi.mock('../../model/rooms/calls.js', () => ({
   updateRoom: vi.fn(),
 }));
 
-const { getNewClientRooms } = await import('./sync-rooms-with-client.js');
+const { getAuthorizedDeletedRoomIds, getNewClientRooms } =
+  await import('./sync-rooms-with-client.js');
 
 describe('getNewClientRooms', () => {
   it('does not recreate cached rooms missing from the server grant', () => {
@@ -42,6 +43,46 @@ describe('getNewClientRooms', () => {
 
     expect(
       getNewClientRooms([deletedRoom], new Set(), [deletedRoom.id])
+    ).toEqual([]);
+  });
+});
+
+describe('getAuthorizedDeletedRoomIds', () => {
+  const room = (overrides: Record<string, unknown> = {}) => ({
+    id: 'room-1',
+    name: 'Notes',
+    collectionKey: 'notes',
+    adminAccess: ['admin-user'],
+    ...overrides,
+  });
+
+  it('accepts a tombstone from an authoritative room admin', () => {
+    expect(
+      getAuthorizedDeletedRoomIds(
+        [room({ _deleted: true })],
+        [room()],
+        'admin-user'
+      )
+    ).toEqual(['room-1']);
+  });
+
+  it('rejects a tombstone from a write collaborator', () => {
+    expect(
+      getAuthorizedDeletedRoomIds(
+        [room({ _deleted: true, adminAccess: ['collaborator'] })],
+        [room({ writeAccess: ['collaborator'] })],
+        'collaborator'
+      )
+    ).toEqual([]);
+  });
+
+  it('uses the server ACL instead of client-provided admin access', () => {
+    expect(
+      getAuthorizedDeletedRoomIds(
+        [room({ _deleted: true, adminAccess: ['collaborator'] })],
+        [room()],
+        'collaborator'
+      )
     ).toEqual([]);
   });
 });

--- a/packages/auth-server-hono/src/services/rooms/sync-rooms-with-client.ts
+++ b/packages/auth-server-hono/src/services/rooms/sync-rooms-with-client.ts
@@ -34,6 +34,21 @@ export function getNewClientRooms(
   );
 }
 
+export function getAuthorizedDeletedRoomIds(
+  clientRooms: Array<Pick<ServerRoom, 'id' | '_deleted'>>,
+  serverRooms: Array<Pick<ServerRoom, 'id' | 'adminAccess'>>,
+  userId: string
+) {
+  const serverRoomsById = new Map(serverRooms.map((room) => [room.id, room]));
+
+  return clientRooms
+    .filter((room) => room._deleted)
+    .filter((room) =>
+      serverRoomsById.get(room.id)?.adminAccess.includes(userId)
+    )
+    .map((room) => room.id);
+}
+
 /**
  * Syncs client rooms with server.
  * Hard cutover: uses syncUrl/syncBaseUrl directly.
@@ -108,13 +123,13 @@ export async function syncRoomsWithClient(
     }
 
     // Handle soft deletes from client
-    const clientDeletedRoomIds = clientRooms
-      .filter((r) => r._deleted)
-      .map((r) => r.id);
+    const clientDeletedRoomIds = getAuthorizedDeletedRoomIds(
+      clientRooms,
+      serverRooms,
+      userId
+    );
     for (const id of clientDeletedRoomIds) {
-      if (serverRoomIdSet.has(id)) {
-        await updateRoom({ id, _deleted: true }, dbInstance);
-      }
+      await updateRoom({ id, _deleted: true }, dbInstance);
     }
 
     const finalRooms = await getRoomsFromAccessGrant(grant, dbInstance);

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -48,6 +48,17 @@ import { pingServer } from './utils/connection/pingServer.js';
 import { pollConnection } from './utils/connection/pollConnection.js';
 import { newRoom } from './methods/newRoom.js';
 import { renameRoom } from './methods/renameRoom.js';
+import {
+  deleteRoom,
+  getActiveRegistryRooms,
+  getRoomDeletionEligibility,
+} from './methods/deleteRoom.js';
+
+export {
+  RoomDeletionError,
+  type RoomDeletionBlockCode,
+  type RoomDeletionEligibility,
+} from './methods/deleteRoom.js';
 
 export * from './utils/index.js';
 export * from './utils/files.js';
@@ -168,6 +179,8 @@ export class Database extends TypedEventEmitter<DatabaseEvents> {
 
   newRoom = newRoom(this);
   renameRoom = renameRoom(this);
+  deleteRoom = deleteRoom(this);
+  getRoomDeletionEligibility = getRoomDeletionEligibility(this);
 
   generateShareRoomLink = generateShareRoomLink(this);
   pingServer = pingServer(this);
@@ -295,8 +308,9 @@ export class Database extends TypedEventEmitter<DatabaseEvents> {
     }
     /** load all rooms in the registry locally, skipping any already handled above */
     const initializedRoomIds = new Set(initializedRooms.map((r) => r.id));
-    const remainingRegistryRooms = this.registry.filter(
-      (r) => !initializedRoomIds.has(r.id)
+    const remainingRegistryRooms = getActiveRegistryRooms(
+      this.registry,
+      initializedRoomIds
     );
     this.loadRooms(remainingRegistryRooms);
     this.pollForRegistrySync();

--- a/packages/db/src/methods/connection/syncRegistry.test.ts
+++ b/packages/db/src/methods/connection/syncRegistry.test.ts
@@ -77,6 +77,75 @@ describe('syncRegistry', () => {
     expect(db.registry).toEqual(rooms);
   });
 
+  it('accepts an empty authoritative registry after the final room is deleted', async () => {
+    const deletedRoom = {
+      id: 'deleted-room',
+      name: 'Empty vault',
+      collectionKey: 'notes',
+      _deleted: true,
+    };
+    const db = {
+      registry: [deletedRoom],
+      collections: { notes: {} },
+      _initialRoomIds: new Set(),
+      _pendingRegistryRoomIds: new Set(),
+      userId: '',
+      accessGrantToken: '',
+      getToken: () => 'token',
+      emit: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      serverFetch: vi.fn().mockResolvedValue({
+        data: { rooms: [], token: 'next-token', userId: 'user-1' },
+        error: null,
+      }),
+    } as unknown as Database;
+
+    await expect(syncRegistry(db)()).resolves.toBe(true);
+    expect(db.registry).toEqual([]);
+    expect(setLocalRegistryMock).toHaveBeenCalledWith([]);
+  });
+
+  it('restores a room when the server rejects its tombstone', async () => {
+    const authoritativeRoom = {
+      id: 'shared-room',
+      name: 'Shared notes',
+      collectionKey: 'notes',
+    };
+    const tombstone = { ...authoritativeRoom, _deleted: true };
+    const loadRooms = vi.fn().mockResolvedValue(undefined);
+    const db = {
+      registry: [tombstone],
+      collections: { notes: {} },
+      _initialRoomIds: new Set(),
+      _pendingRegistryRoomIds: new Set(),
+      userId: '',
+      accessGrantToken: '',
+      getToken: () => 'token',
+      emit: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      loadRooms,
+      serverFetch: vi.fn().mockResolvedValue({
+        data: {
+          rooms: [authoritativeRoom],
+          token: 'next-token',
+          userId: 'user-1',
+        },
+        error: null,
+      }),
+    } as unknown as Database;
+
+    await expect(syncRegistry(db)()).resolves.toBe(false);
+    expect(db.registry).toEqual([authoritativeRoom]);
+    expect(loadRooms).toHaveBeenCalledWith([authoritativeRoom], undefined, 0);
+    expect(db.emit).toHaveBeenCalledWith(
+      'registrySync',
+      'error',
+      'The server did not authorize one or more room deletions.'
+    );
+  });
+
   it('unloads stale rooms after the server removes them while preserving current initial rooms', async () => {
     const staleRoom = {
       id: 'stale-room',

--- a/packages/db/src/methods/connection/syncRegistry.ts
+++ b/packages/db/src/methods/connection/syncRegistry.ts
@@ -74,14 +74,14 @@ export const syncRegistry = (db: Database) => {
       return false;
     }
 
-    if (
-      rooms &&
-      typeof rooms === 'object' &&
-      Array.isArray(rooms) &&
-      rooms.length >= 1
-    ) {
+    if (rooms && typeof rooms === 'object' && Array.isArray(rooms)) {
       db.debug('setting new rooms', rooms);
       const serverRoomIds = new Set(rooms.map((room) => room.id));
+      const rejectedTombstoneRooms = rooms.filter((room) =>
+        previousRooms.some(
+          (previousRoom) => previousRoom.id === room.id && previousRoom._deleted
+        )
+      );
       const roomsCreatedDuringSync = db.registry.filter(
         (room) =>
           db._pendingRegistryRoomIds.has(room.id) && !serverRoomIds.has(room.id)
@@ -95,6 +95,16 @@ export const syncRegistry = (db: Database) => {
         if (serverRoomIds.has(roomId)) {
           db._pendingRegistryRoomIds.delete(roomId);
         }
+      }
+
+      if (rejectedTombstoneRooms.length > 0) {
+        await db.loadRooms(rejectedTombstoneRooms, db.useSync, 0);
+        db.emit(
+          'registrySync',
+          'error',
+          'The server did not authorize one or more room deletions.'
+        );
+        return false;
       }
     } else {
       return false;

--- a/packages/db/src/methods/deleteRoom.test.ts
+++ b/packages/db/src/methods/deleteRoom.test.ts
@@ -1,0 +1,190 @@
+import * as Y from 'yjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Note } from '@eweser/shared';
+import type { Database, YDoc } from '../index';
+import { Room, roomToServerRoom } from '../room';
+import {
+  deleteRoom,
+  getActiveRegistryRooms,
+  getRoomDeletionEligibility,
+  type RoomDeletionError,
+} from './deleteRoom';
+
+const setLocalRegistryMock = vi.fn();
+
+vi.mock('../utils/localStorageService', () => ({
+  setLocalRegistry: () => setLocalRegistryMock,
+}));
+
+function setupRoom({
+  roomId = 'room-1',
+  initial = false,
+  pending = true,
+  userId = '',
+  adminAccess = [],
+  syncUrl = null,
+  encryption = null,
+  online = false,
+}: {
+  roomId?: string;
+  initial?: boolean;
+  pending?: boolean;
+  userId?: string;
+  adminAccess?: string[];
+  syncUrl?: string | null;
+  encryption?: ConstructorParameters<typeof Room<Note>>[0]['encryption'];
+  online?: boolean;
+} = {}) {
+  const clearData = vi.fn().mockResolvedValue(undefined);
+  const destroy = vi.fn();
+  const db = {
+    authServer: 'https://auth.example.test',
+    userId,
+    online,
+    collections: { notes: {} },
+    registry: [],
+    _initialRoomIds: new Set(initial ? [roomId] : []),
+    _pendingRegistryRoomIds: new Set(pending ? [roomId] : []),
+    getToken: vi.fn(() => (online ? 'token' : '')),
+    syncRegistry: vi.fn().mockResolvedValue(true),
+    warn: vi.fn(),
+  } as unknown as Database;
+  const room = new Room<Note>({
+    db,
+    id: roomId,
+    name: 'Test vault',
+    collectionKey: 'notes',
+    adminAccess,
+    syncUrl,
+    encryption,
+    ydoc: new Y.Doc() as YDoc<Note>,
+    indexedDbProvider: { clearData, destroy } as never,
+  });
+  db.collections.notes[room.id] = room;
+  db.registry = [roomToServerRoom(room)];
+
+  return { db, room, clearData, destroy };
+}
+
+describe('getRoomDeletionEligibility', () => {
+  it('allows an empty local vault', () => {
+    const { db, room } = setupRoom();
+
+    expect(getRoomDeletionEligibility(db)(room)).toEqual({
+      canDelete: true,
+      noteCount: 0,
+    });
+  });
+
+  it('counts real undeleted Yjs documents and blocks a non-empty vault', () => {
+    const { db, room } = setupRoom();
+    room.getDocuments().new({ text: '# Keep me' });
+
+    expect(getRoomDeletionEligibility(db)(room)).toEqual({
+      canDelete: false,
+      code: 'not-empty',
+      reason: 'Move or delete its 1 note first.',
+      noteCount: 1,
+    });
+  });
+
+  it('blocks protected, locked, and non-admin vaults with specific reasons', () => {
+    const protectedRoom = setupRoom({ initial: true });
+    expect(
+      getRoomDeletionEligibility(protectedRoom.db)(protectedRoom.room)
+    ).toMatchObject({
+      canDelete: false,
+      code: 'protected',
+    });
+
+    const lockedRoom = setupRoom({
+      encryption: {
+        encrypted: true,
+        algorithm: 'AES-256-GCM',
+        keyDerivation: { method: 'PBKDF2', iterations: 600_000, salt: 'salt' },
+        ivLength: 12,
+      },
+    });
+    expect(
+      getRoomDeletionEligibility(lockedRoom.db)(lockedRoom.room)
+    ).toMatchObject({
+      canDelete: false,
+      code: 'locked',
+    });
+
+    const collaboratorRoom = setupRoom({
+      pending: false,
+      userId: 'collaborator',
+      adminAccess: ['admin'],
+      syncUrl: 'wss://sync.example.test',
+    });
+    expect(
+      getRoomDeletionEligibility(collaboratorRoom.db)(collaboratorRoom.room)
+    ).toMatchObject({ canDelete: false, code: 'not-admin' });
+  });
+});
+
+describe('deleteRoom', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('persists an offline tombstone, unloads the room, and clears its empty cache', async () => {
+    const { db, room, clearData, destroy } = setupRoom();
+
+    await deleteRoom(db)(room);
+
+    expect(db.registry[0]?._deleted).toBe(true);
+    expect(db._pendingRegistryRoomIds).not.toContain(room.id);
+    expect(db.collections.notes).not.toHaveProperty(room.id);
+    expect(setLocalRegistryMock).toHaveBeenCalledWith(db.registry);
+    expect(clearData).toHaveBeenCalledOnce();
+    expect(destroy).toHaveBeenCalledOnce();
+    expect(db.syncRegistry).not.toHaveBeenCalled();
+  });
+
+  it('reports an authoritative server rejection', async () => {
+    const { db, room } = setupRoom({
+      pending: false,
+      online: true,
+      userId: 'admin',
+      adminAccess: ['admin'],
+      syncUrl: 'wss://sync.example.test',
+    });
+    vi.mocked(db.syncRegistry).mockImplementation(async () => {
+      db.registry = [{ ...roomToServerRoom(room), _deleted: false }];
+      return false;
+    });
+
+    await expect(deleteRoom(db)(room)).rejects.toEqual(
+      expect.objectContaining<Partial<RoomDeletionError>>({
+        code: 'rejected',
+      })
+    );
+  });
+
+  it('keeps deletion successful when empty cache cleanup fails', async () => {
+    const { db, room, clearData, destroy } = setupRoom();
+    clearData.mockRejectedValueOnce(new Error('IndexedDB unavailable'));
+
+    await expect(deleteRoom(db)(room)).resolves.toBeUndefined();
+    expect(db.warn).toHaveBeenCalledWith(
+      'Could not clear the deleted room cache',
+      room.id,
+      expect.any(Error)
+    );
+    expect(destroy).toHaveBeenCalledOnce();
+  });
+});
+
+describe('getActiveRegistryRooms', () => {
+  it('keeps tombstones persisted but excludes them from startup loading', () => {
+    const { room } = setupRoom();
+    const active = roomToServerRoom(room);
+    const deleted = { ...active, id: 'deleted-room', _deleted: true };
+
+    expect(getActiveRegistryRooms([active, deleted], new Set())).toEqual([
+      active,
+    ]);
+  });
+});

--- a/packages/db/src/methods/deleteRoom.ts
+++ b/packages/db/src/methods/deleteRoom.ts
@@ -1,0 +1,148 @@
+import type { EweDocument } from '@eweser/shared';
+import type { Database } from '../index.js';
+import type { Room } from '../room.js';
+import type { Registry } from '../types.js';
+import { setLocalRegistry } from '../utils/localStorageService.js';
+
+export type RoomDeletionBlockCode =
+  | 'protected'
+  | 'locked'
+  | 'not-admin'
+  | 'not-loaded'
+  | 'not-empty';
+
+export type RoomDeletionEligibility =
+  | { canDelete: true; noteCount: 0 }
+  | {
+      canDelete: false;
+      code: RoomDeletionBlockCode;
+      reason: string;
+      noteCount?: number;
+    };
+
+export class RoomDeletionError extends Error {
+  constructor(
+    readonly code: RoomDeletionBlockCode | 'rejected',
+    message: string
+  ) {
+    super(message);
+    this.name = 'RoomDeletionError';
+  }
+}
+
+export function getActiveRegistryRooms(
+  registry: Registry,
+  initializedRoomIds: Set<string>
+) {
+  return registry.filter(
+    (room) => !room._deleted && !initializedRoomIds.has(room.id)
+  );
+}
+
+export const getRoomDeletionEligibility =
+  (db: Database) =>
+  <T extends EweDocument>(room: Room<T>): RoomDeletionEligibility => {
+    if (db._initialRoomIds.has(room.id)) {
+      return {
+        canDelete: false,
+        code: 'protected',
+        reason: 'This vault is required by this app.',
+      };
+    }
+
+    if (room.encryption && !room.isUnlocked) {
+      return {
+        canDelete: false,
+        code: 'locked',
+        reason: 'Unlock this vault before deleting it.',
+      };
+    }
+
+    const registryRoom = db.registry.find((entry) => entry.id === room.id);
+    const isPendingLocalRoom = db._pendingRegistryRoomIds.has(room.id);
+    const isSyncedRoom =
+      !isPendingLocalRoom &&
+      Boolean(
+        registryRoom?.syncUrl ||
+        registryRoom?.adminAccess.length ||
+        room.syncUrl ||
+        room.adminAccess.length
+      );
+    const adminAccess = registryRoom?.adminAccess ?? room.adminAccess;
+
+    if (isSyncedRoom && (!db.userId || !adminAccess.includes(db.userId))) {
+      return {
+        canDelete: false,
+        code: 'not-admin',
+        reason: 'Only a vault admin can delete this vault.',
+      };
+    }
+
+    let noteCount: number;
+    try {
+      noteCount = room.getDocuments().getUndeletedToArray().length;
+    } catch {
+      return {
+        canDelete: false,
+        code: 'not-loaded',
+        reason: 'Open this vault before deleting it.',
+      };
+    }
+
+    if (noteCount > 0) {
+      return {
+        canDelete: false,
+        code: 'not-empty',
+        reason: `Move or delete its ${noteCount} note${noteCount === 1 ? '' : 's'} first.`,
+        noteCount,
+      };
+    }
+
+    return { canDelete: true, noteCount: 0 };
+  };
+
+export const deleteRoom =
+  (db: Database) =>
+  async <T extends EweDocument>(room: Room<T>) => {
+    const eligibility = getRoomDeletionEligibility(db)(room);
+    if (!eligibility.canDelete) {
+      throw new RoomDeletionError(eligibility.code, eligibility.reason);
+    }
+
+    const registryRoom = db.registry.find((entry) => entry.id === room.id);
+    if (!registryRoom) {
+      throw new RoomDeletionError(
+        'not-loaded',
+        'This vault is not available in the local registry.'
+      );
+    }
+
+    registryRoom._deleted = true;
+    room._deleted = true;
+    db._pendingRegistryRoomIds.delete(room.id);
+    setLocalRegistry(db)(db.registry);
+
+    room.disconnect();
+    Reflect.deleteProperty(db.collections[room.collectionKey], room.id);
+
+    try {
+      await room.indexedDbProvider?.clearData();
+    } catch (error) {
+      db.warn('Could not clear the deleted room cache', room.id, error);
+    } finally {
+      room.indexedDbProvider?.destroy();
+    }
+
+    if (db.online && db.getToken()) {
+      await db.syncRegistry();
+      const authoritativeRoom = db.registry.find(
+        (entry) => entry.id === room.id && !entry._deleted
+      );
+      if (authoritativeRoom) {
+        throw new RoomDeletionError(
+          'rejected',
+          'The server did not authorize deletion of this vault.'
+        );
+      }
+    }
+  };

--- a/packages/ewe-note/src/app/components/EnhancedSidebar.test.tsx
+++ b/packages/ewe-note/src/app/components/EnhancedSidebar.test.tsx
@@ -1,5 +1,11 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import { within } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -12,6 +18,15 @@ const updateFolder = vi.fn();
 const deleteFolder = vi.fn();
 const addNote = vi.fn(() => ({ id: 'note-created' }));
 const moveNote = vi.fn();
+const deleteVault = vi.fn().mockResolvedValue(undefined);
+let vaultDeletionEligibility:
+  | { canDelete: true; noteCount: 0 }
+  | {
+      canDelete: false;
+      code: 'not-empty';
+      reason: string;
+      noteCount: number;
+    } = { canDelete: true, noteCount: 0 };
 const useDrag = vi.fn((_spec: unknown) => [{ isDragging: false }, vi.fn()]);
 const useDrop = vi.fn((_spec: unknown) => [{ isOver: false }, vi.fn()]);
 const makeNote = (overrides: Partial<Record<string, unknown>> = {}) => ({
@@ -92,6 +107,14 @@ vi.mock('../contexts/NotesContext', () => ({
         expanded: true,
         kind: 'folder',
       },
+      {
+        id: 'room:secure-room',
+        name: '🔒 Secure Notes',
+        parentId: null,
+        expanded: true,
+        kind: 'shared-room',
+        roomId: 'secure-room',
+      },
     ],
     tasks: [],
     addNote,
@@ -113,6 +136,8 @@ vi.mock('../components/ThemeProvider', () => ({
 
 vi.mock('../../db', () => ({
   useDb: () => ({
+    deleteVault,
+    getVaultDeletionEligibility: () => vaultDeletionEligibility,
     loggedIn: false,
     syncStatus: 'local-only',
     syncStatusLabel: 'Local only',
@@ -169,6 +194,9 @@ describe('EnhancedSidebar', () => {
     deleteFolder.mockClear();
     addNote.mockClear();
     moveNote.mockClear();
+    deleteVault.mockReset();
+    deleteVault.mockResolvedValue(undefined);
+    vaultDeletionEligibility = { canDelete: true, noteCount: 0 };
     useDrag.mockClear();
     useDrop.mockClear();
     mockNavigate.mockClear();
@@ -297,6 +325,61 @@ describe('EnhancedSidebar', () => {
       'Delete "Projects" and move 2 notes plus keep 1 subfolder?'
     );
     expect(deleteFolder).toHaveBeenCalledWith('root-folder');
+  });
+
+  it('confirms deletion of an eligible empty vault and returns to the library', async () => {
+    const onViewChange = vi.fn();
+    render(
+      <EnhancedSidebar
+        onSearchClick={vi.fn()}
+        activeView="folder:room:secure-room"
+        onViewChange={onViewChange}
+      />
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Delete vault 🔒 Secure Notes' })
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Delete “🔒 Secure Notes”?' })
+    ).not.toBeNull();
+    expect(
+      screen.getByText(/Files in a mounted filesystem vault are not deleted/)
+    ).not.toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete vault' }));
+
+    await waitFor(() => {
+      expect(deleteVault).toHaveBeenCalledWith('secure-room');
+      expect(onViewChange).toHaveBeenCalledWith('recent');
+      expect(mockNavigate).toHaveBeenCalledWith('/');
+    });
+  });
+
+  it('keeps a non-empty vault deletion visible with a specific disabled reason', () => {
+    vaultDeletionEligibility = {
+      canDelete: false,
+      code: 'not-empty',
+      reason: 'Move or delete its 2 notes first.',
+      noteCount: 2,
+    };
+    render(<EnhancedSidebar onSearchClick={vi.fn()} activeView="recent" />);
+
+    expect(
+      screen.queryByRole('button', { name: 'Delete vault 🔒 Secure Notes' })
+    ).toBeNull();
+    fireEvent.pointerDown(
+      screen.getByRole('button', {
+        name: 'Vault actions for 🔒 Secure Notes',
+      })
+    );
+
+    const item = screen.getByRole('menuitem', {
+      name: 'Delete vault. Move or delete its 2 notes first.',
+    });
+    expect(item.getAttribute('data-disabled')).not.toBeNull();
+    expect(deleteVault).not.toHaveBeenCalled();
   });
 
   it('exposes a pinned notes filter in the rail', () => {

--- a/packages/ewe-note/src/app/components/EnhancedSidebar.tsx
+++ b/packages/ewe-note/src/app/components/EnhancedSidebar.tsx
@@ -28,6 +28,15 @@ import { SecureRoomControls } from './SecureRoomControls';
 import { FederatedSearchPanel } from './FederatedSearchPanel';
 import { useDb } from '../../db';
 import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from './ui/alert-dialog';
+import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -103,8 +112,15 @@ function SidebarContent({
     getNotesInFolder,
     moveNote,
   } = useNotes();
-  const { loggedIn, syncStatus, syncStatusLabel, syncStatusDescription, user } =
-    useDb();
+  const {
+    deleteVault,
+    getVaultDeletionEligibility,
+    loggedIn,
+    syncStatus,
+    syncStatusLabel,
+    syncStatusDescription,
+    user,
+  } = useDb();
   const [expandedFolders, setExpandedFolders] = useState<Set<string>>(
     new Set(['work', 'personal', 'development', 'daily'])
   );
@@ -120,6 +136,10 @@ function SidebarContent({
     parentId?: string | null;
     initialName: string;
   } | null>(null);
+  const [vaultPendingDelete, setVaultPendingDelete] =
+    useState<NotesFolder | null>(null);
+  const [deletingVault, setDeletingVault] = useState(false);
+  const [vaultDeleteError, setVaultDeleteError] = useState<string | null>(null);
   const knownFolderIdsRef = useRef<Set<string>>(new Set());
 
   const childFoldersByParent = useMemo(() => {
@@ -212,6 +232,37 @@ function SidebarContent({
       updateFolder(childFolder.id, { parentId: folder.parentId })
     );
     deleteFolder(folder.id);
+  };
+
+  const requestVaultDeletion = (folder: NotesFolder) => {
+    if (
+      !folder.roomId ||
+      getVaultDeletionEligibility(folder.roomId).canDelete !== true
+    ) {
+      return;
+    }
+    setVaultDeleteError(null);
+    setVaultPendingDelete(folder);
+  };
+
+  const confirmVaultDeletion = async () => {
+    if (!vaultPendingDelete?.roomId) return;
+    setDeletingVault(true);
+    setVaultDeleteError(null);
+    try {
+      await deleteVault(vaultPendingDelete.roomId);
+      setVaultPendingDelete(null);
+      onViewChange?.('recent');
+      navigate('/');
+    } catch (error) {
+      setVaultDeleteError(
+        error instanceof Error
+          ? error.message
+          : 'EweNote could not delete this vault.'
+      );
+    } finally {
+      setDeletingVault(false);
+    }
   };
 
   const incompleteTasks = tasks.filter((t) => !t.completed);
@@ -378,6 +429,7 @@ function SidebarContent({
                   })
                 }
                 onDelete={handleDeleteFolder}
+                onDeleteVault={requestVaultDeletion}
               />
             ))}
             {folders.length === 0 ? (
@@ -475,6 +527,55 @@ function SidebarContent({
         dataCySubmit="ewe-note-folder-submit"
         onSubmit={handleFolderSubmit}
       />
+      <AlertDialog
+        open={Boolean(vaultPendingDelete)}
+        onOpenChange={(open) => {
+          if (!open && !deletingVault) {
+            setVaultPendingDelete(null);
+            setVaultDeleteError(null);
+          }
+        }}
+      >
+        <AlertDialogContent data-cy="ewe-note-delete-vault-dialog">
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Delete “{vaultPendingDelete?.name}”?
+            </AlertDialogTitle>
+            <AlertDialogDescription className="space-y-2">
+              <span className="block">
+                This removes this empty vault from EweNote. If it is synced, it
+                will disappear from your synced devices too. This cannot be
+                undone in EweNote.
+              </span>
+              <span className="block">
+                Files in a mounted filesystem vault are not deleted.
+              </span>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          {vaultDeleteError ? (
+            <p
+              role="alert"
+              className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive"
+            >
+              {vaultDeleteError}
+            </p>
+          ) : null}
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deletingVault}>
+              Cancel
+            </AlertDialogCancel>
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={deletingVault}
+              onClick={() => void confirmVaultDeletion()}
+              data-cy="ewe-note-confirm-delete-vault"
+            >
+              {deletingVault ? 'Deleting…' : 'Delete vault'}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </aside>
   );
 }
@@ -495,6 +596,7 @@ interface FolderBranchProps {
   onShareFolder: (folderId: string, folderName: string) => void;
   onRename: (folder: NotesFolder) => void;
   onDelete: (folder: NotesFolder) => void;
+  onDeleteVault: (folder: NotesFolder) => void;
 }
 
 function FolderBranch({
@@ -513,6 +615,7 @@ function FolderBranch({
   onShareFolder,
   onRename,
   onDelete,
+  onDeleteVault,
 }: FolderBranchProps) {
   const navigate = useNavigate();
   const folderNotes = getDirectNotesInFolder(folder.id);
@@ -534,6 +637,7 @@ function FolderBranch({
         onShareFolder={() => onShareFolder(folder.id, folder.name)}
         onRename={() => onRename(folder)}
         onDelete={() => onDelete(folder)}
+        onDeleteVault={() => onDeleteVault(folder)}
       />
 
       {isExpanded && (childFolders.length > 0 || folderNotes.length > 0) ? (
@@ -556,6 +660,7 @@ function FolderBranch({
               onShareFolder={onShareFolder}
               onRename={onRename}
               onDelete={onDelete}
+              onDeleteVault={onDeleteVault}
             />
           ))}
           {folderNotes.map((note) => (
@@ -625,6 +730,7 @@ interface FolderItemProps {
   onShareFolder: () => void;
   onRename: () => void;
   onDelete: () => void;
+  onDeleteVault: () => void;
 }
 
 function FolderItem({
@@ -640,7 +746,18 @@ function FolderItem({
   onShareFolder,
   onRename,
   onDelete,
+  onDeleteVault,
 }: FolderItemProps) {
+  const { getVaultDeletionEligibility } = useDb();
+  const vaultDeletion = folder.roomId
+    ? getVaultDeletionEligibility(folder.roomId)
+    : undefined;
+  const canDeleteVault =
+    folder.kind === 'shared-room' && vaultDeletion?.canDelete === true;
+  const showDirectDelete = folder.kind === 'folder' || canDeleteVault;
+  const deleteLabel =
+    folder.kind === 'shared-room' ? 'Delete vault' : 'Delete folder';
+  const handleDelete = folder.kind === 'shared-room' ? onDeleteVault : onDelete;
   const [{ isOver }, drop] = useDrop<
     DraggedNoteItem,
     unknown,
@@ -690,14 +807,18 @@ function FolderItem({
           {folder.name}
         </span>
       </button>
-      {folder.kind === 'folder' ? (
+      {showDirectDelete ? (
         <button
           type="button"
-          aria-label={`Delete folder ${folder.name}`}
-          title={`Delete folder ${folder.name}`}
-          onClick={onDelete}
+          aria-label={`${deleteLabel} ${folder.name}`}
+          title={`${deleteLabel} ${folder.name}`}
+          onClick={handleDelete}
           className="shrink-0 self-center rounded-full p-1 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          data-cy={`ewe-note-delete-folder-${folder.id}`}
+          data-cy={
+            folder.kind === 'shared-room'
+              ? `ewe-note-delete-vault-${folder.roomId}`
+              : `ewe-note-delete-folder-${folder.id}`
+          }
         >
           <Trash2 className="h-4 w-4" />
         </button>
@@ -706,7 +827,7 @@ function FolderItem({
         <DropdownMenuTrigger asChild>
           <button
             type="button"
-            aria-label={`Folder actions for ${folder.name}`}
+            aria-label={`${folder.kind === 'shared-room' ? 'Vault' : 'Folder'} actions for ${folder.name}`}
             className="shrink-0 self-center rounded-full p-1 text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground"
             data-cy={`ewe-note-folder-actions-${folder.id}`}
           >
@@ -729,7 +850,7 @@ function FolderItem({
             disabled={folder.kind === 'shared-room'}
           >
             <Share className="mr-2 h-4 w-4" />
-            Share folder
+            {folder.kind === 'shared-room' ? 'Share vault' : 'Share folder'}
           </DropdownMenuItem>
           {folder.kind === 'folder' ? (
             <DropdownMenuItem onClick={onRename}>
@@ -738,9 +859,33 @@ function FolderItem({
             </DropdownMenuItem>
           ) : null}
           {folder.kind === 'folder' ? (
-            <DropdownMenuItem onClick={onDelete}>
+            <DropdownMenuItem onClick={onDelete} variant="destructive">
               <Trash2 className="mr-2 h-4 w-4" />
               Delete folder
+            </DropdownMenuItem>
+          ) : null}
+          {folder.kind === 'shared-room' ? (
+            <DropdownMenuItem
+              onClick={onDeleteVault}
+              disabled={!canDeleteVault}
+              aria-label={
+                vaultDeletion && !vaultDeletion.canDelete
+                  ? `Delete vault. ${vaultDeletion.reason}`
+                  : 'Delete vault'
+              }
+              variant="destructive"
+              className="items-start data-[disabled]:opacity-80"
+              data-cy={`ewe-note-delete-vault-menu-${folder.roomId}`}
+            >
+              <Trash2 className="mr-2 mt-0.5 h-4 w-4 shrink-0" />
+              <span className="flex min-w-0 flex-col">
+                <span>Delete vault</span>
+                {vaultDeletion && !vaultDeletion.canDelete ? (
+                  <span className="max-w-56 whitespace-normal text-xs leading-4 text-muted-foreground">
+                    {vaultDeletion.reason}
+                  </span>
+                ) : null}
+              </span>
             </DropdownMenuItem>
           ) : null}
         </DropdownMenuContent>

--- a/packages/ewe-note/src/db.tsx
+++ b/packages/ewe-note/src/db.tsx
@@ -1,6 +1,11 @@
 import 'yjs';
 import { Database, RoomCrypto } from '@eweser/db';
-import type { CollectionKey, Note, Room } from '@eweser/db';
+import type {
+  CollectionKey,
+  Note,
+  Room,
+  RoomDeletionEligibility,
+} from '@eweser/db';
 import * as config from './config';
 import type { ReactNode } from 'react';
 import {
@@ -112,6 +117,8 @@ export type DbContextType = {
   setSelectedNoteId: (noteId: string | null) => void;
   allRooms: Room<Note>[];
   allRoomIds: string[];
+  getVaultDeletionEligibility: (roomId: string) => RoomDeletionEligibility;
+  deleteVault: (roomId: string) => Promise<void>;
   user: {
     firstName: string;
     lastName: string;
@@ -280,6 +287,44 @@ export const DbProvider = ({ children }: { children: ReactNode }) => {
     return () => window.clearTimeout(id);
   }, []);
 
+  const getVaultDeletionEligibility = useCallback(
+    (roomId: string): RoomDeletionEligibility => {
+      const room = db.getRoom<Note>(collectionKey, roomId);
+      if (!room) {
+        return {
+          canDelete: false,
+          code: 'not-loaded',
+          reason: 'Open this vault before deleting it.',
+        };
+      }
+      return db.getRoomDeletionEligibility(room);
+    },
+    []
+  );
+
+  const deleteVault = useCallback(
+    async (roomId: string) => {
+      const room = db.getRoom<Note>(collectionKey, roomId);
+      if (!room) {
+        throw new Error('This vault is no longer available.');
+      }
+
+      await db.deleteRoom(room);
+
+      const remainingRooms = db.getRooms<'notes'>('notes');
+      setAllRooms(remainingRooms);
+      if (selectedRoom?.id === roomId) {
+        setSelectedRoom(
+          remainingRooms.find((candidate) => candidate.id === defaultRoomId) ??
+            remainingRooms[0] ??
+            null
+        );
+        setSelectedNoteId(null);
+      }
+    },
+    [selectedRoom]
+  );
+
   // ── Secure room actions ──────────────────────────────────────────
   const createSecureRoom = useCallback(async () => {
     try {
@@ -302,6 +347,8 @@ export const DbProvider = ({ children }: { children: ReactNode }) => {
       await room.unlock(phrase);
 
       setRecoveryPhrase(phrase);
+      setSelectedRoom(room);
+      setSelectedNoteId(null);
       setAllRooms(db.getRooms(collectionKey));
       showSecureMessage('Secure room created! Save your recovery phrase.');
     } catch (err) {
@@ -525,6 +572,8 @@ export const DbProvider = ({ children }: { children: ReactNode }) => {
       selectedNoteId: selectedNoteId ?? defaultNote?._id ?? defaultNoteId,
       allRooms,
       allRoomIds,
+      getVaultDeletionEligibility,
+      deleteVault,
       setSelectedNoteId,
       user,
       signOut,
@@ -561,6 +610,8 @@ export const DbProvider = ({ children }: { children: ReactNode }) => {
       defaultNote,
       allRooms,
       allRoomIds,
+      getVaultDeletionEligibility,
+      deleteVault,
       setSelectedNoteId,
       user,
       // Secure room deps


### PR DESCRIPTION
## What

Adds safe, discoverable deletion for Ewe Note top-level vaults. Empty, unlocked, unprotected vaults can be deleted after confirmation; non-empty, locked, protected, and non-admin vaults keep the action visible but disabled with a specific reason. Synced deletions are authorized from the server's room-admin ACL, not client claims.

## Changes

- `packages/auth-server-hono` - authorize room tombstones against authoritative admin ACLs and reject collaborator/client-forged deletion.
- `packages/db` - add public local-first room deletion eligibility/deletion APIs, offline tombstones, cache cleanup, startup filtering, and authoritative rejection recovery.
- `packages/ewe-note` - add direct and menu `Delete vault` actions, reasoned disabled states, destructive confirmation, and safe selection/navigation fallback.
- `e2e/cypress` - cover cancel, empty-vault deletion with refresh persistence, and non-empty-vault blocking.
- `.changeset` - record the new `@eweser/db` public behavior.

## Review Evidence

- Screenshots: attached in the task handoff and in the [sanitized evidence gallery](https://optimization-supplies-antonio-heating.trycloudflare.com/).
- Interactive app preview: [Ewe Note `/notes/`](https://sol-organizations-descriptions-predict.trycloudflare.com/notes/) using synthetic signed-out local data; bounded to one hour from creation.
- Visual assessment: pass. Direct action alignment and density match existing row controls; menu copy is vault-specific; disabled reasons wrap without clipping; the confirmation hierarchy and destructive affordance are clear; 390px mobile fit has no horizontal overflow.
- Real user flow: pass on both the local production build and external HTTPS preview: create empty secure vault, cancel deletion, add note, verify disabled reason, delete note, delete vault, reload, verify absence.

```mermaid
flowchart LR
  Action[Delete vault] --> Eligible{Empty, unlocked, unprotected, admin or local?}
  Eligible -->|No| Reason[Disabled action with reason]
  Eligible -->|Yes| Confirm[Destructive confirmation]
  Confirm --> SDK[Database.deleteRoom]
  SDK --> Local[Persist tombstone and remove local room]
  SDK -->|authenticated| Server[Registry sync]
  Server --> ACL{Authoritative admin ACL}
  ACL -->|Allowed| Removed[Soft-delete room]
  ACL -->|Rejected| Restore[Restore room and surface error]
```

## Testing

- [x] Auth server tests: 19 files, 198 tests passed
- [x] DB tests: 17 files, 123 passed, 1 existing todo
- [x] Ewe Note tests: 33 files, 200 tests passed
- [x] Focused DB/UI/auth type-checks passed
- [x] DB and Ewe Note production builds passed
- [x] Root `npm run check` passed
- [x] Code-index, diff, staged formatting, pre-push, and secret scans passed
- [x] Visible desktop/mobile production-build flow passed
- [ ] Local Cypress CLI could not launch because Xvfb is absent (`spawn Xvfb ENOENT`); the focused regression spec is included for CI

## Checklist

- [x] Changeset added for the published DB package API
- [x] No secrets or machine-specific runtime details committed
- [x] No direct Yjs document mutations introduced
- [x] No database migration required
- [x] UI screenshots inspected for spacing, alignment, balance, wrapping, overflow, density, and responsive fit
- [x] Backend/data-flow change documented in the diagram above
- [x] No recursive note, folder, attachment, filesystem, or sync-persistence deletion introduced
