### PR TITLE
fix(ewe-note): hide read-only mutation controls

### DIFF
--- a/packages/ewe-note/src/app/components/EnhancedSidebar.test.tsx
+++ b/packages/ewe-note/src/app/components/EnhancedSidebar.test.tsx
@@ -19,6 +19,12 @@ const deleteFolder = vi.fn();
 const addNote = vi.fn(() => ({ id: 'note-created' }));
 const moveNote = vi.fn();
 const deleteVault = vi.fn().mockResolvedValue(undefined);
+const readerRoom = {
+  id: 'secure-room',
+  syncUrl: 'wss://sync.example.test',
+  writeAccess: ['writer-user'],
+  adminAccess: [],
+};
 let vaultDeletionEligibility:
   | { canDelete: true; noteCount: 0 }
   | {
@@ -144,7 +150,8 @@ vi.mock('../../db', () => ({
     syncStatusDescription: 'Stored on this device',
     user: { firstName: 'Guest' },
     selectedRoom: null,
-    allRooms: [],
+    allRooms: [readerRoom],
+    db: { userId: 'reader-user' },
     createSecureRoom: vi.fn(),
     lockCurrentRoom: vi.fn(),
     unlockCurrentRoom: vi.fn(),
@@ -380,6 +387,18 @@ describe('EnhancedSidebar', () => {
     });
     expect(item.getAttribute('data-disabled')).not.toBeNull();
     expect(deleteVault).not.toHaveBeenCalled();
+  });
+
+  it('hides note creation for a reader-only vault', () => {
+    render(<EnhancedSidebar onSearchClick={vi.fn()} activeView="recent" />);
+
+    fireEvent.pointerDown(
+      screen.getByRole('button', {
+        name: 'Vault actions for 🔒 Secure Notes',
+      })
+    );
+
+    expect(screen.queryByRole('menuitem', { name: 'New note' })).toBeNull();
   });
 
   it('exposes a pinned notes filter in the rail', () => {

--- a/packages/ewe-note/src/app/components/EnhancedSidebar.tsx
+++ b/packages/ewe-note/src/app/components/EnhancedSidebar.tsx
@@ -47,6 +47,7 @@ import {
 import { Button } from './ui/button';
 import { Input } from './ui/input';
 import { getSyncStatusDotClass } from './sync-status-visual';
+import { canWriteRoom } from '../lib/room-write-access';
 import { DndProvider, useDrag, useDrop } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import {
@@ -748,7 +749,13 @@ function FolderItem({
   onDelete,
   onDeleteVault,
 }: FolderItemProps) {
-  const { getVaultDeletionEligibility } = useDb();
+  const { allRooms, db, getVaultDeletionEligibility } = useDb();
+  const room = folder.roomId
+    ? allRooms.find((candidate) => candidate.id === folder.roomId)
+    : null;
+  const canCreateNote =
+    folder.kind !== 'shared-room' ||
+    (room ? canWriteRoom(room, db.userId) : false);
   const vaultDeletion = folder.roomId
     ? getVaultDeletionEligibility(folder.roomId)
     : undefined;
@@ -835,10 +842,12 @@ function FolderItem({
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          <DropdownMenuItem onClick={onNewNote}>
-            <Plus className="mr-2 h-4 w-4" />
-            New note
-          </DropdownMenuItem>
+          {canCreateNote ? (
+            <DropdownMenuItem onClick={onNewNote}>
+              <Plus className="mr-2 h-4 w-4" />
+              New note
+            </DropdownMenuItem>
+          ) : null}
           {folder.kind === 'folder' ? (
             <DropdownMenuItem onClick={onNewSubfolder}>
               <FolderOpen className="mr-2 h-4 w-4" />

--- a/packages/ewe-note/src/app/pages/EnhancedEditor.read-only-controls.test.tsx
+++ b/packages/ewe-note/src/app/pages/EnhancedEditor.read-only-controls.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { EditorWorkspace } from './EnhancedEditor';
+
+vi.mock('@/db', () => ({
+  useDb: () => ({ selectedRoom: null }),
+}));
+
+vi.mock('../contexts/NotesContext', () => ({
+  useNotes: () => ({}),
+}));
+
+vi.mock('../components/WorkspaceShell', () => ({
+  WorkspaceShell: ({ children }: { children: React.ReactNode }) => children,
+  useWorkspaceShell: () => ({
+    metadataVisible: false,
+    setMetadataVisible: vi.fn(),
+  }),
+}));
+
+vi.mock('../components/ui/use-mobile', () => ({
+  useIsMobile: () => false,
+}));
+
+vi.mock('@/components/editor', () => ({
+  default: () => <div>Editor</div>,
+}));
+
+const note = {
+  id: 'note-reader',
+  roomId: 'room-reader',
+  title: 'Reader note',
+  content: '# Reader note',
+  folder: 'room:room-reader',
+  tags: [],
+  properties: {},
+  aliases: [],
+  createdAt: '2026-08-10T00:00:00.000Z',
+  updatedAt: '2026-08-10T00:00:00.000Z',
+  pinned: false,
+  links: [],
+  outgoingLinks: [],
+  backlinks: [],
+  unlinkedMentions: [],
+};
+
+const callbacks = {
+  onUpdateTitle: vi.fn(),
+  onCopyLink: vi.fn(),
+  copyLinkState: 'idle' as const,
+  onDuplicate: vi.fn(),
+  onExport: vi.fn(),
+  onDelete: vi.fn(),
+  folders: [],
+  onMoveNote: vi.fn(),
+  onTogglePin: vi.fn(),
+  onFocusMode: vi.fn(),
+  editorRoom: null,
+  onNavigateWikiLink: vi.fn(),
+  sourceMode: false,
+  onSourceModeChange: vi.fn(),
+};
+
+describe('EditorWorkspace read-only controls', () => {
+  afterEach(cleanup);
+
+  it('hides mutation controls while keeping read-only actions available', () => {
+    render(<EditorWorkspace {...callbacks} note={note} readOnly />);
+
+    expect(screen.queryByRole('button', { name: 'Pin note' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Delete note' })).toBeNull();
+    expect(
+      screen.queryByRole('button', { name: 'Enter focus mode' })
+    ).toBeNull();
+    expect(
+      screen.getByRole('button', { name: 'Open note info' })
+    ).not.toBeNull();
+    expect(
+      screen.getByRole('button', { name: 'Open note actions' })
+    ).not.toBeNull();
+  });
+
+  it('keeps mutation controls for a writable note', () => {
+    render(<EditorWorkspace {...callbacks} note={note} readOnly={false} />);
+
+    expect(screen.getByRole('button', { name: 'Pin note' })).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'Delete note' })).not.toBeNull();
+    expect(
+      screen.getByRole('button', { name: 'Enter focus mode' })
+    ).not.toBeNull();
+  });
+});

--- a/packages/ewe-note/src/app/pages/EnhancedEditor.tsx
+++ b/packages/ewe-note/src/app/pages/EnhancedEditor.tsx
@@ -268,7 +268,7 @@ function EditorMetadataPanel({
   );
 }
 
-function EditorWorkspace({
+export function EditorWorkspace({
   note,
   onUpdateTitle,
   onCopyLink,
@@ -334,7 +334,7 @@ function EditorWorkspace({
               : ''
           }`}
         >
-          {isMobile ? (
+          {isMobile && !readOnly ? (
             <button
               type="button"
               aria-label={note.pinned ? 'Unpin note' : 'Pin note'}
@@ -378,7 +378,7 @@ function EditorWorkspace({
               <Maximize2 className="w-4 h-4" />
             </button>
           ) : null}
-          {!isMobile ? (
+          {!isMobile && !readOnly ? (
             <button
               type="button"
               aria-label={note.pinned ? 'Unpin note' : 'Pin note'}
@@ -393,16 +393,18 @@ function EditorWorkspace({
               />
             </button>
           ) : null}
-          <button
-            type="button"
-            aria-label="Delete note"
-            data-cy="ewe-note-delete-note-button"
-            onClick={onDelete}
-            className="rounded-full p-2 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            title="Delete note"
-          >
-            <Trash2 className="w-4 h-4" />
-          </button>
+          {!readOnly ? (
+            <button
+              type="button"
+              aria-label="Delete note"
+              data-cy="ewe-note-delete-note-button"
+              onClick={onDelete}
+              className="rounded-full p-2 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              title="Delete note"
+            >
+              <Trash2 className="w-4 h-4" />
+            </button>
+          ) : null}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <button


### PR DESCRIPTION
## Summary
- hide pin, focus, and delete actions for reader-only notes
- hide note creation from reader-only vault menus
- add focused regression coverage for read-only and writable controls

## Verification
- `npm test --workspace @eweser/ewe-note` (210 passing)
- `npm run type-check --workspace @eweser/ewe-note`
- `npm run lint --workspace @eweser/ewe-note`
- `npm run build --workspace @eweser/ewe-note`
