### PR TITLE
fix(ewe-note): enforce read-only rooms

### DIFF
--- a/.changeset/safe-readonly-room-logs.md
+++ b/.changeset/safe-readonly-room-logs.md
@@ -1,0 +1,5 @@
+---
+'@eweser/db': patch
+---
+
+Redact access-grant credentials from client diagnostics while preserving safe registry sync status logging.

--- a/docs/ai/plans/2026-08-10-agent-memory-readonly-room.md
+++ b/docs/ai/plans/2026-08-10-agent-memory-readonly-room.md
@@ -1,0 +1,184 @@
+# Plan: Read-only Agent Memory room
+
+## Goal
+
+Publish curated agent-session journals into one private Ewe Note room that the
+local publisher can write and the room reader's Ewe Note identity can browse but cannot
+modify.
+
+## Scope
+
+- In: read-inclusive room registries, read-only sync tokens and relay
+  enforcement, Ewe Note read-only editor behavior, access-token log redaction,
+  focused tests, production deployment, and one least-privilege room/grant
+  canary.
+- Out: Agent Control, bulk journal publication, Omnara archival, room cleanup,
+  public sharing, automatic capture, and changes to unrelated existing rooms.
+
+## Assumptions / Open Questions
+
+- Assumption: The existing Hocuspocus connection `readOnly` flag is the
+  authoritative server-side write barrier for a read-only room connection.
+- Assumption: A non-login service principal can own the private Agent Memory
+  room and its single-room publisher grant; it will have no password or browser
+  session.
+- Assumption: The existing Ewe Note app grant can discover rooms where its owner
+  has explicit read access after registry queries include read ACLs.
+- Open question: none blocking; stop if production evidence contradicts these
+  assumptions.
+
+## Domain Language
+
+- Glossary docs: `packages/auth-server-hono/GLOSSARY.md`,
+  `packages/sync-server/GLOSSARY.md`.
+- New terms: none.
+- Changed terms: a granted room is readable when the grant owner is present in
+  the room read, write, or admin ACL; it is writable only through write or admin
+  ACL membership.
+- ADR candidates: none; this completes the semantics already represented by
+  room ACLs and read-only invites.
+
+## Runs
+
+## Run Order And Manual Test Handoffs
+
+Run order: sequential because the production canary depends on the deployed
+auth and sync enforcement.
+
+### Run 1: Enforce read-only room grants end to end
+
+- **Id**: `run-1`
+- **Title**: `Enforce read-only room grants end to end`
+- **UI classification**: `ui: false`
+- **Browser checkpoint**: `none`
+- **Deliverable**:
+  - Read-granted rooms appear in registries, receive read-only sync tokens, and
+    cannot submit Yjs updates to the relay.
+- **Files**:
+  - `packages/auth-server-hono/src/model/rooms/calls.ts`: include explicit read
+    ACLs while preserving write/admin behavior.
+  - `packages/auth-server-hono/src/routes/access-grant.ts`: issue the correct
+    read-only room sync token.
+  - `packages/auth-server-hono/src/services/sync-token.ts`: carry the read-only
+    claim.
+  - `packages/sync-server/src/index.ts`: set Hocuspocus connection read-only.
+  - focused tests for all boundaries.
+- **Steps**:
+  - [x] Add ACL helpers and read-inclusive registry queries.
+  - [x] Derive room write authority when refreshing a sync token.
+  - [x] Set and test the relay read-only connection flag.
+- **Tests**:
+  - `npm test --workspace @eweser/auth-server-hono`
+  - `npm test --workspace @eweser/sync-server`
+- **Verification**:
+  - Unit proof that a read grantee can load but a read-only connection cannot
+    apply an update.
+- **Manual test handoff**:
+  - Deferred to Run 3 production canary.
+- **Dependencies**:
+  - None.
+- **Model tier**: `strong`
+- **Risk level**: `high`
+
+### Run 2: Make Ewe Note visibly read-only and redact tokens
+
+- **Id**: `run-2`
+- **Title**: `Make Ewe Note visibly read-only and redact tokens`
+- **UI classification**: `ui: true`
+- **Browser checkpoint**: `focused`
+- **Deliverable**:
+  - Read-only notes have no editable body, raw-source, title, move, duplicate,
+    or delete controls; the client never logs access-grant JWTs.
+- **Files**:
+  - `packages/db/src/methods/connection/syncRegistry.ts` and
+    `packages/db/src/utils/localStorageService.ts`: redact credential-bearing
+    log values.
+  - `packages/ewe-note/src/app/contexts/NotesContext.tsx`: fail closed on room
+    mutations without write ACL.
+  - `packages/ewe-note/src/app/pages/EnhancedEditor.tsx` and editor components:
+    render a clear read-only state and disable all editing paths.
+  - focused tests for the mutation guard and UI.
+- **Steps**:
+  - [x] Add one reusable room-write check.
+  - [x] Guard context mutations and editor/source/frontmatter writes.
+  - [x] Remove token values from client logging.
+- **Tests**:
+  - `npm test --workspace @eweser/db`
+  - `npm test --workspace @eweser/ewe-note`
+- **Verification**:
+  - Synthetic browser pass with a read-only room and console inspection.
+- **Manual test handoff**:
+  - Provide screenshot and interactive fixture preview before PR handoff.
+- **Dependencies**:
+  - `run-1`.
+- **Model tier**: `strong`
+- **Risk level**: `high`
+
+### Run 3: Deploy and publish one journal canary
+
+- **Id**: `run-3`
+- **Title**: `Deploy and publish one journal canary`
+- **UI classification**: `ui: true`
+- **Browser checkpoint**: `full`
+- **Deliverable**:
+  - One private service-owned `Agent Memory` notes room, one single-room writer
+    grant, explicit read access for an existing reader identity, and one verified
+    journal note.
+- **Files**:
+  - Private runtime token and receipt files only; no credentials or personal
+    identifiers in the public repository.
+- **Steps**:
+  - [ ] Merge the scoped PR and verify all production services on the merged
+        commit.
+  - [ ] Create the non-login service principal, room, ACL, and publisher grant
+        in one fail-closed transaction.
+  - [ ] Publish only the reviewed journal and perform fresh server read-back.
+  - [ ] Verify Ewe Note can browse/export but cannot edit the note.
+- **Tests**:
+  - Production access-grant registry and read-only sync canary.
+- **Verification**:
+  - Exact content hash, deterministic note identity, private receipt, UI
+    screenshot, zero credential-bearing console logs, and attempted-write
+    rejection.
+- **Manual test handoff**:
+  - Open the exact Ewe Note route and confirm the journal is scannable and marked
+    read-only; the source Omnara session remains unarchived.
+- **Dependencies**:
+  - `run-1`, `run-2`, green CI, merged deployment.
+- **Model tier**: `strong`
+- **Risk level**: `high`
+
+## Stop Conditions
+
+Stop and ask for user approval if:
+
+- The production canary would touch an existing room, grant, note, or account.
+- A schema migration, public package API change beyond the read-only token
+  claim, or destructive cleanup becomes necessary.
+- The relay cannot prove server-side write rejection for a read-only token.
+- Provisioning cannot remain one new service principal, one room, one writer
+  grant, and one read ACL.
+- Required credentials or authenticated UI access are unavailable.
+
+## Approval Boundary
+
+The approved rollout is exactly one private Agent Memory room, a single-room
+publisher writer grant, read-only access for an existing Ewe Note identity,
+one reviewed journal, and production verification. This plan narrows the
+prerequisite product changes to making that approved permission model true.
+
+Approval does not authorize bulk publication, Omnara archival, room cleanup,
+Agent Control rollout, edits to existing rooms/grants, or unrelated refactors.
+
+## Execution Summary
+
+| Run     | Status      | Files Changed                           | Verification                           | Notes                                      |
+| ------- | ----------- | --------------------------------------- | -------------------------------------- | ------------------------------------------ |
+| `run-1` | Complete    | Auth registry, token, relay             | 27 focused tests and type checks green | Read-only claim enforced by Hocuspocus     |
+| `run-2` | Complete    | DB diagnostics, Ewe Note context/editor | 23 focused tests and type checks green | Browser evidence pending milestone runtime |
+| `run-3` | Not started |                                         |                                        | Requires merge and deployment              |
+
+## Self-Reflection / Instruction Improvements
+
+- Production console inspection must filter/redact credential-bearing SDK logs;
+  never dump a raw browser console file during auth work.

