### PR TITLE
feat(ewe-note): add opt-in Agent Workspace mod

### DIFF
--- a/packages/ewe-note/src/app/INDEX.md
+++ b/packages/ewe-note/src/app/INDEX.md
@@ -36,6 +36,9 @@ including page routes, note context, and product-specific app components.
   existing room hooks.
 - User-visible workflow changes should keep Cypress selectors stable or update
   E2E coverage in the same change.
+- `components/agent-workspace-settings.ts` owns the browser-local, off-by-default
+  Agent Workspace mod preference. It must not contain bridge credentials,
+  personal paths, or automatic network behavior.
 
 ## Update Triggers
 

--- a/packages/ewe-note/src/app/components/agent-workspace-settings.ts
+++ b/packages/ewe-note/src/app/components/agent-workspace-settings.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+
+export const AGENT_WORKSPACE_ENABLED_STORAGE_KEY =
+  'ewe-note-mod-agent-workspace-enabled';
+
+export type AgentWorkspacePreferences = {
+  enabled: boolean;
+};
+
+export const DEFAULT_AGENT_WORKSPACE_PREFERENCES: AgentWorkspacePreferences = {
+  enabled: false,
+};
+
+export function readAgentWorkspacePreferences(): AgentWorkspacePreferences {
+  if (typeof window === 'undefined') {
+    return DEFAULT_AGENT_WORKSPACE_PREFERENCES;
+  }
+
+  return {
+    enabled:
+      window.localStorage.getItem(AGENT_WORKSPACE_ENABLED_STORAGE_KEY) ===
+      'true',
+  };
+}
+
+export function useAgentWorkspacePreferences() {
+  const [preferences, setPreferences] = useState<AgentWorkspacePreferences>(
+    readAgentWorkspacePreferences
+  );
+
+  useEffect(() => {
+    window.localStorage.setItem(
+      AGENT_WORKSPACE_ENABLED_STORAGE_KEY,
+      String(preferences.enabled)
+    );
+  }, [preferences.enabled]);
+
+  return {
+    preferences,
+    setEnabled: (enabled: boolean) => {
+      setPreferences({ enabled });
+    },
+  };
+}

--- a/packages/ewe-note/src/app/pages/Settings.test.tsx
+++ b/packages/ewe-note/src/app/pages/Settings.test.tsx
@@ -9,6 +9,7 @@ import {
   WORKSPACE_MOBILE_PULLDOWN_SEARCH_STORAGE_KEY,
   WORKSPACE_MOBILE_SWIPE_EFFECTS_STORAGE_KEY,
 } from '../components/workspace-interaction-settings';
+import { AGENT_WORKSPACE_ENABLED_STORAGE_KEY } from '../components/agent-workspace-settings';
 
 const mockNavigate = vi.fn();
 const mockSetSelectedRoom = vi.fn();
@@ -144,5 +145,36 @@ describe('Settings', () => {
         'Open a local Markdown folder and edit its files in EweNote. Sign in first if you also want the room synced across devices.'
       )
     ).toBeTruthy();
+  });
+
+  it('keeps the Agent Workspace mod off by default', () => {
+    render(<Settings />);
+
+    const toggle = screen.getByRole('switch', {
+      name: 'Enable Agent Workspace',
+    });
+
+    expect(toggle.getAttribute('data-state')).toBe('unchecked');
+    expect(
+      screen.getByText(
+        'Off. No agent workspace tasks or connections are active.'
+      )
+    ).toBeTruthy();
+    expect(screen.queryByText('Ready to pair')).toBeNull();
+  });
+
+  it('enables the Agent Workspace mod for this browser only', () => {
+    render(<Settings />);
+
+    fireEvent.click(
+      screen.getByRole('switch', { name: 'Enable Agent Workspace' })
+    );
+
+    expect(
+      window.localStorage.getItem(AGENT_WORKSPACE_ENABLED_STORAGE_KEY)
+    ).toBe('true');
+    expect(screen.getByText('Ready to pair')).toBeTruthy();
+    expect(screen.getByText('Agent Control')).toBeTruthy();
+    expect(screen.getByText('Agent Memory')).toBeTruthy();
   });
 });

