### PR TITLE
fix(ewe-note): sync Agent Workspace setting across browsers

### DIFF
--- a/packages/ewe-note/src/app/INDEX.md
+++ b/packages/ewe-note/src/app/INDEX.md
@@ -36,9 +36,10 @@ including page routes, note context, and product-specific app components.
   existing room hooks.
 - User-visible workflow changes should keep Cypress selectors stable or update
   E2E coverage in the same change.
-- `components/agent-workspace-settings.ts` owns the browser-local, off-by-default
-  Agent Workspace mod preference. It must not contain bridge credentials,
-  personal paths, or automatic network behavior.
+- `components/agent-workspace-settings.ts` owns the off-by-default Agent
+  Workspace mod preference, using a browser cache plus the signed-in private
+  profile for cross-browser sync. It must not contain bridge credentials,
+  personal paths, or external runtime commands.
 
 ## Update Triggers
 

--- a/packages/ewe-note/src/app/components/agent-workspace-settings.test.tsx
+++ b/packages/ewe-note/src/app/components/agent-workspace-settings.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
-import { act, renderHook } from '@testing-library/react';
-import { beforeEach, describe, expect, it } from 'vitest';
+import type { Database } from '@eweser/db';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   AGENT_WORKSPACE_ENABLED_STORAGE_KEY,
   isAgentWorkspaceRoom,
@@ -18,7 +19,7 @@ describe('Agent Workspace settings', () => {
     );
   });
 
-  it('updates every mounted consumer when the browser-local mod changes', () => {
+  it('updates every mounted consumer when the browser cache changes', () => {
     const first = renderHook(() => useAgentWorkspacePreferences());
     const second = renderHook(() => useAgentWorkspacePreferences());
 
@@ -29,5 +30,92 @@ describe('Agent Workspace settings', () => {
     expect(
       window.localStorage.getItem(AGENT_WORKSPACE_ENABLED_STORAGE_KEY)
     ).toBe('true');
+  });
+
+  it('uses the private account preference in a fresh browser', async () => {
+    const profile = {
+      _id: 'default',
+      _created: 1,
+      _updated: 1,
+      eweNote: { agentWorkspaceEnabled: true },
+    };
+    const observers = new Set<() => void>();
+    const documents = {
+      get: vi.fn(() => profile),
+      set: vi.fn(),
+      new: vi.fn(),
+      onChange: vi.fn((observer: () => void) => observers.add(observer)),
+      documents: {
+        unobserve: vi.fn((observer: () => void) => observers.delete(observer)),
+      },
+    };
+    const room = {
+      name: 'Private Profile',
+      publicAccess: 'private',
+      ydoc: {},
+      syncProvider: { isSynced: true, on: vi.fn(), off: vi.fn() },
+      getDocuments: () => documents,
+    };
+    const database = {
+      getRooms: vi.fn(() => [room]),
+      on: vi.fn(),
+      off: vi.fn(),
+    } as unknown as Database;
+
+    const hook = renderHook(() => useAgentWorkspacePreferences(database));
+
+    await waitFor(() => {
+      expect(hook.result.current.accountBacked).toBe(true);
+      expect(hook.result.current.preferences.enabled).toBe(true);
+    });
+    expect(
+      window.localStorage.getItem(AGENT_WORKSPACE_ENABLED_STORAGE_KEY)
+    ).toBe('true');
+    expect(documents.set).not.toHaveBeenCalled();
+    expect(documents.new).not.toHaveBeenCalled();
+  });
+
+  it('migrates an explicit browser choice without writing a fresh default', async () => {
+    const profile = { _id: 'default', _created: 1, _updated: 1 };
+    const documents = {
+      get: vi.fn(() => profile),
+      set: vi.fn(),
+      new: vi.fn(),
+      onChange: vi.fn(),
+      documents: { unobserve: vi.fn() },
+    };
+    const room = {
+      name: 'Private Profile',
+      publicAccess: 'private',
+      ydoc: {},
+      syncProvider: { isSynced: true, on: vi.fn(), off: vi.fn() },
+      getDocuments: () => documents,
+    };
+    const database = {
+      getRooms: vi.fn(() => [room]),
+      on: vi.fn(),
+      off: vi.fn(),
+    } as unknown as Database;
+
+    const freshBrowser = renderHook(() =>
+      useAgentWorkspacePreferences(database)
+    );
+    await waitFor(() =>
+      expect(freshBrowser.result.current.accountBacked).toBe(true)
+    );
+    expect(documents.set).not.toHaveBeenCalled();
+    freshBrowser.unmount();
+
+    window.localStorage.setItem(AGENT_WORKSPACE_ENABLED_STORAGE_KEY, 'true');
+    const browserWithChoice = renderHook(() =>
+      useAgentWorkspacePreferences(database)
+    );
+    await waitFor(() => expect(documents.set).toHaveBeenCalledTimes(1));
+    expect(documents.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eweNote: { agentWorkspaceEnabled: true },
+      })
+    );
+    browserWithChoice.unmount();
   });
 });

