### PR TITLE
fix(ewe-note): focus agent workspace

### DIFF
--- a/packages/ewe-note/src/app/components/EnhancedCommandPalette.test.tsx
+++ b/packages/ewe-note/src/app/components/EnhancedCommandPalette.test.tsx
@@ -56,6 +56,7 @@ describe('EnhancedCommandPalette', () => {
     mockUseNotes.mockReturnValue({
       folders: [],
       addNote: vi.fn(() => ({ id: 'note-created' })),
+      canCreateNote: true,
       searchNotes: vi.fn(() => []),
       getRecentNotes: vi.fn(() => [
         {
@@ -110,6 +111,7 @@ describe('EnhancedCommandPalette', () => {
     mockUseNotes.mockReturnValue({
       folders: [],
       addNote: vi.fn(() => ({ id: 'note-created' })),
+      canCreateNote: true,
       searchNotes: vi.fn(() => [importedNote]),
       getRecentNotes: vi.fn(() => []),
     });

--- a/packages/ewe-note/src/app/components/EnhancedCommandPalette.tsx
+++ b/packages/ewe-note/src/app/components/EnhancedCommandPalette.tsx
@@ -34,7 +34,8 @@ export function EnhancedCommandPalette({
     commandContext?: EditorCommandContext;
   } | null>(null);
   const navigate = useNavigate();
-  const { folders, addNote, searchNotes, getRecentNotes } = useNotes();
+  const { folders, addNote, canCreateNote, searchNotes, getRecentNotes } =
+    useNotes();
 
   const handleNewNote = useCallback(
     (customTitle?: string) => {
@@ -57,7 +58,7 @@ export function EnhancedCommandPalette({
         e.preventDefault();
         onOpenChange(!open);
       }
-      if (e.key === 'n' && (e.metaKey || e.ctrlKey) && !open) {
+      if (canCreateNote && e.key === 'n' && (e.metaKey || e.ctrlKey) && !open) {
         e.preventDefault();
         handleNewNote();
       }
@@ -65,7 +66,7 @@ export function EnhancedCommandPalette({
 
     document.addEventListener('keydown', down);
     return () => document.removeEventListener('keydown', down);
-  }, [open, onOpenChange, handleNewNote]);
+  }, [canCreateNote, open, onOpenChange, handleNewNote]);
 
   useEffect(() => {
     if (open) {
@@ -259,7 +260,7 @@ export function EnhancedCommandPalette({
                   )}
 
                 {/* Create new note - show after matches so search retrieval wins by default */}
-                {search && (
+                {search && canCreateNote && (
                   <Command.Group className="mt-3">
                     <Command.Item
                       value={`create-note:${normalizedSearch}`}
@@ -289,21 +290,23 @@ export function EnhancedCommandPalette({
                       heading="Quick Actions"
                       className="mb-4 [&_[cmdk-group-heading]]:px-3 [&_[cmdk-group-heading]]:py-2 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wider"
                     >
-                      <Command.Item
-                        value="action:new-note"
-                        onSelect={handleNewNote}
-                        className="flex items-center gap-3 px-3 py-2.5 rounded-lg cursor-pointer hover:bg-accent/70 data-[selected=true]:bg-accent transition-colors"
-                      >
-                        <Plus className="w-4 h-4 text-primary" />
-                        <div className="flex-1">
-                          <div className="text-[15px] font-medium">
-                            New Note
+                      {canCreateNote ? (
+                        <Command.Item
+                          value="action:new-note"
+                          onSelect={handleNewNote}
+                          className="flex items-center gap-3 px-3 py-2.5 rounded-lg cursor-pointer hover:bg-accent/70 data-[selected=true]:bg-accent transition-colors"
+                        >
+                          <Plus className="w-4 h-4 text-primary" />
+                          <div className="flex-1">
+                            <div className="text-[15px] font-medium">
+                              New Note
+                            </div>
                           </div>
-                        </div>
-                        <kbd className="hidden sm:inline-flex h-5 select-none items-center gap-1 rounded border border-border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
-                          ⌘N
-                        </kbd>
-                      </Command.Item>
+                          <kbd className="hidden sm:inline-flex h-5 select-none items-center gap-1 rounded border border-border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
+                            ⌘N
+                          </kbd>
+                        </Command.Item>
+                      ) : null}
                       <Command.Item
                         data-cy="ewe-note-browse-templates"
                         value="action:browse-templates"

--- a/packages/ewe-note/src/app/components/EnhancedSidebar.test.tsx
+++ b/packages/ewe-note/src/app/components/EnhancedSidebar.test.tsx
@@ -98,6 +98,8 @@ vi.mock('react-router', () => ({
 vi.mock('../contexts/NotesContext', () => ({
   useNotes: () => ({
     currentNoteId: null,
+    agentWorkspaceEnabled: false,
+    canCreateNote: true,
     folders: [
       {
         id: 'root-folder',

--- a/packages/ewe-note/src/app/components/EnhancedSidebar.tsx
+++ b/packages/ewe-note/src/app/components/EnhancedSidebar.tsx
@@ -105,6 +105,8 @@ function SidebarContent({
     folders,
     tasks,
     currentNoteId,
+    agentWorkspaceEnabled,
+    canCreateNote,
     addNote,
     addFolder,
     updateFolder,
@@ -289,7 +291,11 @@ function SidebarContent({
       className="relative flex h-full w-full shrink-0 flex-col border-r border-sidebar-border bg-sidebar-background text-sidebar-foreground md:h-screen"
       style={desktopWidth ? { width: `${desktopWidth}px` } : undefined}
     >
-      <div className="hidden grid-cols-7 gap-1 border-b border-sidebar-border px-2 py-2 md:grid">
+      <div
+        className={`hidden gap-1 border-b border-sidebar-border px-2 py-2 md:grid ${
+          agentWorkspaceEnabled ? 'grid-cols-5' : 'grid-cols-7'
+        }`}
+      >
         <IconRailButton
           icon={Search}
           label="Search notes"
@@ -326,28 +332,34 @@ function SidebarContent({
           badge={incompleteTasks.length}
           onClick={() => onViewChange?.('tasks')}
         />
-        <IconRailButton
-          icon={Plus}
-          label="New note"
-          onClick={() => handleNewNoteInFolder('')}
-        />
-        <IconRailButton
-          dataCy="ewe-note-new-folder-trigger"
-          icon={FolderOpen}
-          label={activeFolderId ? 'New subfolder' : 'New folder'}
-          onClick={() =>
-            setFolderDialog({
-              mode: 'create',
-              initialName: '',
-              parentId: activeFolderId,
-            })
-          }
-        />
+        {canCreateNote ? (
+          <IconRailButton
+            icon={Plus}
+            label="New note"
+            onClick={() => handleNewNoteInFolder('')}
+          />
+        ) : null}
+        {!agentWorkspaceEnabled ? (
+          <IconRailButton
+            dataCy="ewe-note-new-folder-trigger"
+            icon={FolderOpen}
+            label={activeFolderId ? 'New subfolder' : 'New folder'}
+            onClick={() =>
+              setFolderDialog({
+                mode: 'create',
+                initialName: '',
+                parentId: activeFolderId,
+              })
+            }
+          />
+        ) : null}
       </div>
 
       <div
         data-cy="ewe-note-sidebar-mobile-toolbar"
-        className="grid grid-cols-4 gap-1 border-b border-sidebar-border px-2 py-2 md:hidden"
+        className={`grid gap-1 border-b border-sidebar-border px-2 py-2 md:hidden ${
+          agentWorkspaceEnabled ? 'grid-cols-2' : 'grid-cols-4'
+        }`}
       >
         <IconRailButton
           dataCy="ewe-note-pinned-link-mobile"
@@ -364,23 +376,27 @@ function SidebarContent({
           badge={incompleteTasks.length}
           onClick={() => onViewChange?.('tasks')}
         />
-        <IconRailButton
-          icon={Plus}
-          label="New note"
-          onClick={() => handleNewNoteInFolder('')}
-        />
-        <IconRailButton
-          dataCy="ewe-note-new-folder-trigger-mobile"
-          icon={FolderOpen}
-          label={activeFolderId ? 'New subfolder' : 'New folder'}
-          onClick={() =>
-            setFolderDialog({
-              mode: 'create',
-              initialName: '',
-              parentId: activeFolderId,
-            })
-          }
-        />
+        {canCreateNote ? (
+          <IconRailButton
+            icon={Plus}
+            label="New note"
+            onClick={() => handleNewNoteInFolder('')}
+          />
+        ) : null}
+        {!agentWorkspaceEnabled ? (
+          <IconRailButton
+            dataCy="ewe-note-new-folder-trigger-mobile"
+            icon={FolderOpen}
+            label={activeFolderId ? 'New subfolder' : 'New folder'}
+            onClick={() =>
+              setFolderDialog({
+                mode: 'create',
+                initialName: '',
+                parentId: activeFolderId,
+              })
+            }
+          />
+        ) : null}
       </div>
 
       <nav

--- a/packages/ewe-note/src/app/components/NotesListPane.test.tsx
+++ b/packages/ewe-note/src/app/components/NotesListPane.test.tsx
@@ -13,6 +13,8 @@ vi.mock('react-router', () => ({
 
 vi.mock('../contexts/NotesContext', () => ({
   useNotes: () => ({
+    agentWorkspaceEnabled: false,
+    canCreateNote: true,
     notes: [
       {
         id: 'note-1',

--- a/packages/ewe-note/src/app/components/NotesListPane.tsx
+++ b/packages/ewe-note/src/app/components/NotesListPane.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router';
 import { FileText, Hash, Plus, Star, CheckSquare, X } from 'lucide-react';
 import { useNotes } from '../contexts/NotesContext';
@@ -22,11 +23,21 @@ export function NotesListPane({
     notes,
     folders,
     tasks,
+    agentWorkspaceEnabled,
+    canCreateNote,
     addNote,
     getPinnedNotes,
     getRecentNotes,
     getNotesInFolder,
   } = useNotes();
+
+  useEffect(() => {
+    if (!agentWorkspaceEnabled || !activeView.startsWith('folder:')) return;
+    const folderId = activeView.replace('folder:', '');
+    if (!folders.some((folder) => folder.id === folderId)) {
+      onViewChange('recent');
+    }
+  }, [activeView, agentWorkspaceEnabled, folders, onViewChange]);
 
   const handleNewNote = () => {
     const created = addNote({ title: 'Untitled', content: '' });
@@ -76,18 +87,20 @@ export function NotesListPane({
         </div>
       ) : null}
 
-      <div className="flex items-center justify-end px-3 py-3">
-        <button
-          type="button"
-          data-cy="ewe-note-new-note"
-          onClick={handleNewNote}
-          className="inline-flex h-9 w-9 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-          title="New note"
-          aria-label="New note"
-        >
-          <Plus className="h-4 w-4" />
-        </button>
-      </div>
+      {canCreateNote ? (
+        <div className="flex items-center justify-end px-3 py-3">
+          <button
+            type="button"
+            data-cy="ewe-note-new-note"
+            onClick={handleNewNote}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            title="New note"
+            aria-label="New note"
+          >
+            <Plus className="h-4 w-4" />
+          </button>
+        </div>
+      ) : null}
 
       <div className="min-h-0 flex-1 overflow-y-auto px-2 pb-3">
         {activeView === 'tasks' && incompleteTasks.length === 0 ? (

--- a/packages/ewe-note/src/app/components/agent-workspace-settings.test.tsx
+++ b/packages/ewe-note/src/app/components/agent-workspace-settings.test.tsx
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  AGENT_WORKSPACE_ENABLED_STORAGE_KEY,
+  isAgentWorkspaceRoom,
+  useAgentWorkspacePreferences,
+} from './agent-workspace-settings';
+
+describe('Agent Workspace settings', () => {
+  beforeEach(() => window.localStorage.clear());
+
+  it('recognizes only the portable agent room names', () => {
+    expect(isAgentWorkspaceRoom({ name: 'Agent Memory' })).toBe(true);
+    expect(isAgentWorkspaceRoom({ name: 'Agent Control' })).toBe(true);
+    expect(isAgentWorkspaceRoom({ name: 'Obsidian Sync Smoke Notes' })).toBe(
+      false
+    );
+  });
+
+  it('updates every mounted consumer when the browser-local mod changes', () => {
+    const first = renderHook(() => useAgentWorkspacePreferences());
+    const second = renderHook(() => useAgentWorkspacePreferences());
+
+    act(() => first.result.current.setEnabled(true));
+
+    expect(first.result.current.preferences.enabled).toBe(true);
+    expect(second.result.current.preferences.enabled).toBe(true);
+    expect(
+      window.localStorage.getItem(AGENT_WORKSPACE_ENABLED_STORAGE_KEY)
+    ).toBe('true');
+  });
+});

--- a/packages/ewe-note/src/app/components/agent-workspace-settings.ts
+++ b/packages/ewe-note/src/app/components/agent-workspace-settings.ts
@@ -2,6 +2,12 @@ import { useEffect, useState } from 'react';
 
 export const AGENT_WORKSPACE_ENABLED_STORAGE_KEY =
   'ewe-note-mod-agent-workspace-enabled';
+export const AGENT_WORKSPACE_PREFERENCES_CHANGED_EVENT =
+  'ewe-note-agent-workspace-preferences-changed';
+export const AGENT_WORKSPACE_ROOM_NAMES = [
+  'Agent Control',
+  'Agent Memory',
+] as const;
 
 export type AgentWorkspacePreferences = {
   enabled: boolean;
@@ -10,6 +16,12 @@ export type AgentWorkspacePreferences = {
 export const DEFAULT_AGENT_WORKSPACE_PREFERENCES: AgentWorkspacePreferences = {
   enabled: false,
 };
+
+export function isAgentWorkspaceRoom(room: { name: string }) {
+  return AGENT_WORKSPACE_ROOM_NAMES.includes(
+    room.name as (typeof AGENT_WORKSPACE_ROOM_NAMES)[number]
+  );
+}
 
 export function readAgentWorkspacePreferences(): AgentWorkspacePreferences {
   if (typeof window === 'undefined') {
@@ -29,16 +41,29 @@ export function useAgentWorkspacePreferences() {
   );
 
   useEffect(() => {
-    window.localStorage.setItem(
-      AGENT_WORKSPACE_ENABLED_STORAGE_KEY,
-      String(preferences.enabled)
-    );
-  }, [preferences.enabled]);
+    const refresh = () => setPreferences(readAgentWorkspacePreferences());
+    window.addEventListener('storage', refresh);
+    window.addEventListener(AGENT_WORKSPACE_PREFERENCES_CHANGED_EVENT, refresh);
+    return () => {
+      window.removeEventListener('storage', refresh);
+      window.removeEventListener(
+        AGENT_WORKSPACE_PREFERENCES_CHANGED_EVENT,
+        refresh
+      );
+    };
+  }, []);
 
   return {
     preferences,
     setEnabled: (enabled: boolean) => {
+      window.localStorage.setItem(
+        AGENT_WORKSPACE_ENABLED_STORAGE_KEY,
+        String(enabled)
+      );
       setPreferences({ enabled });
+      window.dispatchEvent(
+        new Event(AGENT_WORKSPACE_PREFERENCES_CHANGED_EVENT)
+      );
     },
   };
 }

--- a/packages/ewe-note/src/app/contexts/NotesContext.test.tsx
+++ b/packages/ewe-note/src/app/contexts/NotesContext.test.tsx
@@ -8,6 +8,7 @@ import {
   readFeatureVaultFixture,
 } from '../../editor/obsidian-feature-fixtures';
 import { NotesProvider, useNotes, type Template } from './NotesContext';
+import { AGENT_WORKSPACE_ENABLED_STORAGE_KEY } from '../components/agent-workspace-settings';
 
 type DocumentsLike = {
   toArray: (notes: DbNote[]) => DbNote[];
@@ -311,6 +312,58 @@ describe('NotesContext parity behavior', () => {
         },
       ])
     );
+  });
+
+  it('limits the enabled Agent Workspace mod to agent rooms', async () => {
+    const [fixture] = await loadFixtureNotes(['01 Markdown Syntax.md']);
+    const regularRoom = createRoom(
+      'room-notes',
+      'Notes',
+      new FakeDocuments([
+        { ...fixture, _id: 'regular-note' } as unknown as DbNote,
+      ])
+    );
+    const memoryRoom = createRoom(
+      'room-memory',
+      'Agent Memory',
+      new FakeDocuments([
+        {
+          ...fixture,
+          _id: 'journal-note',
+          text: '# Agent journal\n\nSummary',
+          frontmatter: { title: 'Agent journal' },
+        } as unknown as DbNote,
+      ])
+    );
+
+    dbState = createDbState(regularRoom);
+    dbState.allRooms = [regularRoom, memoryRoom];
+    dbState.allRoomIds = ['room-notes', 'room-memory'];
+    mockUseDb.mockImplementation(() => dbState);
+    mockUseFolders.mockReturnValue({
+      folders: folderFixtures,
+      createFolder: vi.fn(),
+      renameFolder: vi.fn(),
+      deleteFolder: vi.fn(),
+    });
+    window.localStorage.setItem(AGENT_WORKSPACE_ENABLED_STORAGE_KEY, 'true');
+
+    render(
+      <NotesProvider>
+        <Probe />
+      </NotesProvider>
+    );
+
+    await waitFor(() => {
+      expect(latestContext?.notes.map((note) => note.id)).toEqual([
+        'journal-note',
+      ]);
+    });
+    expect(latestContext?.folders.map((folder) => folder.name)).toEqual([
+      'Agent Memory',
+    ]);
+    expect(latestContext?.agentWorkspaceEnabled).toBe(true);
+    expect(latestContext?.canCreateNote).toBe(false);
   });
 
   it('synchronizes an automatic title with first-heading edits', async () => {

--- a/packages/ewe-note/src/app/contexts/NotesContext.tsx
+++ b/packages/ewe-note/src/app/contexts/NotesContext.tsx
@@ -7,6 +7,10 @@ import { collectFolderTreeIds } from './folder-tree';
 import { writeBrowserLocalVaultNotes } from '../lib/browser-local-vault';
 import { canWriteRoom } from '../lib/room-write-access';
 import {
+  isAgentWorkspaceRoom,
+  useAgentWorkspacePreferences,
+} from '../components/agent-workspace-settings';
+import {
   buildDefaultUntitledNoteTitle,
   getFirstHeading,
   getSyncedTitle,
@@ -99,6 +103,8 @@ interface NotesContextType {
   getRecentNotes: (limit?: number) => Note[];
   getPinnedNotes: () => Note[];
   resolveWikiLink: (target: string) => string | null;
+  agentWorkspaceEnabled: boolean;
+  canCreateNote: boolean;
   convertUnlinkedMentionToLink: (
     noteId: string,
     targetNoteId: string,
@@ -369,8 +375,21 @@ export function NotesProvider({ children }: { children: React.ReactNode }) {
     setSelectedNoteId,
     setSelectedRoom,
   } = useDb();
+  const { preferences: agentWorkspacePreferences } =
+    useAgentWorkspacePreferences();
+  const agentWorkspaceEnabled = agentWorkspacePreferences.enabled;
   const canonicalRoom =
     allRooms.find((room) => room.name === 'Notes') ?? allRooms[0] ?? null;
+  const agentControlRoom =
+    allRooms.find((room) => room.name === 'Agent Control') ?? null;
+  const visibleRooms = useMemo(
+    () =>
+      agentWorkspaceEnabled ? allRooms.filter(isAgentWorkspaceRoom) : allRooms,
+    [agentWorkspaceEnabled, allRooms]
+  );
+  const canCreateNote = agentWorkspaceEnabled
+    ? Boolean(agentControlRoom && canWriteRoom(agentControlRoom, db.userId))
+    : Boolean(canonicalRoom && canWriteRoom(canonicalRoom, db.userId));
   const {
     folders: roomFolders,
     createFolder,
@@ -441,17 +460,23 @@ export function NotesProvider({ children }: { children: React.ReactNode }) {
   }, [allRooms]);
 
   const folders = useMemo<Folder[]>(() => {
-    const baseFolders = roomFolders.map((folder) => ({
-      id: folder.id,
-      name: folder.name,
-      parentId: folder.parentFolderId ?? null,
-      expanded: true,
-      kind: 'folder' as const,
-      roomId: canonicalRoom?.id,
-    }));
+    const baseFolders = agentWorkspaceEnabled
+      ? []
+      : roomFolders.map((folder) => ({
+          id: folder.id,
+          name: folder.name,
+          parentId: folder.parentFolderId ?? null,
+          expanded: true,
+          kind: 'folder' as const,
+          roomId: canonicalRoom?.id,
+        }));
 
-    const sharedRoomFolders = allRooms
-      .filter((room) => canonicalRoom && room.id !== canonicalRoom.id)
+    const sharedRoomFolders = visibleRooms
+      .filter(
+        (room) =>
+          agentWorkspaceEnabled ||
+          (canonicalRoom && room.id !== canonicalRoom.id)
+      )
       .map((room) => ({
         id: `room:${room.id}`,
         name: room.name,
@@ -462,14 +487,14 @@ export function NotesProvider({ children }: { children: React.ReactNode }) {
       }));
 
     return [...baseFolders, ...sharedRoomFolders];
-  }, [allRooms, canonicalRoom, roomFolders]);
+  }, [agentWorkspaceEnabled, canonicalRoom, roomFolders, visibleRooms]);
 
   const notes = useMemo<Note[]>(() => {
     const internal: InternalNote[] = [];
 
     const noteById = new Map<string, InternalNote>();
 
-    for (const room of allRooms) {
+    for (const room of visibleRooms) {
       const docs = notesByRoomId[room.id] ?? [];
       for (const source of docs) {
         const title = deriveTitle(source);
@@ -546,7 +571,7 @@ export function NotesProvider({ children }: { children: React.ReactNode }) {
         (a, b) =>
           new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
       );
-  }, [allRooms, canonicalRoom, notesByRoomId, pinnedIds]);
+  }, [canonicalRoom, notesByRoomId, pinnedIds, visibleRooms]);
 
   const tasks = useMemo(() => {
     const extracted = notes.flatMap((note) =>
@@ -611,7 +636,9 @@ export function NotesProvider({ children }: { children: React.ReactNode }) {
     const targetRoom =
       (note.folder?.startsWith('room:')
         ? allRooms.find((room) => room.id === note.folder?.replace('room:', ''))
-        : canonicalRoom) ??
+        : agentWorkspaceEnabled
+          ? agentControlRoom
+          : canonicalRoom) ??
       selectedRoom ??
       canonicalRoom ??
       allRooms[0];
@@ -941,6 +968,8 @@ export function NotesProvider({ children }: { children: React.ReactNode }) {
     getRecentNotes,
     getPinnedNotes,
     resolveWikiLink,
+    agentWorkspaceEnabled,
+    canCreateNote,
     convertUnlinkedMentionToLink,
   };
 

--- a/packages/ewe-note/src/app/pages/EnhancedEditor.tsx
+++ b/packages/ewe-note/src/app/pages/EnhancedEditor.tsx
@@ -39,6 +39,20 @@ import type { Note } from '../contexts/NotesContext';
 import { useIsMobile } from '../components/ui/use-mobile';
 import { canWriteRoom } from '../lib/room-write-access';
 
+export const REMOTE_NOTE_HYDRATION_GRACE_MS = 10_000;
+
+export function shouldWaitForRemoteNote({
+  hasToken,
+  noteFound,
+  waitExpired,
+}: {
+  hasToken: boolean;
+  noteFound: boolean;
+  waitExpired: boolean;
+}) {
+  return hasToken && !noteFound && !waitExpired;
+}
+
 export function buildEditorWikiLinkPath(
   noteId: string,
   parsed: WikiLinkResolution
@@ -60,6 +74,7 @@ export function EnhancedEditor() {
     'idle' | 'copied' | 'failed'
   >('idle');
   const [sourceMode, setSourceMode] = useState(false);
+  const [missingNoteWaitExpired, setMissingNoteWaitExpired] = useState(false);
   const navigate = useNavigate();
   const { noteId } = useParams();
   const {
@@ -125,14 +140,30 @@ export function EnhancedEditor() {
     });
     navigate(buildEditorWikiLinkPath(created.id, parsed));
   };
-  const { allRooms, db, selectedRoom, setSelectedRoom, setSelectedNoteId } =
-    useDb();
+  const {
+    allRooms,
+    db,
+    hasToken,
+    selectedRoom,
+    setSelectedRoom,
+    setSelectedNoteId,
+  } = useDb();
 
   const note = notes.find((n) => n.id === noteId);
   const noteRoom = useMemo(
     () => allRooms.find((room) => room.id === note?.roomId) ?? null,
     [allRooms, note?.roomId]
   );
+
+  useEffect(() => {
+    setMissingNoteWaitExpired(false);
+    if (note || !hasToken) return;
+    const timeout = window.setTimeout(
+      () => setMissingNoteWaitExpired(true),
+      REMOTE_NOTE_HYDRATION_GRACE_MS
+    );
+    return () => window.clearTimeout(timeout);
+  }, [hasToken, note, noteId]);
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
@@ -163,6 +194,25 @@ export function EnhancedEditor() {
     }
     setSelectedNoteId(note.id);
   }, [note, noteRoom, selectedRoom?.id, setSelectedNoteId, setSelectedRoom]);
+
+  if (
+    shouldWaitForRemoteNote({
+      hasToken,
+      noteFound: Boolean(note),
+      waitExpired: missingNoteWaitExpired,
+    })
+  ) {
+    return (
+      <div className="flex h-screen items-center justify-center bg-background text-foreground">
+        <div className="text-center" role="status">
+          <h2 className="text-2xl font-medium mb-2">Opening note…</h2>
+          <p className="text-muted-foreground">
+            Waiting for the synced vault to finish loading.
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   if (!note) {
     return (

--- a/packages/ewe-note/src/app/pages/EnhancedEditor.wiki-navigation.test.ts
+++ b/packages/ewe-note/src/app/pages/EnhancedEditor.wiki-navigation.test.ts
@@ -24,9 +24,28 @@ vi.mock('@/db', () => ({
   }),
 }));
 
-import { buildEditorWikiLinkPath } from './EnhancedEditor';
+import {
+  buildEditorWikiLinkPath,
+  shouldWaitForRemoteNote,
+} from './EnhancedEditor';
 
 describe('EnhancedEditor wiki navigation helpers', () => {
+  it('keeps a missing synced note in hydration state during the grace period', () => {
+    expect(
+      shouldWaitForRemoteNote({
+        hasToken: true,
+        noteFound: false,
+        waitExpired: false,
+      })
+    ).toBe(true);
+    expect(
+      shouldWaitForRemoteNote({
+        hasToken: true,
+        noteFound: false,
+        waitExpired: true,
+      })
+    ).toBe(false);
+  });
   it('preserves heading targets as editor URL hashes', () => {
     expect(
       buildEditorWikiLinkPath('note-target', {

--- a/packages/ewe-note/src/app/pages/EnhancedHome.tsx
+++ b/packages/ewe-note/src/app/pages/EnhancedHome.tsx
@@ -5,7 +5,7 @@ import { useNotes } from '../contexts/NotesContext';
 
 export function EnhancedHome() {
   const navigate = useNavigate();
-  const { addNote } = useNotes();
+  const { addNote, canCreateNote } = useNotes();
 
   const handleNewNote = () => {
     const created = addNote({ title: 'Untitled', content: '' });
@@ -15,16 +15,18 @@ export function EnhancedHome() {
   return (
     <WorkspaceShell>
       <main className="relative h-full min-w-0 overflow-hidden bg-background md:h-screen">
-        <button
-          type="button"
-          data-cy="ewe-note-new-note"
-          onClick={handleNewNote}
-          className="absolute right-4 top-4 flex h-10 w-10 items-center justify-center rounded-full border border-border/70 bg-card/90 text-foreground shadow-lg shadow-black/10 transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          aria-label="New note"
-          title="New note"
-        >
-          <Plus className="h-4 w-4" />
-        </button>
+        {canCreateNote ? (
+          <button
+            type="button"
+            data-cy="ewe-note-new-note"
+            onClick={handleNewNote}
+            className="absolute right-4 top-4 flex h-10 w-10 items-center justify-center rounded-full border border-border/70 bg-card/90 text-foreground shadow-lg shadow-black/10 transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            aria-label="New note"
+            title="New note"
+          >
+            <Plus className="h-4 w-4" />
+          </button>
+        ) : null}
       </main>
     </WorkspaceShell>
   );

--- a/packages/ewe-note/src/app/routes.test.tsx
+++ b/packages/ewe-note/src/app/routes.test.tsx
@@ -11,6 +11,7 @@ const addNote = vi.hoisted(() => vi.fn(() => ({ id: 'created-note' })));
 vi.mock('./contexts/NotesContext', () => ({
   useNotes: () => ({
     addNote,
+    canCreateNote: true,
   }),
 }));
 


### PR DESCRIPTION
## Summary
- make the default-off Agent Workspace mod filter the workspace to Agent Memory and Agent Control rooms
- suppress note/folder creation when the focused workspace has no writable Agent Control room
- replace transient direct-link false negatives with a bounded remote-hydration state
- clear stale folder filters when focused rooms hide an old vault

## Safety
- no rooms or notes are deleted
- mod remains browser-local and off by default
- users who do not enable the mod retain the existing workspace

## Verification
- `npm test --workspace @eweser/ewe-note` (214 passing)
- `npm run type-check --workspace @eweser/ewe-note`
- `npm run lint --workspace @eweser/ewe-note`
- `npm run build --workspace @eweser/ewe-note`