--- a/packages/ewe-note/src/app/pages/Settings.tsx
+++ b/packages/ewe-note/src/app/pages/Settings.tsx
@@ -1,5 +1,6 @@
 import {
   ArrowLeft,
+  Bot,
   ChevronRight,
   Download,
   HardDrive,
@@ -24,6 +25,7 @@ import { AUTH_PAGES_SERVER, AUTH_SERVER, env, routerBase } from '../../config';
 import { useTheme } from '../components/ThemeProvider';
 import { Switch } from '../components/ui/switch';
 import { useWorkspaceInteractionPreferences } from '../components/workspace-interaction-settings';
+import { useAgentWorkspacePreferences } from '../components/agent-workspace-settings';
 import {
   importVaultFromFiles,
   type BrowserVaultImportProgress,
@@ -41,6 +43,7 @@ const SETTINGS_SECTIONS = [
   { id: 'appearance', label: 'Appearance' },
   { id: 'interaction', label: 'Interaction' },
   { id: 'sync', label: 'Sync' },
+  { id: 'mods', label: 'Mods' },
   { id: 'developer', label: 'Developer' },
 ] as const;
 
@@ -61,6 +64,10 @@ export function Settings() {
   const { mode, theme, setMode } = useTheme();
   const { preferences, updatePreference } =
     useWorkspaceInteractionPreferences();
+  const {
+    preferences: agentWorkspacePreferences,
+    setEnabled: setAgentWorkspaceEnabled,
+  } = useAgentWorkspacePreferences();
   const {
     allRooms,
     allRoomIds,
@@ -604,6 +611,64 @@ export function Settings() {
                       </div>
                     ) : null}
                   </div>
+                </div>
+              </SettingsPanel>
+            </section>
+
+            <section id="mods" className="mb-8 scroll-mt-6">
+              <h2 className="mb-4 text-sm font-medium uppercase tracking-wider text-muted-foreground">
+                Mods
+              </h2>
+              <SettingsPanel icon={Bot} title="Agent Workspace">
+                <div className="space-y-4">
+                  <SettingsToggleRow
+                    id="ewe-note-settings-agent-workspace"
+                    title="Enable Agent Workspace"
+                    description="Connect editable agent controls and read-only agent memory through a separately installed local bridge. Off by default and enabled only in this browser."
+                    checked={agentWorkspacePreferences.enabled}
+                    onCheckedChange={setAgentWorkspaceEnabled}
+                  />
+
+                  {agentWorkspacePreferences.enabled ? (
+                    <div
+                      data-cy="ewe-note-settings-agent-workspace-setup"
+                      className="space-y-4 rounded-lg border border-border/70 bg-background/60 px-4 py-4"
+                    >
+                      <div>
+                        <div className="text-sm font-medium text-foreground">
+                          Ready to pair
+                        </div>
+                        <p className="mt-1 text-sm text-muted-foreground">
+                          Install and pair an Agent Bridge to connect vaults.
+                          Ewe Note does not receive local paths, Git commands,
+                          runtime commands, or bridge credentials.
+                        </p>
+                      </div>
+                      <div className="grid gap-3 sm:grid-cols-2">
+                        <InfoBlock
+                          icon={Bot}
+                          title="Agent Control"
+                          description="Editable, allowlisted Markdown controls. The bridge validates and versions changes before applying them."
+                        />
+                        <InfoBlock
+                          icon={HardDrive}
+                          title="Agent Memory"
+                          description="Read-only memory and session-journal snapshots for browsing and search."
+                        />
+                      </div>
+                      <p className="text-xs text-muted-foreground">
+                        Not connected. Turning on this mod does not create a
+                        vault, contact a bridge, or affect another user.
+                      </p>
+                    </div>
+                  ) : (
+                    <p
+                      data-cy="ewe-note-settings-agent-workspace-off"
+                      className="text-xs text-muted-foreground"
+                    >
+                      Off. No agent workspace tasks or connections are active.
+                    </p>
+                  )}
                 </div>
               </SettingsPanel>
             </section>


### PR DESCRIPTION
## What changed

- add an `Agent Workspace` mod section to Ewe Note Settings
- keep the mod disabled by default and store enablement only in the current browser
- show the generic split between editable `Agent Control` and read-only `Agent Memory`
- state that a separately installed bridge owns local paths, Git/runtime commands, and credentials

## Why

Agent instructions and memory should be easy to browse in Ewe Note without embedding one user's private workstation configuration or automatically affecting other users.

## Safety

The disabled state performs no bridge, vault, polling, or network activity. This change adds no schema, auth, grant, credential, local path, runtime command, or shared-account setting. The package is an internal app, so no published-package changeset is required.

## Validation

- `npm run lint --workspace @eweser/ewe-note`
- `npm test --workspace @eweser/ewe-note` (`202 passed`)
- `npm run type-check --workspace @eweser/ewe-note`
- `npm run build --workspace @eweser/ewe-note`
- pre-commit/pre-push formatting, DCO, and secret scans
- external fixture review: default-off and enabled states, zero console errors