--- a/packages/ewe-note/src/app/components/agent-workspace-settings.ts
+++ b/packages/ewe-note/src/app/components/agent-workspace-settings.ts
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react';
+import type { Database, GetDocuments, Profile, Room } from '@eweser/db';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 export const AGENT_WORKSPACE_ENABLED_STORAGE_KEY =
   'ewe-note-mod-agent-workspace-enabled';
@@ -11,6 +12,12 @@ export const AGENT_WORKSPACE_ROOM_NAMES = [
 
 export type AgentWorkspacePreferences = {
   enabled: boolean;
+};
+
+type AgentWorkspaceProfile = Profile & {
+  eweNote?: {
+    agentWorkspaceEnabled?: boolean;
+  };
 };
 
 export const DEFAULT_AGENT_WORKSPACE_PREFERENCES: AgentWorkspacePreferences = {
@@ -35,10 +42,71 @@ export function readAgentWorkspacePreferences(): AgentWorkspacePreferences {
   };
 }
 
-export function useAgentWorkspacePreferences() {
+function readLocalEnabledChoice() {
+  if (typeof window === 'undefined') return null;
+  const value = window.localStorage.getItem(
+    AGENT_WORKSPACE_ENABLED_STORAGE_KEY
+  );
+  return value === null ? null : value === 'true';
+}
+
+function cacheEnabledChoice(enabled: boolean) {
+  window.localStorage.setItem(
+    AGENT_WORKSPACE_ENABLED_STORAGE_KEY,
+    String(enabled)
+  );
+  window.dispatchEvent(new Event(AGENT_WORKSPACE_PREFERENCES_CHANGED_EVENT));
+}
+
+function readAccountEnabledChoice(
+  documents: GetDocuments<AgentWorkspaceProfile>
+) {
+  const enabled = documents.get('default')?.eweNote?.agentWorkspaceEnabled;
+  return typeof enabled === 'boolean' ? enabled : null;
+}
+
+function writeAccountEnabledChoice(
+  documents: GetDocuments<AgentWorkspaceProfile>,
+  enabled: boolean
+) {
+  const current = documents.get('default');
+  const eweNote = {
+    ...current?.eweNote,
+    agentWorkspaceEnabled: enabled,
+  };
+
+  if (current) {
+    documents.set({ ...current, eweNote });
+    return;
+  }
+
+  documents.new({ eweNote }, 'default');
+}
+
+function getPrivateProfileRoom(database: Database) {
+  if (typeof database.getRooms !== 'function') return null;
+  const rooms = database.getRooms('profiles') as unknown as Array<
+    Room<AgentWorkspaceProfile>
+  >;
+  return (
+    rooms.find((room) => room.name === 'Private Profile') ??
+    rooms.find((room) => room.publicAccess !== 'read') ??
+    null
+  );
+}
+
+export function useAgentWorkspacePreferences(database?: Database) {
   const [preferences, setPreferences] = useState<AgentWorkspacePreferences>(
     readAgentWorkspacePreferences
   );
+  const [accountBacked, setAccountBacked] = useState(false);
+  const accountDocumentsRef =
+    useRef<GetDocuments<AgentWorkspaceProfile> | null>(null);
+
+  const applyEnabledChoice = useCallback((enabled: boolean) => {
+    cacheEnabledChoice(enabled);
+    setPreferences({ enabled });
+  }, []);
 
   useEffect(() => {
     const refresh = () => setPreferences(readAgentWorkspacePreferences());
@@ -53,17 +121,94 @@ export function useAgentWorkspacePreferences() {
     };
   }, []);
 
+  useEffect(() => {
+    if (
+      !database ||
+      typeof database.getRooms !== 'function' ||
+      typeof database.on !== 'function'
+    ) {
+      return;
+    }
+
+    let observedDocuments: GetDocuments<AgentWorkspaceProfile> | null = null;
+    let observedRoom: Room<AgentWorkspaceProfile> | null = null;
+    let accountReadyForMigration = false;
+
+    const handleProfileSynced = ({ state }: { state: boolean }) => {
+      if (!state) return;
+      accountReadyForMigration = true;
+      setAccountBacked(true);
+      syncFromAccount();
+    };
+
+    const detachDocuments = () => {
+      if (observedDocuments) {
+        observedDocuments.documents.unobserve(syncFromAccount);
+      }
+      observedRoom?.syncProvider?.off('synced', handleProfileSynced);
+      observedDocuments = null;
+      observedRoom = null;
+      accountReadyForMigration = false;
+      accountDocumentsRef.current = null;
+      setAccountBacked(false);
+    };
+
+    const syncFromAccount = () => {
+      if (!observedDocuments) return;
+      const accountEnabled = readAccountEnabledChoice(observedDocuments);
+      if (accountEnabled !== null) {
+        setAccountBacked(true);
+        applyEnabledChoice(accountEnabled);
+        return;
+      }
+
+      // Migrate an explicit browser choice once. A fresh browser has no local
+      // value and therefore cannot overwrite an existing account preference
+      // with the default false state.
+      const localEnabled = readLocalEnabledChoice();
+      if (accountReadyForMigration && localEnabled !== null) {
+        writeAccountEnabledChoice(observedDocuments, localEnabled);
+      }
+    };
+
+    const attachPrivateProfile = () => {
+      const room = getPrivateProfileRoom(database);
+      if (!room?.ydoc) return;
+      const documents = room.getDocuments();
+      if (documents === observedDocuments) return;
+
+      detachDocuments();
+      observedRoom = room;
+      observedDocuments = documents;
+      accountDocumentsRef.current = documents;
+      accountReadyForMigration = Boolean(room.syncProvider?.isSynced);
+      setAccountBacked(
+        accountReadyForMigration || readAccountEnabledChoice(documents) !== null
+      );
+      room.syncProvider?.on('synced', handleProfileSynced);
+      documents.onChange(syncFromAccount);
+      syncFromAccount();
+    };
+
+    const handleRoomLoaded = () => attachPrivateProfile();
+    database.on('roomLoaded', handleRoomLoaded);
+    attachPrivateProfile();
+
+    return () => {
+      database.off('roomLoaded', handleRoomLoaded);
+      detachDocuments();
+    };
+  }, [applyEnabledChoice, database]);
+
   return {
     preferences,
+    accountBacked,
     setEnabled: (enabled: boolean) => {
-      window.localStorage.setItem(
-        AGENT_WORKSPACE_ENABLED_STORAGE_KEY,
-        String(enabled)
-      );
-      setPreferences({ enabled });
-      window.dispatchEvent(
-        new Event(AGENT_WORKSPACE_PREFERENCES_CHANGED_EVENT)
-      );
+      applyEnabledChoice(enabled);
+      const accountDocuments = accountDocumentsRef.current;
+      if (accountDocuments) {
+        writeAccountEnabledChoice(accountDocuments, enabled);
+      }
     },
   };
 }

--- a/packages/ewe-note/src/app/contexts/NotesContext.tsx
+++ b/packages/ewe-note/src/app/contexts/NotesContext.tsx
@@ -376,7 +376,7 @@ export function NotesProvider({ children }: { children: React.ReactNode }) {
     setSelectedRoom,
   } = useDb();
   const { preferences: agentWorkspacePreferences } =
-    useAgentWorkspacePreferences();
+    useAgentWorkspacePreferences(db);
   const agentWorkspaceEnabled = agentWorkspacePreferences.enabled;
   const canonicalRoom =
     allRooms.find((room) => room.name === 'Notes') ?? allRooms[0] ?? null;

--- a/packages/ewe-note/src/app/pages/Settings.test.tsx
+++ b/packages/ewe-note/src/app/pages/Settings.test.tsx
@@ -163,7 +163,7 @@ describe('Settings', () => {
     expect(screen.queryByText('Ready to pair')).toBeNull();
   });
 
-  it('enables the Agent Workspace mod for this browser only', () => {
+  it('enables the Agent Workspace mod and caches the choice locally', () => {
     render(<Settings />);
 
     fireEvent.click(

--- a/packages/ewe-note/src/app/pages/Settings.tsx
+++ b/packages/ewe-note/src/app/pages/Settings.tsx
@@ -65,10 +65,6 @@ export function Settings() {
   const { preferences, updatePreference } =
     useWorkspaceInteractionPreferences();
   const {
-    preferences: agentWorkspacePreferences,
-    setEnabled: setAgentWorkspaceEnabled,
-  } = useAgentWorkspacePreferences();
-  const {
     allRooms,
     allRoomIds,
     db,
@@ -84,6 +80,11 @@ export function Settings() {
     syncStatusLabel,
     user,
   } = useDb();
+  const {
+    preferences: agentWorkspacePreferences,
+    accountBacked: agentWorkspaceAccountBacked,
+    setEnabled: setAgentWorkspaceEnabled,
+  } = useAgentWorkspacePreferences(db);
 
   const importingVault = vaultImportProgress !== null;
   const canSyncRemotely = loggedIn || hasToken;
@@ -624,7 +625,7 @@ export function Settings() {
                   <SettingsToggleRow
                     id="ewe-note-settings-agent-workspace"
                     title="Enable Agent Workspace"
-                    description="Connect editable agent controls and read-only agent memory through a separately installed local bridge. Off by default and enabled only in this browser."
+                    description="Focus Ewe Note on editable agent controls and read-only agent memory. Off by default; signed-in choices sync privately across browsers."
                     checked={agentWorkspacePreferences.enabled}
                     onCheckedChange={setAgentWorkspaceEnabled}
                   />
@@ -657,8 +658,9 @@ export function Settings() {
                         />
                       </div>
                       <p className="text-xs text-muted-foreground">
-                        Not connected. Turning on this mod does not create a
-                        vault, contact a bridge, or affect another user.
+                        {agentWorkspaceAccountBacked
+                          ? 'Enabled for this signed-in account. Turning on this mod does not affect another user.'
+                          : 'Stored in this browser until the signed-in private profile is available. Turning on this mod does not affect another user.'}
                       </p>
                     </div>
                   ) : (

--- a/packages/ewe-note/src/prioritized-room-sync.test.ts
+++ b/packages/ewe-note/src/prioritized-room-sync.test.ts
@@ -29,7 +29,7 @@ function makeDatabase({
 }
 
 describe('loginWithPrioritizedNoteSync', () => {
-  it('starts every note room before loading the full registry', async () => {
+  it('starts note and profile rooms before loading the full registry', async () => {
     const events: string[] = [];
     const firstRoom = makeRegistryRoom('first-note');
     const secondRoom = makeRegistryRoom('second-note');
@@ -51,16 +51,25 @@ describe('loginWithPrioritizedNoteSync', () => {
     );
 
     expect(database.login).toHaveBeenCalledWith({ loadAllRooms: false });
-    expect(loadRoom).toHaveBeenCalledTimes(2);
-    expect(loadRoom).toHaveBeenNthCalledWith(1, firstRoom, {
+    expect(loadRoom).toHaveBeenCalledTimes(3);
+    expect(loadRoom).toHaveBeenNthCalledWith(1, profileRoom, {
       loadRemote: true,
       awaitLoadRemote: false,
     });
-    expect(loadRoom).toHaveBeenNthCalledWith(2, secondRoom, {
+    expect(loadRoom).toHaveBeenNthCalledWith(2, firstRoom, {
       loadRemote: true,
       awaitLoadRemote: false,
     });
-    expect(events).toEqual(['first-note', 'second-note', 'registry']);
+    expect(loadRoom).toHaveBeenNthCalledWith(3, secondRoom, {
+      loadRemote: true,
+      awaitLoadRemote: false,
+    });
+    expect(events).toEqual([
+      'profile',
+      'first-note',
+      'second-note',
+      'registry',
+    ]);
     expect(loadRooms).toHaveBeenCalledWith(database.registry, true);
   });
 

--- a/packages/ewe-note/src/prioritized-room-sync.ts
+++ b/packages/ewe-note/src/prioritized-room-sync.ts
@@ -5,8 +5,8 @@ export type BackgroundSyncErrorHandler = (error: unknown) => void;
 /**
  * Authenticate without blocking the notes UI behind every room in the account.
  *
- * EweNote needs all note rooms immediately, while profile and other collection
- * rooms can continue loading in the background.
+ * EweNote needs all note rooms and private account preferences immediately,
+ * while other collection rooms can continue loading in the background.
  */
 export async function loginWithPrioritizedNoteSync(
   database: Database,
@@ -17,11 +17,12 @@ export async function loginWithPrioritizedNoteSync(
     return false;
   }
 
-  const noteRooms = database.registry.filter(
-    (room) => room.collectionKey === 'notes'
+  const priorityRooms = database.registry.filter(
+    (room) =>
+      room.collectionKey === 'notes' || room.collectionKey === 'profiles'
   );
   await Promise.allSettled(
-    noteRooms.map((room) =>
+    priorityRooms.map((room) =>
       database.loadRoom(room, {
         loadRemote: true,
         // Start every notes connection now instead of serially waiting for each


### PR DESCRIPTION
## Summary
- store the off-by-default Agent Workspace choice in the signed-in private profile, with localStorage as an offline cache
- migrate only explicit browser choices and never write a fresh default over account state
- prioritize profile-room sync so the setting is not queued behind dozens of note vaults

## Verification
- `npm test --workspace @eweser/ewe-note` (216 passing)
- `npm run lint --workspace @eweser/ewe-note -- --max-warnings=0`
- `npm run type-check --workspace @eweser/ewe-note`
- `npm run build --workspace @eweser/ewe-note`

Follow-up to #82 after production verification showed browser-local state did not carry from Chrome to Brave.