--- a/packages/auth-server-hono/src/model/rooms/calls.ts
+++ b/packages/auth-server-hono/src/model/rooms/calls.ts
@@ -11,6 +11,14 @@ import type { CollectionKey } from '@eweser/shared';
 
 export type { Room };
 
+function readableRoomPredicate(userId: string) {
+  return or(
+    arrayOverlaps(rooms.readAccess, [userId]),
+    arrayOverlaps(rooms.writeAccess, [userId]),
+    arrayOverlaps(rooms.adminAccess, [userId])
+  );
+}
+
 export async function getRoomById(
   id: string,
   dbInstance?: DBInstance
@@ -186,7 +194,7 @@ export async function getRoomIdsFromAccessGrant(
         .where(
           and(
             or(isNull(rooms._deleted), ne(rooms._deleted, true)),
-            arrayOverlaps(rooms.writeAccess, [ownerId])
+            readableRoomPredicate(ownerId)
           )
         )
     : await (dbInstance ?? db)
@@ -195,7 +203,7 @@ export async function getRoomIdsFromAccessGrant(
         .where(
           and(
             or(isNull(rooms._deleted), ne(rooms._deleted, true)),
-            arrayOverlaps(rooms.writeAccess, [ownerId]),
+            readableRoomPredicate(ownerId),
             or(
               grantRoomIds.length > 0
                 ? inArray(rooms.id, grantRoomIds)
@@ -229,7 +237,7 @@ export async function getRoomsFromAccessGrant(
       .from(rooms)
       .where(
         and(
-          arrayOverlaps(rooms.writeAccess, [ownerId]),
+          readableRoomPredicate(ownerId),
           or(isNull(rooms._deleted), ne(rooms._deleted, true))
         )
       );
@@ -241,7 +249,7 @@ export async function getRoomsFromAccessGrant(
     .where(
       and(
         or(isNull(rooms._deleted), ne(rooms._deleted, true)),
-        arrayOverlaps(rooms.writeAccess, [ownerId]),
+        readableRoomPredicate(ownerId),
         or(
           grantRoomIds.length > 0
             ? inArray(rooms.id, grantRoomIds)

--- a/packages/auth-server-hono/src/model/rooms/room-access.test.ts
+++ b/packages/auth-server-hono/src/model/rooms/room-access.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { roomAllowsRead, roomAllowsWrite } from './room-access.js';
+
+const room = {
+  readAccess: ['reader'],
+  writeAccess: ['writer'],
+  adminAccess: ['admin'],
+};
+
+describe('room access helpers', () => {
+  it.each(['reader', 'writer', 'admin'])('allows %s to read', (userId) => {
+    expect(roomAllowsRead(room, userId)).toBe(true);
+  });
+
+  it('keeps read-only users out of write access', () => {
+    expect(roomAllowsWrite(room, 'reader')).toBe(false);
+    expect(roomAllowsWrite(room, 'writer')).toBe(true);
+    expect(roomAllowsWrite(room, 'admin')).toBe(true);
+  });
+});

--- a/packages/auth-server-hono/src/model/rooms/room-access.ts
+++ b/packages/auth-server-hono/src/model/rooms/room-access.ts
@@ -1,0 +1,19 @@
+import type { Room } from '../../db/schema/rooms.js';
+
+export function roomAllowsRead(
+  room: Pick<Room, 'readAccess' | 'writeAccess' | 'adminAccess'>,
+  userId: string
+) {
+  return (
+    room.readAccess.includes(userId) ||
+    room.writeAccess.includes(userId) ||
+    room.adminAccess.includes(userId)
+  );
+}
+
+export function roomAllowsWrite(
+  room: Pick<Room, 'writeAccess' | 'adminAccess'>,
+  userId: string
+) {
+  return room.writeAccess.includes(userId) || room.adminAccess.includes(userId);
+}

--- a/packages/auth-server-hono/src/routes/access-grant.test.ts
+++ b/packages/auth-server-hono/src/routes/access-grant.test.ts
@@ -5,6 +5,8 @@ import type { Context, Next } from 'hono';
 const syncRoomsWithClientMock = vi.fn();
 const getRoomsByIdsMock = vi.fn();
 const getWritableRoomsByUserIdMock = vi.fn();
+const roomAllowsReadMock = vi.fn();
+const roomAllowsWriteMock = vi.fn();
 const updateRoomPublicAccessMock = vi.fn();
 const updateRoomMock = vi.fn();
 const createRoomInviteLinkMock = vi.fn();
@@ -43,6 +45,11 @@ vi.mock('../model/rooms/calls.js', () => ({
   getWritableRoomsByUserId: getWritableRoomsByUserIdMock,
   updateRoomPublicAccess: updateRoomPublicAccessMock,
   updateRoom: updateRoomMock,
+}));
+
+vi.mock('../model/rooms/room-access.js', () => ({
+  roomAllowsRead: roomAllowsReadMock,
+  roomAllowsWrite: roomAllowsWriteMock,
 }));
 
 vi.mock('../services/access-grant/create-room-invite-link.js', () => ({
@@ -87,6 +94,8 @@ describe('accessGrantRouter', () => {
     getWritableRoomsByUserIdMock.mockResolvedValue([
       { id: 'room-1', collectionKey: 'notes' },
     ]);
+    roomAllowsReadMock.mockReturnValue(true);
+    roomAllowsWriteMock.mockReturnValue(true);
   });
 
   it('returns 401 on sync-registry when auth header is missing', async () => {
@@ -392,6 +401,23 @@ describe('accessGrantRouter', () => {
     expect(updateRoomPublicAccessMock).not.toHaveBeenCalled();
   });
 
+  it('rejects room renames from a read-only grantee', async () => {
+    getRoomsByIdsMock.mockResolvedValueOnce([{ id: 'room-1' }]);
+    roomAllowsWriteMock.mockReturnValueOnce(false);
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/access-grant/update-room/room-1', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ newName: 'Renamed' }),
+      })
+    );
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({ error: 'Room is read only' });
+    expect(updateRoomMock).not.toHaveBeenCalled();
+  });
+
   it('returns 403 when publication update is not admin-authorized', async () => {
     updateRoomPublicAccessMock.mockRejectedValueOnce(
       new Error('Room publication requires admin access')
@@ -430,8 +456,9 @@ describe('accessGrantRouter', () => {
     expect(generateSyncTokenMock).toHaveBeenCalledWith(
       'room-1',
       'notes',
-      undefined,
-      'read'
+      'grant-1',
+      'read',
+      false
     );
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toEqual({
@@ -439,5 +466,43 @@ describe('accessGrantRouter', () => {
       syncToken: 'sync-token',
       tokenExpiry: '2026-04-03T00:00:00.000Z',
     });
+  });
+
+  it('issues a read-only sync token for a read grantee', async () => {
+    getRoomsByIdsMock.mockResolvedValueOnce([
+      { id: 'room-1', collectionKey: 'notes', publicAccess: 'private' },
+    ]);
+    roomAllowsWriteMock.mockReturnValueOnce(false);
+    generateSyncTokenMock.mockReturnValueOnce({
+      token: 'read-only-sync-token',
+      expiry: new Date('2026-04-03T00:00:00.000Z'),
+    });
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/access-grant/refresh-sync-token/room-1')
+    );
+
+    expect(generateSyncTokenMock).toHaveBeenCalledWith(
+      'room-1',
+      'notes',
+      'grant-1',
+      'private',
+      true
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects a room absent from the grant owner ACL', async () => {
+    getRoomsByIdsMock.mockResolvedValueOnce([
+      { id: 'room-1', collectionKey: 'notes', publicAccess: 'private' },
+    ]);
+    roomAllowsReadMock.mockReturnValueOnce(false);
+
+    const res = await app.fetch(
+      new Request('http://localhost/api/access-grant/refresh-sync-token/room-1')
+    );
+
+    expect(res.status).toBe(403);
+    expect(generateSyncTokenMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/auth-server-hono/src/routes/access-grant.ts
+++ b/packages/auth-server-hono/src/routes/access-grant.ts
@@ -15,6 +15,7 @@ import {
   updateRoomPublicAccess,
   updateRoom,
 } from '../model/rooms/calls.js';
+import { roomAllowsRead, roomAllowsWrite } from '../model/rooms/room-access.js';
 import { createRoomInviteLink } from '../services/access-grant/create-room-invite-link.js';
 import { verifyRoomInviteToken } from '../services/access-grant/create-room-invite-link.js';
 import { generateSyncToken } from '../services/sync-token.js';
@@ -284,6 +285,12 @@ accessGrantRouter.post('/update-room/:roomId', requireJwtAuth, async (c) => {
     return c.json({ error: 'Invalid room' }, 403);
   }
 
+  const [room] = await getRoomsByIds([roomId]);
+  const { ownerId } = parseAccessGrantId(c.get('access_grant_id'));
+  if (!room || !roomAllowsWrite(room, ownerId)) {
+    return c.json({ error: 'Room is read only' }, 403);
+  }
+
   const updated = await updateRoom({ id: roomId, name: newName });
   return c.json(updated);
 });
@@ -356,12 +363,17 @@ accessGrantRouter.get(
     if (!room) {
       return c.json({ error: 'Room not found' }, 404);
     }
+    const { ownerId } = parseAccessGrantId(c.get('access_grant_id'));
+    if (!roomAllowsRead(room, ownerId)) {
+      return c.json({ error: 'Invalid room' }, 403);
+    }
 
     const { token, expiry } = generateSyncToken(
       roomId,
       room.collectionKey,
-      undefined,
-      room.publicAccess
+      ownerId,
+      room.publicAccess,
+      !roomAllowsWrite(room, ownerId)
     );
 
     const response: RefreshSyncTokenRouteResponse = {

--- a/packages/auth-server-hono/src/services/sync-token.test.ts
+++ b/packages/auth-server-hono/src/services/sync-token.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../env.js', () => ({
+  env: {
+    SERVER_SECRET: 'test-secret',
+    SYNC_AUTH_SECRET: 'test-secret',
+  },
+}));
+
+const { generateSyncToken, verifySyncToken } = await import('./sync-token.js');
+
+describe('sync tokens', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-10T00:00:00.000Z'));
+  });
+
+  it('carries a read-only claim only for read-only room access', () => {
+    const readOnly = generateSyncToken(
+      'room-memory',
+      'notes',
+      'reader-1',
+      'private',
+      true
+    );
+    const writable = generateSyncToken(
+      'room-memory',
+      'notes',
+      'writer-1',
+      'private',
+      false
+    );
+
+    expect(verifySyncToken(readOnly.token)).toMatchObject({
+      roomId: 'room-memory',
+      userId: 'reader-1',
+      readOnly: true,
+    });
+    expect(verifySyncToken(writable.token).readOnly).toBeUndefined();
+  });
+});

--- a/packages/auth-server-hono/src/services/sync-token.ts
+++ b/packages/auth-server-hono/src/services/sync-token.ts
@@ -6,6 +6,7 @@ export interface SyncTokenPayload {
   userId?: string;
   collectionKey?: string;
   publicAccess?: 'private' | 'read' | 'write';
+  readOnly?: boolean;
 }
 
 const TOKEN_VALID_MINUTES = 60; // 1 hour
@@ -19,6 +20,7 @@ export function generateSyncToken(
   collectionKey?: string,
   userId?: string,
   publicAccess?: 'private' | 'read' | 'write',
+  readOnly = false,
   validMinutes = TOKEN_VALID_MINUTES
 ): { token: string; expiry: Date } {
   const payload: SyncTokenPayload = {
@@ -26,6 +28,7 @@ export function generateSyncToken(
     ...(collectionKey ? { collectionKey } : {}),
     ...(userId ? { userId } : {}),
     ...(publicAccess ? { publicAccess } : {}),
+    ...(readOnly ? { readOnly: true } : {}),
   };
   const secret = env.SYNC_AUTH_SECRET ?? env.SERVER_SECRET;
   const token = jwt.sign(payload, secret, {

--- a/packages/db/src/methods/connection/syncRegistry.test.ts
+++ b/packages/db/src/methods/connection/syncRegistry.test.ts
@@ -75,6 +75,17 @@ describe('syncRegistry', () => {
     expect(db.userId).toBe('user-1');
     expect(db.accessGrantToken).toBe('next-token');
     expect(db.registry).toEqual(rooms);
+    expect(db.info).toHaveBeenCalledWith('syncResult', {
+      roomCount: 1,
+      hasToken: true,
+      hasUserId: true,
+    });
+    expect(db.debug).toHaveBeenCalledWith('setting new token', '[redacted]');
+    expect(db.info).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ token: 'next-token' })
+    );
+    expect(db.debug).not.toHaveBeenCalledWith(expect.anything(), 'next-token');
   });
 
   it('accepts an empty authoritative registry after the final room is deleted', async () => {

--- a/packages/db/src/methods/connection/syncRegistry.ts
+++ b/packages/db/src/methods/connection/syncRegistry.ts
@@ -59,15 +59,18 @@ export const syncRegistry = (db: Database) => {
       db.emit('registrySync', 'error', error);
       return false;
     }
-    db.info('syncResult', syncResult);
-
     const { rooms, token, userId } = syncResult ?? {};
+    db.info('syncResult', {
+      roomCount: Array.isArray(rooms) ? rooms.length : 0,
+      hasToken: typeof token === 'string' && token.length > 0,
+      hasUserId: typeof userId === 'string' && userId.length > 0,
+    });
     if (userId && typeof userId === 'string') {
       db.debug('setting new userId', userId);
       db.userId = userId;
     }
     if (token && typeof token === 'string') {
-      db.debug('setting new token', token);
+      db.debug('setting new token', '[redacted]');
       setLocalAccessGrantToken(db)(token);
       db.accessGrantToken = token;
     } else {

--- a/packages/db/src/utils/localStorageService.test.ts
+++ b/packages/db/src/utils/localStorageService.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import {
+  LocalStorageKey,
+  localStorageLogValue,
+} from './localStorageService.js';
+
+describe('localStorageLogValue', () => {
+  it('redacts access-grant tokens', () => {
+    expect(
+      localStorageLogValue(LocalStorageKey.accessGrantToken, 'secret-jwt')
+    ).toBe('[redacted]');
+  });
+
+  it('keeps non-credential registry diagnostics available', () => {
+    const registry = [{ id: 'room-1' }];
+    expect(localStorageLogValue(LocalStorageKey.roomRegistry, registry)).toBe(
+      registry
+    );
+  });
+});

--- a/packages/db/src/utils/localStorageService.ts
+++ b/packages/db/src/utils/localStorageService.ts
@@ -13,16 +13,24 @@ export type LocalStorageService = {
   setItem: <T = unknown>(key: LocalStorageKey, value: T) => void;
   removeItem: (key: LocalStorageKey) => void;
 };
+
+export function localStorageLogValue(
+  key: LocalStorageKey,
+  value: unknown
+): unknown {
+  return key === LocalStorageKey.accessGrantToken ? '[redacted]' : value;
+}
+
 export const localStorageSet =
   (db: Database) => (key: LocalStorageKey, value: unknown) => {
-    db.debug('#### localStorageSet', key, value);
+    db.debug('#### localStorageSet', key, localStorageLogValue(key, value));
     db.localStoragePolyfill.setItem('ewe_' + key, JSON.stringify(value));
   };
 export const localStorageGet =
   (db: Database) =>
   <T>(key: LocalStorageKey): T | null => {
     const value = db.localStoragePolyfill.getItem('ewe_' + key);
-    db.debug('localStorageGet', key, value);
+    db.debug('localStorageGet', key, localStorageLogValue(key, value));
     if (!value) return null;
     return JSON.parse(value) as T;
   };

--- a/packages/ewe-note/src/app/components/RightPanel.source-metadata.test.tsx
+++ b/packages/ewe-note/src/app/components/RightPanel.source-metadata.test.tsx
@@ -20,8 +20,8 @@ const mocks = vi.hoisted(() => ({
     title: 'Overview',
     content: '# Overview\n\nImported source metadata should stay visible.',
     folder: '',
-    tags: [],
-    properties: {},
+    tags: ['journal'],
+    properties: { status: 'reviewed' },
     aliases: [],
     createdAt: '2026-05-04T00:00:00.000Z',
     updatedAt: '2026-05-05T00:00:00.000Z',
@@ -84,5 +84,21 @@ describe('RightPanel source metadata', () => {
     expect(
       within(metadata as HTMLElement).getByText('feature-vault')
     ).not.toBeNull();
+  });
+
+  it('shows metadata but no mutation controls when the room is read only', () => {
+    render(<RightPanel noteId="note-source" readOnly />);
+
+    fireEvent.mouseDown(screen.getByRole('tab', { name: /meta/i }), {
+      button: 0,
+      ctrlKey: false,
+    });
+
+    expect(screen.getByText('journal')).not.toBeNull();
+    expect(screen.getByText('reviewed')).not.toBeNull();
+    expect(screen.queryByLabelText('Remove tag journal')).toBeNull();
+    expect(screen.queryByLabelText('Remove property status')).toBeNull();
+    expect(screen.queryByPlaceholderText('Add tag...')).toBeNull();
+    expect(screen.queryByPlaceholderText('Property name...')).toBeNull();
   });
 });

--- a/packages/ewe-note/src/app/components/RightPanel.tsx
+++ b/packages/ewe-note/src/app/components/RightPanel.tsx
@@ -19,9 +19,14 @@ import { Input } from './ui/input';
 interface RightPanelProps {
   noteId: string;
   onClose?: () => void;
+  readOnly?: boolean;
 }
 
-export function RightPanel({ noteId, onClose }: RightPanelProps) {
+export function RightPanel({
+  noteId,
+  onClose,
+  readOnly = false,
+}: RightPanelProps) {
   const navigate = useNavigate();
   const { notes, updateNote, convertUnlinkedMentionToLink } = useNotes();
   const [newTag, setNewTag] = useState('');
@@ -321,19 +326,21 @@ export function RightPanel({ noteId, onClose }: RightPanelProps) {
                           {mention.mention}
                         </div>
                       </div>
-                      <button
-                        type="button"
-                        className="text-xs px-2 py-1 rounded bg-primary/10 text-primary hover:bg-primary/20"
-                        onClick={() =>
-                          convertUnlinkedMentionToLink(
-                            note.id,
-                            mention.noteId,
-                            mention.mention
-                          )
-                        }
-                      >
-                        Convert
-                      </button>
+                      {!readOnly ? (
+                        <button
+                          type="button"
+                          className="text-xs px-2 py-1 rounded bg-primary/10 text-primary hover:bg-primary/20"
+                          onClick={() =>
+                            convertUnlinkedMentionToLink(
+                              note.id,
+                              mention.noteId,
+                              mention.mention
+                            )
+                          }
+                        >
+                          Convert
+                        </button>
+                      ) : null}
                     </div>
                   ))}
                 </div>
@@ -362,40 +369,44 @@ export function RightPanel({ noteId, onClose }: RightPanelProps) {
                   >
                     <Hash className="w-3 h-3 mr-0.5" />
                     {tag}
-                    <button
-                      type="button"
-                      aria-label={`Remove tag ${tag}`}
-                      onClick={() => handleRemoveTag(tag)}
-                      className="ml-1 p-0.5 rounded hover:bg-background opacity-0 group-hover:opacity-100 transition-opacity"
-                    >
-                      <X className="w-2.5 h-2.5" />
-                    </button>
+                    {!readOnly ? (
+                      <button
+                        type="button"
+                        aria-label={`Remove tag ${tag}`}
+                        onClick={() => handleRemoveTag(tag)}
+                        className="ml-1 p-0.5 rounded hover:bg-background opacity-0 group-hover:opacity-100 transition-opacity"
+                      >
+                        <X className="w-2.5 h-2.5" />
+                      </button>
+                    ) : null}
                   </Badge>
                 ))}
               </div>
-              <div className="flex gap-2">
-                <Input
-                  data-cy="ewe-note-add-tag-input"
-                  value={newTag}
-                  onChange={(e) => setNewTag(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') {
-                      handleAddTag();
-                    }
-                  }}
-                  placeholder="Add tag..."
-                  className="h-8 text-sm"
-                />
-                <button
-                  type="button"
-                  aria-label="Add tag"
-                  data-cy="ewe-note-add-tag-btn"
-                  onClick={handleAddTag}
-                  className="px-3 h-8 bg-primary text-primary-foreground rounded-md hover:opacity-90 transition-opacity flex items-center gap-1 text-sm"
-                >
-                  <Plus className="w-3.5 h-3.5" />
-                </button>
-              </div>
+              {!readOnly ? (
+                <div className="flex gap-2">
+                  <Input
+                    data-cy="ewe-note-add-tag-input"
+                    value={newTag}
+                    onChange={(e) => setNewTag(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        handleAddTag();
+                      }
+                    }}
+                    placeholder="Add tag..."
+                    className="h-8 text-sm"
+                  />
+                  <button
+                    type="button"
+                    aria-label="Add tag"
+                    data-cy="ewe-note-add-tag-btn"
+                    onClick={handleAddTag}
+                    className="px-3 h-8 bg-primary text-primary-foreground rounded-md hover:opacity-90 transition-opacity flex items-center gap-1 text-sm"
+                  >
+                    <Plus className="w-3.5 h-3.5" />
+                  </button>
+                </div>
+              ) : null}
             </div>
 
             {/* Properties */}
@@ -415,49 +426,53 @@ export function RightPanel({ noteId, onClose }: RightPanelProps) {
                         {value}
                       </div>
                     </div>
-                    <button
-                      type="button"
-                      aria-label={`Remove property ${key}`}
-                      onClick={() => handleRemoveProperty(key)}
-                      className="p-1 rounded hover:bg-background opacity-0 group-hover:opacity-100 transition-opacity"
-                    >
-                      <X className="w-3 h-3" />
-                    </button>
+                    {!readOnly ? (
+                      <button
+                        type="button"
+                        aria-label={`Remove property ${key}`}
+                        onClick={() => handleRemoveProperty(key)}
+                        className="p-1 rounded hover:bg-background opacity-0 group-hover:opacity-100 transition-opacity"
+                      >
+                        <X className="w-3 h-3" />
+                      </button>
+                    ) : null}
                   </div>
                 ))}
               </div>
-              <div className="space-y-2">
-                <Input
-                  data-cy="ewe-note-add-property-key"
-                  value={newPropertyKey}
-                  onChange={(e) => setNewPropertyKey(e.target.value)}
-                  placeholder="Property name..."
-                  className="h-8 text-sm"
-                />
-                <div className="flex gap-2">
+              {!readOnly ? (
+                <div className="space-y-2">
                   <Input
-                    data-cy="ewe-note-add-property-value"
-                    value={newPropertyValue}
-                    onChange={(e) => setNewPropertyValue(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter') {
-                        handleAddProperty();
-                      }
-                    }}
-                    placeholder="Property value..."
+                    data-cy="ewe-note-add-property-key"
+                    value={newPropertyKey}
+                    onChange={(e) => setNewPropertyKey(e.target.value)}
+                    placeholder="Property name..."
                     className="h-8 text-sm"
                   />
-                  <button
-                    type="button"
-                    aria-label="Add property"
-                    data-cy="ewe-note-add-property-btn"
-                    onClick={handleAddProperty}
-                    className="px-3 h-8 bg-primary text-primary-foreground rounded-md hover:opacity-90 transition-opacity flex items-center gap-1 text-sm"
-                  >
-                    <Plus className="w-3.5 h-3.5" />
-                  </button>
+                  <div className="flex gap-2">
+                    <Input
+                      data-cy="ewe-note-add-property-value"
+                      value={newPropertyValue}
+                      onChange={(e) => setNewPropertyValue(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          handleAddProperty();
+                        }
+                      }}
+                      placeholder="Property value..."
+                      className="h-8 text-sm"
+                    />
+                    <button
+                      type="button"
+                      aria-label="Add property"
+                      data-cy="ewe-note-add-property-btn"
+                      onClick={handleAddProperty}
+                      className="px-3 h-8 bg-primary text-primary-foreground rounded-md hover:opacity-90 transition-opacity flex items-center gap-1 text-sm"
+                    >
+                      <Plus className="w-3.5 h-3.5" />
+                    </button>
+                  </div>
                 </div>
-              </div>
+              ) : null}
             </div>
 
             {/* Metadata */}

--- a/packages/ewe-note/src/app/contexts/NotesContext.test.tsx
+++ b/packages/ewe-note/src/app/contexts/NotesContext.test.tsx
@@ -140,9 +140,9 @@ function createRoom(
   } as unknown as Room<DbNote>;
 }
 
-function createDbState(room: Room<DbNote>) {
+function createDbState(room: Room<DbNote>, userId?: string) {
   return {
-    db: {} as never,
+    db: { userId } as never,
     loginUrl: '',
     loaded: true,
     loggedIn: false,
@@ -689,5 +689,49 @@ describe('NotesContext parity behavior', () => {
         type: 'daily',
       });
     });
+  });
+
+  it('blocks every note mutation in a remote read-only room', async () => {
+    latestContext = undefined;
+    const [source] = await loadFixtureNotes(['01 Markdown Syntax.md']);
+    const docs = new FakeDocuments([source]);
+    const room = {
+      ...createRoom('agent-memory', 'Agent Memory', docs),
+      syncUrl: 'wss://sync.example.test',
+      readAccess: ['reader'],
+      writeAccess: ['publisher'],
+      adminAccess: ['publisher'],
+    } as Room<DbNote>;
+
+    dbState = createDbState(room, 'reader');
+    mockUseDb.mockImplementation(() => dbState);
+    mockUseFolders.mockReturnValue({
+      folders: [],
+      createFolder: vi.fn(),
+      renameFolder: vi.fn(),
+      deleteFolder: vi.fn(),
+    });
+
+    render(
+      <NotesProvider>
+        <Probe />
+      </NotesProvider>
+    );
+
+    await waitFor(() => expect(latestContext?.notes).toHaveLength(1));
+    const original = docs.get(source._id);
+
+    latestContext?.updateNote(source._id, { title: 'Changed' });
+    latestContext?.moveNote(source._id, 'some-folder');
+    latestContext?.deleteNote(source._id);
+
+    expect(docs.get(source._id)).toEqual(original);
+    expect(() =>
+      latestContext?.addNote({
+        title: 'New memory',
+        folder: 'room:agent-memory',
+      })
+    ).toThrow('This room is read only');
+    expect(docs.getUndeleted()).toHaveLength(1);
   });
 });

--- a/packages/ewe-note/src/app/contexts/NotesContext.tsx
+++ b/packages/ewe-note/src/app/contexts/NotesContext.tsx
@@ -5,6 +5,7 @@ import { useDb } from '@/db';
 import { useFolders } from '@/notes-room';
 import { collectFolderTreeIds } from './folder-tree';
 import { writeBrowserLocalVaultNotes } from '../lib/browser-local-vault';
+import { canWriteRoom } from '../lib/room-write-access';
 import {
   buildDefaultUntitledNoteTitle,
   getFirstHeading,
@@ -361,6 +362,7 @@ function extractUnlinkedMentionsForNote(
 
 export function NotesProvider({ children }: { children: React.ReactNode }) {
   const {
+    db,
     allRooms,
     selectedRoom,
     selectedNoteId,
@@ -566,6 +568,8 @@ export function NotesProvider({ children }: { children: React.ReactNode }) {
     return null;
   };
 
+  const roomIsWritable = (room: Room<DbNote>) => canWriteRoom(room, db.userId);
+
   const adaptNote = (room: Room<DbNote>, source: DbNote): Note => {
     const note = notes.find((item) => item.id === source._id);
     if (note) return note;
@@ -615,6 +619,9 @@ export function NotesProvider({ children }: { children: React.ReactNode }) {
     if (!targetRoom) {
       throw new Error('No available room to create a note');
     }
+    if (!roomIsWritable(targetRoom as Room<DbNote>)) {
+      throw new Error('This room is read only');
+    }
 
     const requestedTitle = note.title?.trim();
     const resolvedTitle =
@@ -649,6 +656,7 @@ export function NotesProvider({ children }: { children: React.ReactNode }) {
   const updateNote = (id: string, updates: Partial<Note>) => {
     const found = getRoomAndSource(id);
     if (!found) return;
+    if (!roomIsWritable(found.room)) return;
 
     const next: DbNote = { ...found.source };
     let nextFrontmatter = { ...(found.source.frontmatter ?? {}) };
@@ -711,6 +719,7 @@ export function NotesProvider({ children }: { children: React.ReactNode }) {
   const deleteNote = (id: string) => {
     const found = getRoomAndSource(id);
     if (!found) return;
+    if (!roomIsWritable(found.room)) return;
     found.docs.delete(id);
   };
 
@@ -726,6 +735,7 @@ export function NotesProvider({ children }: { children: React.ReactNode }) {
   const moveNote = (noteId: string, targetFolder: string) => {
     const found = getRoomAndSource(noteId);
     if (!found) return;
+    if (!roomIsWritable(found.room)) return;
 
     if (targetFolder.startsWith('room:')) {
       return;

--- a/packages/ewe-note/src/app/lib/room-write-access.test.ts
+++ b/packages/ewe-note/src/app/lib/room-write-access.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { canWriteRoom } from './room-write-access';
+
+describe('canWriteRoom', () => {
+  it('keeps unsynced local rooms writable', () => {
+    expect(
+      canWriteRoom(
+        { syncUrl: null, writeAccess: [], adminAccess: [] },
+        undefined
+      )
+    ).toBe(true);
+  });
+
+  it('allows remote writers and admins', () => {
+    const room = {
+      syncUrl: 'wss://sync.example.test',
+      writeAccess: ['writer'],
+      adminAccess: ['admin'],
+    };
+    expect(canWriteRoom(room, 'writer')).toBe(true);
+    expect(canWriteRoom(room, 'admin')).toBe(true);
+  });
+
+  it('fails closed for remote readers and unresolved identities', () => {
+    const room = {
+      syncUrl: 'wss://sync.example.test',
+      writeAccess: ['writer'],
+      adminAccess: [],
+    };
+    expect(canWriteRoom(room, 'reader')).toBe(false);
+    expect(canWriteRoom(room, undefined)).toBe(false);
+  });
+});

--- a/packages/ewe-note/src/app/lib/room-write-access.ts
+++ b/packages/ewe-note/src/app/lib/room-write-access.ts
@@ -1,0 +1,10 @@
+import type { Note, Room } from '@eweser/db';
+
+export function canWriteRoom(
+  room: Pick<Room<Note>, 'syncUrl' | 'writeAccess' | 'adminAccess'>,
+  userId: string | null | undefined
+) {
+  if (!room.syncUrl) return true;
+  if (!userId) return false;
+  return room.writeAccess.includes(userId) || room.adminAccess.includes(userId);
+}

--- a/packages/ewe-note/src/app/pages/EnhancedEditor.tsx
+++ b/packages/ewe-note/src/app/pages/EnhancedEditor.tsx
@@ -37,6 +37,7 @@ import {
 } from '../components/WorkspaceShell';
 import type { Note } from '../contexts/NotesContext';
 import { useIsMobile } from '../components/ui/use-mobile';
+import { canWriteRoom } from '../lib/room-write-access';
 
 export function buildEditorWikiLinkPath(
   noteId: string,
@@ -115,6 +116,8 @@ export function EnhancedEditor() {
       return;
     }
 
+    if (noteRoom && !canWriteRoom(noteRoom, db.userId)) return;
+
     const created = addNote({
       title: parsed.noteName,
       folder: note?.folder,
@@ -122,7 +125,7 @@ export function EnhancedEditor() {
     });
     navigate(buildEditorWikiLinkPath(created.id, parsed));
   };
-  const { allRooms, selectedRoom, setSelectedRoom, setSelectedNoteId } =
+  const { allRooms, db, selectedRoom, setSelectedRoom, setSelectedNoteId } =
     useDb();
 
   const note = notes.find((n) => n.id === noteId);
@@ -178,6 +181,7 @@ export function EnhancedEditor() {
   }
 
   const editorRoom = noteRoom ?? selectedRoom;
+  const readOnly = editorRoom ? !canWriteRoom(editorRoom, db.userId) : false;
   if (focusMode) {
     return (
       <div className="flex h-screen flex-col bg-background">
@@ -201,6 +205,7 @@ export function EnhancedEditor() {
               <Editor
                 selectedRoom={editorRoom}
                 selectedNoteId={note.id}
+                readOnly={readOnly}
                 showFrontmatterEditor={false}
                 sourceMode={sourceMode}
                 onSourceModeChange={setSourceMode}
@@ -215,7 +220,9 @@ export function EnhancedEditor() {
   return (
     <WorkspaceShell
       selectedNoteId={note.id}
-      metadataSlot={<EditorMetadataPanel noteId={note.id} />}
+      metadataSlot={
+        <EditorMetadataPanel noteId={note.id} readOnly={readOnly} />
+      }
     >
       <EditorWorkspace
         note={note}
@@ -238,15 +245,26 @@ export function EnhancedEditor() {
         onNavigateWikiLink={handleNavigateWikiLink}
         sourceMode={sourceMode}
         onSourceModeChange={setSourceMode}
+        readOnly={readOnly}
       />
     </WorkspaceShell>
   );
 }
 
-function EditorMetadataPanel({ noteId }: { noteId: string }) {
+function EditorMetadataPanel({
+  noteId,
+  readOnly,
+}: {
+  noteId: string;
+  readOnly: boolean;
+}) {
   const { setMetadataVisible } = useWorkspaceShell();
   return (
-    <RightPanel noteId={noteId} onClose={() => setMetadataVisible(false)} />
+    <RightPanel
+      noteId={noteId}
+      onClose={() => setMetadataVisible(false)}
+      readOnly={readOnly}
+    />
   );
 }
 
@@ -266,6 +284,7 @@ function EditorWorkspace({
   onNavigateWikiLink,
   sourceMode,
   onSourceModeChange,
+  readOnly,
 }: {
   note: Note;
   onUpdateTitle: (title: string) => void;
@@ -282,6 +301,7 @@ function EditorWorkspace({
   onNavigateWikiLink: (href: string) => void;
   sourceMode: boolean;
   onSourceModeChange: (sourceMode: boolean) => void;
+  readOnly: boolean;
 }) {
   const { metadataVisible, setMetadataVisible } = useWorkspaceShell();
   const isMobile = useIsMobile();
@@ -303,6 +323,7 @@ function EditorWorkspace({
           aria-label="Note title"
           value={note.title}
           onChange={(e) => onUpdateTitle(e.target.value)}
+          readOnly={readOnly}
           className="sr-only"
           tabIndex={-1}
         />
@@ -345,16 +366,18 @@ function EditorWorkspace({
               )}
             </button>
           )}
-          <button
-            type="button"
-            aria-label="Enter focus mode"
-            data-cy="ewe-note-focus-mode"
-            onClick={onFocusMode}
-            className="rounded-full p-2 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-            title="Focus Mode"
-          >
-            <Maximize2 className="w-4 h-4" />
-          </button>
+          {!readOnly ? (
+            <button
+              type="button"
+              aria-label="Enter focus mode"
+              data-cy="ewe-note-focus-mode"
+              onClick={onFocusMode}
+              className="rounded-full p-2 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              title="Focus Mode"
+            >
+              <Maximize2 className="w-4 h-4" />
+            </button>
+          ) : null}
           {!isMobile ? (
             <button
               type="button"
@@ -392,14 +415,18 @@ function EditorWorkspace({
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              <DropdownMenuItem onClick={() => onSourceModeChange(!sourceMode)}>
-                {sourceMode ? (
-                  <Eye className="mr-2 h-4 w-4" />
-                ) : (
-                  <FileCode className="mr-2 h-4 w-4" />
-                )}
-                {sourceMode ? 'Return to rich editor' : 'Edit raw Markdown'}
-              </DropdownMenuItem>
+              {!readOnly ? (
+                <DropdownMenuItem
+                  onClick={() => onSourceModeChange(!sourceMode)}
+                >
+                  {sourceMode ? (
+                    <Eye className="mr-2 h-4 w-4" />
+                  ) : (
+                    <FileCode className="mr-2 h-4 w-4" />
+                  )}
+                  {sourceMode ? 'Return to rich editor' : 'Edit raw Markdown'}
+                </DropdownMenuItem>
+              ) : null}
               <DropdownMenuSeparator />
               <DropdownMenuItem
                 data-cy="ewe-note-copy-link"
@@ -418,45 +445,51 @@ function EditorWorkspace({
                     ? 'Copy failed'
                     : 'Copy Link'}
               </DropdownMenuItem>
-              <DropdownMenuItem
-                data-cy="ewe-note-duplicate"
-                onClick={onDuplicate}
-              >
-                <Copy className="mr-2 h-4 w-4" />
-                Duplicate
-              </DropdownMenuItem>
+              {!readOnly ? (
+                <DropdownMenuItem
+                  data-cy="ewe-note-duplicate"
+                  onClick={onDuplicate}
+                >
+                  <Copy className="mr-2 h-4 w-4" />
+                  Duplicate
+                </DropdownMenuItem>
+              ) : null}
               <DropdownMenuItem data-cy="ewe-note-export" onClick={onExport}>
                 <Download className="mr-2 h-4 w-4" />
                 Export as Markdown
               </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuLabel>Move to folder</DropdownMenuLabel>
-              <DropdownMenuItem
-                data-cy="ewe-note-move-note-all"
-                disabled={!note.folder}
-                onClick={() => onMoveNote('')}
-              >
-                <FolderInput className="mr-2 h-4 w-4" />
-                All Notes
-              </DropdownMenuItem>
-              {moveTargets.slice(0, 8).map((folder) => (
-                <DropdownMenuItem
-                  key={folder.id}
-                  data-cy={`ewe-note-move-note-${folder.id}`}
-                  onClick={() => onMoveNote(folder.id)}
-                >
-                  <FolderOpen className="mr-2 h-4 w-4" />
-                  {folder.name}
-                </DropdownMenuItem>
-              ))}
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                data-cy="ewe-note-delete-note"
-                className="text-destructive"
-                onClick={onDelete}
-              >
-                Delete Note
-              </DropdownMenuItem>
+              {!readOnly ? (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuLabel>Move to folder</DropdownMenuLabel>
+                  <DropdownMenuItem
+                    data-cy="ewe-note-move-note-all"
+                    disabled={!note.folder}
+                    onClick={() => onMoveNote('')}
+                  >
+                    <FolderInput className="mr-2 h-4 w-4" />
+                    All Notes
+                  </DropdownMenuItem>
+                  {moveTargets.slice(0, 8).map((folder) => (
+                    <DropdownMenuItem
+                      key={folder.id}
+                      data-cy={`ewe-note-move-note-${folder.id}`}
+                      onClick={() => onMoveNote(folder.id)}
+                    >
+                      <FolderOpen className="mr-2 h-4 w-4" />
+                      {folder.name}
+                    </DropdownMenuItem>
+                  ))}
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    data-cy="ewe-note-delete-note"
+                    className="text-destructive"
+                    onClick={onDelete}
+                  >
+                    Delete Note
+                  </DropdownMenuItem>
+                </>
+              ) : null}
             </DropdownMenuContent>
           </DropdownMenu>
         </div>
@@ -468,6 +501,7 @@ function EditorWorkspace({
             <Editor
               selectedRoom={editorRoom}
               selectedNoteId={note.id}
+              readOnly={readOnly}
               showFrontmatterEditor={false}
               onNavigateWikiLink={onNavigateWikiLink}
               sourceMode={sourceMode}

--- a/packages/ewe-note/src/components/editor.tsx
+++ b/packages/ewe-note/src/components/editor.tsx
@@ -46,6 +46,7 @@ export default function Editor({
   onEditorReady,
   onEditorFocusChange,
   onNavigateWikiLink,
+  readOnly = false,
   sourceMode,
   onSourceModeChange,
 }: {
@@ -55,6 +56,7 @@ export default function Editor({
   onEditorReady?: (editor: TiptapEditorInstance | null) => void;
   onEditorFocusChange?: (focused: boolean) => void;
   onNavigateWikiLink?: (href: string) => void;
+  readOnly?: boolean;
   sourceMode?: boolean;
   onSourceModeChange?: (sourceMode: boolean) => void;
 }) {
@@ -89,6 +91,7 @@ export default function Editor({
       onEditorReady={onEditorReady}
       onEditorFocusChange={onEditorFocusChange}
       onNavigateWikiLink={onNavigateWikiLink}
+      readOnly={readOnly}
       sourceMode={sourceMode}
       onSourceModeChange={onSourceModeChange}
     />
@@ -107,6 +110,7 @@ function EditorInternal({
   onEditorReady,
   onEditorFocusChange,
   onNavigateWikiLink,
+  readOnly,
   sourceMode,
   onSourceModeChange,
 }: {
@@ -124,6 +128,7 @@ function EditorInternal({
   onEditorReady?: (editor: TiptapEditorInstance | null) => void;
   onEditorFocusChange?: (focused: boolean) => void;
   onNavigateWikiLink?: (href: string) => void;
+  readOnly: boolean;
   sourceMode?: boolean;
   onSourceModeChange?: (sourceMode: boolean) => void;
 }) {
@@ -147,6 +152,7 @@ function EditorInternal({
           <FrontmatterEditor
             note={note}
             onUpdate={(fm) => updateNoteFrontmatter(fm, note)}
+            readOnly={readOnly}
           />
         )}
         <TiptapEditor
@@ -160,6 +166,7 @@ function EditorInternal({
           onEditorReady={onEditorReady}
           onEditorFocusChange={onEditorFocusChange}
           onNavigateWikiLink={onNavigateWikiLink}
+          readOnly={readOnly}
           sourceMode={sourceMode}
           onSourceModeChange={onSourceModeChange}
           attachmentContext={attachmentContext}

--- a/packages/ewe-note/src/components/frontmatter-editor.tsx
+++ b/packages/ewe-note/src/components/frontmatter-editor.tsx
@@ -11,6 +11,7 @@ import type { Note } from '@eweser/db';
 interface FrontmatterEditorProps {
   note: Note;
   onUpdate: (frontmatter: Record<string, unknown>) => void;
+  readOnly?: boolean;
 }
 
 type FieldType = 'text' | 'number' | 'boolean' | 'date' | 'list';
@@ -49,6 +50,7 @@ function parseInputValue(raw: string, type: FieldType): unknown {
 export default function FrontmatterEditor({
   note,
   onUpdate,
+  readOnly = false,
 }: FrontmatterEditorProps) {
   const frontmatter = note.frontmatter ?? {};
   const [expanded, setExpanded] = useState(false);
@@ -101,7 +103,11 @@ export default function FrontmatterEditor({
                 <span className="text-xs font-mono text-muted-foreground w-32 shrink-0 truncate">
                   {key}
                 </span>
-                {type === 'boolean' ? (
+                {readOnly ? (
+                  <span className="flex-1 text-sm text-foreground">
+                    {renderValue(value)}
+                  </span>
+                ) : type === 'boolean' ? (
                   <input
                     type="checkbox"
                     checked={Boolean(value)}
@@ -125,51 +131,57 @@ export default function FrontmatterEditor({
                     className="flex-1 text-sm border border-input rounded px-2 py-1 bg-background"
                   />
                 )}
-                <button
-                  onClick={() => handleDelete(key)}
-                  className="text-muted-foreground hover:text-destructive text-xs shrink-0"
-                  title={`Delete ${key}`}
-                >
-                  ✕
-                </button>
+                {!readOnly ? (
+                  <button
+                    onClick={() => handleDelete(key)}
+                    className="text-muted-foreground hover:text-destructive text-xs shrink-0"
+                    title={`Delete ${key}`}
+                  >
+                    ✕
+                  </button>
+                ) : null}
               </div>
             );
           })}
-          <div className="grid gap-2 rounded-lg border border-border/70 bg-background/60 p-3 md:grid-cols-[minmax(0,1fr)_8rem_minmax(0,1fr)_auto]">
-            <input
-              aria-label="New property name"
-              value={newKey}
-              onChange={(event) => setNewKey(event.target.value)}
-              placeholder="Property"
-              className="min-w-0 rounded border border-input bg-background px-2 py-1 text-sm"
-            />
-            <select
-              aria-label="New property type"
-              value={newType}
-              onChange={(event) => setNewType(event.target.value as FieldType)}
-              className="rounded border border-input bg-background px-2 py-1 text-sm"
-            >
-              <option value="text">Text</option>
-              <option value="number">Number</option>
-              <option value="boolean">Boolean</option>
-              <option value="date">Date</option>
-              <option value="list">List</option>
-            </select>
-            <input
-              aria-label="New property value"
-              value={newValue}
-              onChange={(event) => setNewValue(event.target.value)}
-              placeholder={newType === 'list' ? 'item1, item2' : 'Value'}
-              className="min-w-0 rounded border border-input bg-background px-2 py-1 text-sm"
-            />
-            <button
-              type="button"
-              onClick={handleAddField}
-              className="rounded border border-border px-3 py-1 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-            >
-              Add
-            </button>
-          </div>
+          {!readOnly ? (
+            <div className="grid gap-2 rounded-lg border border-border/70 bg-background/60 p-3 md:grid-cols-[minmax(0,1fr)_8rem_minmax(0,1fr)_auto]">
+              <input
+                aria-label="New property name"
+                value={newKey}
+                onChange={(event) => setNewKey(event.target.value)}
+                placeholder="Property"
+                className="min-w-0 rounded border border-input bg-background px-2 py-1 text-sm"
+              />
+              <select
+                aria-label="New property type"
+                value={newType}
+                onChange={(event) =>
+                  setNewType(event.target.value as FieldType)
+                }
+                className="rounded border border-input bg-background px-2 py-1 text-sm"
+              >
+                <option value="text">Text</option>
+                <option value="number">Number</option>
+                <option value="boolean">Boolean</option>
+                <option value="date">Date</option>
+                <option value="list">List</option>
+              </select>
+              <input
+                aria-label="New property value"
+                value={newValue}
+                onChange={(event) => setNewValue(event.target.value)}
+                placeholder={newType === 'list' ? 'item1, item2' : 'Value'}
+                className="min-w-0 rounded border border-input bg-background px-2 py-1 text-sm"
+              />
+              <button
+                type="button"
+                onClick={handleAddField}
+                className="rounded border border-border px-3 py-1 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              >
+                Add
+              </button>
+            </div>
+          ) : null}
         </div>
       )}
     </div>

--- a/packages/ewe-note/src/components/tiptap-editor.tsx
+++ b/packages/ewe-note/src/components/tiptap-editor.tsx
@@ -74,6 +74,7 @@ interface TiptapEditorProps {
   onNavigateWikiLink?: (href: string) => void;
   onEditorReady?: (editor: Editor | null) => void;
   onEditorFocusChange?: (focused: boolean) => void;
+  readOnly?: boolean;
   sourceMode?: boolean;
   onSourceModeChange?: (sourceMode: boolean) => void;
   attachmentContext?: AttachmentResolverContext;
@@ -275,6 +276,7 @@ export function TiptapEditor({
   onNavigateWikiLink,
   onEditorReady,
   onEditorFocusChange,
+  readOnly = false,
   sourceMode = false,
   onSourceModeChange,
   attachmentContext,
@@ -325,6 +327,7 @@ export function TiptapEditor({
   const editor = useEditor(
     {
       extensions,
+      editable: !readOnly,
       content: provider ? undefined : initialHtml,
       editorProps: {
         attributes: {
@@ -360,7 +363,7 @@ export function TiptapEditor({
         onEditorReady?.(editor);
       },
       onUpdate({ editor }) {
-        if (suppressEditorSaveRef.current || sourceMode) {
+        if (readOnly || suppressEditorSaveRef.current || sourceMode) {
           return;
         }
 
@@ -388,8 +391,15 @@ export function TiptapEditor({
         onEditorFocusChange?.(false);
       },
     },
-    [selectedNoteId, doc, provider?.awareness]
+    [selectedNoteId, doc, provider?.awareness, readOnly]
   );
+
+  useEffect(() => {
+    editor?.setEditable(!readOnly);
+    if (readOnly && sourceMode) {
+      onSourceModeChange?.(false);
+    }
+  }, [editor, onSourceModeChange, readOnly, sourceMode]);
 
   useEffect(() => {
     const activeEditor = editor;
@@ -416,7 +426,7 @@ export function TiptapEditor({
 
   const closeSlashMenu = useCallback(() => setSlashMenuState(null), []);
   const toggleSourceMode = useCallback(() => {
-    if (!onSourceModeChange) return;
+    if (readOnly || !onSourceModeChange) return;
 
     if (!sourceMode && editor) {
       const markdown = editorJsonToMarkdown(editor.getJSON() as JSONContent);
@@ -428,7 +438,7 @@ export function TiptapEditor({
     }
 
     onSourceModeChange(false);
-  }, [editor, onSaveMarkdown, onSourceModeChange, sourceMode]);
+  }, [editor, onSaveMarkdown, onSourceModeChange, readOnly, sourceMode]);
 
   const requestLink = useCallback(
     ({ kind, href }: { kind: 'link' | 'external-link'; href?: string }) => {
@@ -489,10 +499,14 @@ export function TiptapEditor({
     [editor, closeSlashMenu, commandContext, slashMenuState]
   );
 
-  const saveSourceMarkdown = useCallback((nextValue: string) => {
-    setSourceValue(nextValue);
-    debouncedSaveRef.current?.(nextValue, noteRef.current);
-  }, []);
+  const saveSourceMarkdown = useCallback(
+    (nextValue: string) => {
+      if (readOnly) return;
+      setSourceValue(nextValue);
+      debouncedSaveRef.current?.(nextValue, noteRef.current);
+    },
+    [readOnly]
+  );
 
   const exitSourceMode = useCallback(() => {
     debouncedSaveRef.current?.flush();
@@ -556,18 +570,30 @@ export function TiptapEditor({
 
   return (
     <div className="tiptap-editor">
-      <EditorToolbar
-        editor={editor}
-        onSave={() => saveEditor(editor, noteRef.current, onSaveMarkdown)}
-        focused={focused}
-        commandContext={commandContext}
-      />
-      {sourceMode ? (
+      {readOnly ? (
+        <div
+          className="mb-4 inline-flex rounded-full border border-border bg-muted/60 px-3 py-1 text-xs font-medium text-muted-foreground"
+          data-cy="ewe-note-read-only-badge"
+          role="status"
+        >
+          Read only
+        </div>
+      ) : (
+        <EditorToolbar
+          editor={editor}
+          onSave={() => saveEditor(editor, noteRef.current, onSaveMarkdown)}
+          focused={focused}
+          commandContext={commandContext}
+        />
+      )}
+      {!readOnly && sourceMode ? (
         <SourceModeEditor
           value={sourceValue}
           onChange={saveSourceMarkdown}
           onExit={exitSourceMode}
         />
+      ) : readOnly ? (
+        <EditorContent editor={editor} className="editor-view" />
       ) : (
         <EditorBubbleMenu editor={editor} commandContext={commandContext}>
           <EditorContextMenu editor={editor} commandContext={commandContext}>
@@ -575,12 +601,17 @@ export function TiptapEditor({
           </EditorContextMenu>
         </EditorBubbleMenu>
       )}
-      <EditorSlashMenu
-        commandsOpenState={slashMenuState}
-        onSelect={executeSlashCommand}
-        onClose={closeSlashMenu}
-      />
-      <Dialog open={linkDialog.open} onOpenChange={closeLinkDialog}>
+      {!readOnly ? (
+        <EditorSlashMenu
+          commandsOpenState={slashMenuState}
+          onSelect={executeSlashCommand}
+          onClose={closeSlashMenu}
+        />
+      ) : null}
+      <Dialog
+        open={!readOnly && linkDialog.open}
+        onOpenChange={closeLinkDialog}
+      >
         <DialogContent className="max-w-md">
           <DialogHeader>
             <DialogTitle>

--- a/packages/sync-server/src/index.ts
+++ b/packages/sync-server/src/index.ts
@@ -7,10 +7,10 @@
 import { Server } from '@hocuspocus/server';
 import type { Extension } from '@hocuspocus/server';
 import { SQLite } from '@hocuspocus/extension-sqlite';
-import jwt from 'jsonwebtoken';
 import { createLogger, initTelemetry } from '@eweser/logger';
 import { createAggregatorWebhookExtension } from './aggregator-webhook.js';
 import { getCapabilitiesResponse } from './capabilities.js';
+import { authenticateSyncConnection } from './sync-auth.js';
 
 await initTelemetry('sync-server');
 
@@ -60,31 +60,8 @@ const server = Server.configure({
       return;
     }
   },
-  async onAuthenticate({ token }) {
-    if (!token) {
-      throw new Error('Authentication required');
-    }
-
-    try {
-      const decoded = jwt.verify(token, secret) as {
-        roomId: string;
-        userId?: string;
-        collectionKey?: string;
-        publicAccess?: 'private' | 'read' | 'write';
-      };
-      return {
-        user: {
-          id: decoded.userId || 'anonymous',
-          name: decoded.userId || 'anonymous',
-        },
-        roomId: decoded.roomId,
-        userId: decoded.userId,
-        collectionKey: decoded.collectionKey,
-        publicAccess: decoded.publicAccess ?? 'private',
-      };
-    } catch {
-      throw new Error('Invalid token');
-    }
+  async onAuthenticate({ connection, token }) {
+    return authenticateSyncConnection({ connection, secret, token });
   },
 });
 

--- a/packages/sync-server/src/sync-auth.test.ts
+++ b/packages/sync-server/src/sync-auth.test.ts
@@ -1,0 +1,60 @@
+import jwt from 'jsonwebtoken';
+import { describe, expect, it } from 'vitest';
+import { authenticateSyncConnection } from './sync-auth.js';
+
+const secret = 'test-secret';
+
+function token(claims: Record<string, unknown>) {
+  return jwt.sign(claims, secret);
+}
+
+describe('authenticateSyncConnection', () => {
+  it('marks a read-only token connection as read only', () => {
+    const connection = { readOnly: false };
+    const context = authenticateSyncConnection({
+      connection,
+      secret,
+      token: token({
+        roomId: 'room-memory',
+        userId: 'reader-1',
+        collectionKey: 'notes',
+        readOnly: true,
+      }),
+    });
+
+    expect(connection.readOnly).toBe(true);
+    expect(context).toMatchObject({
+      roomId: 'room-memory',
+      userId: 'reader-1',
+      collectionKey: 'notes',
+    });
+  });
+
+  it('keeps a writer token connection writable', () => {
+    const connection = { readOnly: true };
+    authenticateSyncConnection({
+      connection,
+      secret,
+      token: token({ roomId: 'room-memory', userId: 'writer-1' }),
+    });
+
+    expect(connection.readOnly).toBe(false);
+  });
+
+  it('rejects missing or invalid tokens', () => {
+    expect(() =>
+      authenticateSyncConnection({
+        connection: { readOnly: false },
+        secret,
+        token: undefined,
+      })
+    ).toThrow('Authentication required');
+    expect(() =>
+      authenticateSyncConnection({
+        connection: { readOnly: false },
+        secret,
+        token: 'not-a-jwt',
+      })
+    ).toThrow('Invalid token');
+  });
+});

--- a/packages/sync-server/src/sync-auth.ts
+++ b/packages/sync-server/src/sync-auth.ts
@@ -1,0 +1,47 @@
+import jwt from 'jsonwebtoken';
+
+export type SyncConnectionConfiguration = {
+  readOnly: boolean;
+};
+
+export type SyncTokenClaims = {
+  roomId: string;
+  userId?: string;
+  collectionKey?: string;
+  publicAccess?: 'private' | 'read' | 'write';
+  readOnly?: boolean;
+};
+
+export function authenticateSyncConnection({
+  connection,
+  secret,
+  token,
+}: {
+  connection: SyncConnectionConfiguration;
+  secret: string;
+  token: string | null | undefined;
+}) {
+  if (!token) {
+    throw new Error('Authentication required');
+  }
+
+  let decoded: SyncTokenClaims;
+  try {
+    decoded = jwt.verify(token, secret) as SyncTokenClaims;
+  } catch {
+    throw new Error('Invalid token');
+  }
+
+  connection.readOnly = decoded.readOnly === true;
+
+  return {
+    user: {
+      id: decoded.userId || 'anonymous',
+      name: decoded.userId || 'anonymous',
+    },
+    roomId: decoded.roomId,
+    userId: decoded.userId,
+    collectionKey: decoded.collectionKey,
+    publicAccess: decoded.publicAccess ?? 'private',
+  };
+}


### PR DESCRIPTION
## What changed

- include explicit read grants when resolving access-grant room registries
- issue read-only sync JWTs and enforce them on Hocuspocus connections
- fail closed on Ewe Note note mutations and hide editor, metadata, move, duplicate, and delete controls for room readers
- redact access-grant values from browser diagnostics
- add focused authorization, relay, context, UI, and logging regression tests

## Why

Room ACLs represented read access, but registry selection and sync authentication previously treated room access as writable. A reader therefore could not safely receive a room as a truly read-only Ewe Note vault. Browser diagnostics also logged access-grant token values.

## Impact

Writers and admins retain existing behavior. Explicit room readers can browse and export notes but cannot edit or rename the room. Users without a read-only room grant are unaffected; the existing Agent Workspace setting remains off by default.

## Validation

- 559 tests passed across auth-server-hono, sync-server, db, and ewe-note
- all four changed workspaces passed lint and type-check
- auth-server-hono, sync-server, db dependencies, and ewe-note production builds passed
- code-index check passed
- staged and tracked secret scans passed