### PR TITLE
fix(ewe-note): show signed-in account identity

### DIFF
--- a/packages/auth-server-hono/src/INDEX.md
+++ b/packages/auth-server-hono/src/INDEX.md
@@ -17,6 +17,8 @@ Drizzle models, and service helpers for the auth API.
 - [`auth.ts`](./auth.ts): better-auth configuration.
 - [`routes/access-grant.ts`](./routes/access-grant.ts): Room registry sync,
   invite, update, and sync-token routes.
+- [`routes/account.ts`](./routes/account.ts): Session-backed account bootstrap
+  plus trusted-origin, grant-bound minimal app identity.
 - [`routes/agents.ts`](./routes/agents.ts): Agent token API.
 - [`routes/connect-ai.ts`](./routes/connect-ai.ts): Signed-in AI connector API.
 - [`routes/files.ts`](./routes/files.ts): S3-compatible attachment

--- a/packages/auth-server-hono/src/routes/account.test.ts
+++ b/packages/auth-server-hono/src/routes/account.test.ts
@@ -9,12 +9,33 @@ const mockParseAccessGrantId = vi.fn();
 const mockRevokeAccessGrantForOwner = vi.fn();
 const mockGetRoomsFromAccessGrant = vi.fn();
 const mockGetUserCount = vi.fn();
+const mockGetUserById = vi.fn();
 const mockEnsureUserRooms = vi.fn();
 const mockGetStorageProviderProfile = vi.fn();
 
 vi.mock('../env.js', () => ({
   env: {
     AUTH_SERVER_DOMAIN: 'auth.local',
+    AUTH_TRUSTED_ORIGINS: ['https://note.local', 'https://other-trusted.local'],
+  },
+}));
+
+vi.mock('../middleware/jwt-auth.js', () => ({
+  requireJwtAuth: async (
+    c: {
+      req: { header: (name: string) => string | undefined };
+      set: (key: string, value: unknown) => void;
+      json: (body: unknown, status: number) => Response;
+    },
+    next: () => Promise<void>
+  ) => {
+    const accessGrantId = c.req.header('X-Test-Access-Grant-Id');
+    if (!accessGrantId) {
+      return c.json({ error: 'No token provided' }, 401);
+    }
+    c.set('access_grant_id', accessGrantId);
+    c.set('roomIds', []);
+    await next();
   },
 }));
 
@@ -38,6 +59,7 @@ vi.mock('../model/rooms/calls.js', () => ({
 }));
 
 vi.mock('../model/users.js', () => ({
+  getUserById: mockGetUserById,
   getUserCount: mockGetUserCount,
 }));
 
@@ -145,6 +167,99 @@ describe('accountRouter', () => {
 
     expect(response.status).toBe(200);
     expect(mockEnsureUserRooms).toHaveBeenCalledWith('user-1');
+  });
+
+  it('returns minimal identity to the trusted app that owns the grant', async () => {
+    mockGetAccessGrantById.mockResolvedValue({
+      id: 'user-1|note.local',
+      isValid: true,
+      ownerId: 'user-1',
+      requesterId: 'note.local',
+      requesterType: 'app',
+    });
+    mockGetUserById.mockResolvedValue({
+      email: 'test@example.com',
+      id: 'user-1',
+      image: 'https://images.example/avatar.png',
+      name: 'Test User',
+      passwordHash: 'must-not-leak',
+      rooms: ['room-1'],
+    });
+
+    const response = await app.fetch(
+      new Request('http://localhost/api/account/identity', {
+        headers: {
+          Origin: 'https://note.local',
+          'X-Test-Access-Grant-Id': 'user-1|note.local',
+        },
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(body).toEqual({
+      user: {
+        email: 'test@example.com',
+        image: 'https://images.example/avatar.png',
+        name: 'Test User',
+      },
+    });
+    expect(JSON.stringify(body)).not.toContain('must-not-leak');
+    expect(JSON.stringify(body)).not.toContain('room-1');
+  });
+
+  it('rejects identity requests from untrusted or mismatched origins', async () => {
+    mockGetAccessGrantById.mockResolvedValue({
+      id: 'user-1|note.local',
+      isValid: true,
+      ownerId: 'user-1',
+      requesterId: 'note.local',
+      requesterType: 'app',
+    });
+
+    const untrusted = await app.fetch(
+      new Request('http://localhost/api/account/identity', {
+        headers: {
+          Origin: 'https://evil.example',
+          'X-Test-Access-Grant-Id': 'user-1|note.local',
+        },
+      })
+    );
+    const mismatched = await app.fetch(
+      new Request('http://localhost/api/account/identity', {
+        headers: {
+          Origin: 'https://other-trusted.local',
+          'X-Test-Access-Grant-Id': 'user-1|note.local',
+        },
+      })
+    );
+
+    expect(untrusted.status).toBe(403);
+    expect(mismatched.status).toBe(403);
+    expect(mockGetUserById).not.toHaveBeenCalled();
+  });
+
+  it('rejects a revoked access grant for account identity', async () => {
+    mockGetAccessGrantById.mockResolvedValue({
+      id: 'user-1|note.local',
+      isValid: false,
+      ownerId: 'user-1',
+      requesterId: 'note.local',
+      requesterType: 'app',
+    });
+
+    const response = await app.fetch(
+      new Request('http://localhost/api/account/identity', {
+        headers: {
+          Origin: 'https://note.local',
+          'X-Test-Access-Grant-Id': 'user-1|note.local',
+        },
+      })
+    );
+
+    expect(response.status).toBe(401);
+    expect(mockGetUserById).not.toHaveBeenCalled();
   });
 
   it('lists connected app grants without exposing the auth-server self grant', async () => {

--- a/packages/auth-server-hono/src/routes/account.ts
+++ b/packages/auth-server-hono/src/routes/account.ts
@@ -2,6 +2,7 @@ import { Hono, type Context } from 'hono';
 import { z } from 'zod';
 import { env } from '../env.js';
 import { requireAuth } from '../middleware/auth.js';
+import { requireJwtAuth } from '../middleware/jwt-auth.js';
 import {
   createAccessGrantId,
   getAccessGrantById,
@@ -10,7 +11,7 @@ import {
   revokeAccessGrantForOwner,
 } from '../model/access_grants.js';
 import { getRoomsFromAccessGrant } from '../model/rooms/calls.js';
-import { getUserCount } from '../model/users.js';
+import { getUserById, getUserCount } from '../model/users.js';
 import { ensureUserRoomsAndAuthServerAccess } from '../services/account/create-user-rooms.js';
 import { getStorageProviderProfile } from '../lib/storage.js';
 
@@ -20,10 +21,10 @@ const revokeConnectedAppBodySchema = z.object({
   grantId: z.string().min(1),
 });
 
-function noStoreJson(c: Context, body: unknown) {
+function noStoreJson(c: Context, body: unknown, status?: 401 | 403 | 404) {
   c.header('Cache-Control', 'no-store');
   c.header('Pragma', 'no-cache');
-  return c.json(body);
+  return status ? c.json(body, status) : c.json(body);
 }
 
 accountRouter.get('/bootstrap', requireAuth, async (c) => {
@@ -54,6 +55,52 @@ accountRouter.get('/bootstrap', requireAuth, async (c) => {
     profileRooms,
     storageProviderProfile: getStorageProviderProfile(),
     userCount,
+  });
+});
+
+/**
+ * Return the minimum account identity needed by a trusted first-party app.
+ *
+ * Access-grant tokens are domain-bound. Requiring both an explicitly trusted
+ * browser Origin and an exact requester-domain match prevents an unrelated app
+ * with a valid room grant from learning the account email.
+ */
+accountRouter.get('/identity', requireJwtAuth, async (c) => {
+  const origin = c.req.header('Origin');
+  if (!origin || !env.AUTH_TRUSTED_ORIGINS.includes(origin)) {
+    return noStoreJson(c, { error: 'Origin is not trusted' }, 403);
+  }
+
+  const accessGrant = await getAccessGrantById(c.get('access_grant_id'));
+  if (!accessGrant || !accessGrant.isValid) {
+    return noStoreJson(c, { error: 'Invalid access grant' }, 401);
+  }
+
+  let requesterDomain: string;
+  try {
+    requesterDomain = new URL(origin).host;
+  } catch {
+    return noStoreJson(c, { error: 'Origin is not trusted' }, 403);
+  }
+
+  if (
+    accessGrant.requesterType !== 'app' ||
+    accessGrant.requesterId !== requesterDomain
+  ) {
+    return noStoreJson(c, { error: 'Access grant domain mismatch' }, 403);
+  }
+
+  const user = await getUserById(accessGrant.ownerId);
+  if (!user) {
+    return noStoreJson(c, { error: 'Account not found' }, 404);
+  }
+
+  return noStoreJson(c, {
+    user: {
+      email: user.email,
+      image: user.image ?? null,
+      name: user.name ?? null,
+    },
   });
 });
 

--- a/packages/ewe-note/src/INDEX.md
+++ b/packages/ewe-note/src/INDEX.md
@@ -21,6 +21,8 @@ helpers.
 - [`notes-room.tsx`](./notes-room.tsx): React hook for note room state and CRUD.
 - [`prioritized-room-sync.ts`](./prioritized-room-sync.ts): Authenticates and
   starts note-room sync before loading other account rooms in the background.
+- [`user.tsx`](./user.tsx): Resolves signed-in name, email, and avatar from the
+  trusted app identity endpoint plus synced profile overrides.
 - [`components/INDEX.md`](./components/): Editor, layout, sidebar, and UI
   component map.
 - [`cli/INDEX.md`](./cli/): Vault import, export, and sync CLI map.

--- a/packages/ewe-note/src/app/pages/Settings.test.tsx
+++ b/packages/ewe-note/src/app/pages/Settings.test.tsx
@@ -24,9 +24,9 @@ vi.mock('../../db', () => ({
     allRooms: [],
     allRoomIds: [],
     db: {},
-    hasToken: false,
+    hasToken: true,
     loaded: true,
-    loggedIn: false,
+    loggedIn: true,
     loginUrl: 'http://localhost:38101/login',
     selectedRoom: null,
     setSelectedRoom: mockSetSelectedRoom,
@@ -34,7 +34,12 @@ vi.mock('../../db', () => ({
     syncStatus: 'signed-out',
     syncStatusDescription: 'Signed out',
     syncStatusLabel: 'Signed out',
-    user: {},
+    user: {
+      firstName: 'Test',
+      lastName: 'User',
+      email: 'test@example.com',
+      avatar: '',
+    },
   }),
 }));
 
@@ -109,6 +114,14 @@ describe('Settings', () => {
     ).toBe('false');
   });
 
+  it('shows the signed-in account name and email', () => {
+    render(<Settings />);
+
+    expect(screen.getByText('Test User')).toBeTruthy();
+    expect(screen.getByText('test@example.com')).toBeTruthy();
+    expect(screen.queryByText('Signed In')).toBeNull();
+  });
+
   it('shows the full theme preset controls in settings', () => {
     render(<Settings />);
 
@@ -142,7 +155,7 @@ describe('Settings', () => {
     ).toBeTruthy();
     expect(
       screen.getByText(
-        'Open a local Markdown folder and edit its files in EweNote. Sign in first if you also want the room synced across devices.'
+        'Markdown files become normal synced EweNote notes while this desktop keeps writable links to the originals.'
       )
     ).toBeTruthy();
   });

--- a/packages/ewe-note/src/app/pages/Settings.tsx
+++ b/packages/ewe-note/src/app/pages/Settings.tsx
@@ -300,7 +300,7 @@ export function Settings() {
                             'Signed In'}
                         </div>
                         <div className="text-sm text-muted-foreground">
-                          {user.avatar ?? ''}
+                          {user.email || 'Email unavailable'}
                         </div>
                       </>
                     ) : (

--- a/packages/ewe-note/src/db.tsx
+++ b/packages/ewe-note/src/db.tsx
@@ -122,6 +122,7 @@ export type DbContextType = {
   user: {
     firstName: string;
     lastName: string;
+    email: string;
     avatar: string;
   };
   signOut: () => void;

--- a/packages/ewe-note/src/user.test.tsx
+++ b/packages/ewe-note/src/user.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import type { Database } from '@eweser/db';
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useGetUserFromDb } from './user';
+
+describe('useGetUserFromDb', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('loads name and email through the access-grant identity endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          user: {
+            email: 'test@example.com',
+            image: 'https://images.example/avatar.png',
+            name: 'Test User',
+          },
+        }),
+        {
+          headers: { 'Content-Type': 'application/json' },
+          status: 200,
+        }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const database = {
+      authServer: 'https://auth.example.com',
+      getRooms: vi.fn(() => []),
+      getToken: vi.fn(() => 'test-access-grant-token'),
+      on: vi.fn(),
+      off: vi.fn(),
+    } as unknown as Database;
+
+    const hook = renderHook(() => useGetUserFromDb(database, true));
+
+    await waitFor(() => {
+      expect(hook.result.current).toEqual({
+        avatar: 'https://images.example/avatar.png',
+        email: 'test@example.com',
+        firstName: 'Test',
+        lastName: 'User',
+      });
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://auth.example.com/api/account/identity',
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer test-access-grant-token' },
+        referrerPolicy: 'no-referrer',
+      })
+    );
+  });
+});

--- a/packages/ewe-note/src/user.tsx
+++ b/packages/ewe-note/src/user.tsx
@@ -4,11 +4,13 @@ import { useEffect, useMemo, useState } from 'react';
 type UserState = {
   firstName: string;
   lastName: string;
+  email: string;
   avatar: string;
 };
 
 type AccountBootstrapResponse = {
   user?: {
+    email?: string | null;
     image?: string | null;
     name?: string | null;
   };
@@ -32,6 +34,7 @@ export const useGetUserFromDb = (db: Database, canFetchAccount = false) => {
   const [user, setUser] = useState<UserState>({
     firstName: '',
     lastName: '',
+    email: '',
     avatar: '',
   });
   const [accountUser, setAccountUser] = useState<UserState | null>(null);
@@ -64,12 +67,22 @@ export const useGetUserFromDb = (db: Database, canFetchAccount = false) => {
 
     async function loadAccountUser() {
       try {
+        const token = db.getToken();
         const response = await fetch(
-          new URL('/api/account/bootstrap', db.authServer).toString(),
-          {
-            credentials: 'include',
-            signal: controller.signal,
-          }
+          new URL(
+            token ? '/api/account/identity' : '/api/account/bootstrap',
+            db.authServer
+          ).toString(),
+          token
+            ? {
+                headers: { Authorization: `Bearer ${token}` },
+                referrerPolicy: 'no-referrer',
+                signal: controller.signal,
+              }
+            : {
+                credentials: 'include',
+                signal: controller.signal,
+              }
         );
 
         if (!response.ok) {
@@ -82,6 +95,7 @@ export const useGetUserFromDb = (db: Database, canFetchAccount = false) => {
         setAccountUser({
           firstName: names.firstName,
           lastName: names.lastName,
+          email: data.user?.email ?? '',
           avatar: data.user?.image ?? '',
         });
       } catch (error) {
@@ -96,7 +110,7 @@ export const useGetUserFromDb = (db: Database, canFetchAccount = false) => {
     return () => {
       controller.abort();
     };
-  }, [canFetchAccount, db.authServer]);
+  }, [canFetchAccount, db]);
 
   const PublicProfile = useMemo(
     () =>
@@ -167,6 +181,7 @@ export const useGetUserFromDb = (db: Database, canFetchAccount = false) => {
     const nextUser: UserState = {
       firstName: accountUser?.firstName ?? '',
       lastName: accountUser?.lastName ?? '',
+      email: accountUser?.email ?? '',
       avatar: accountUser?.avatar ?? '',
     };
 
@@ -188,6 +203,7 @@ export const useGetUserFromDb = (db: Database, canFetchAccount = false) => {
       if (
         currentUser.firstName === nextUser.firstName &&
         currentUser.lastName === nextUser.lastName &&
+        currentUser.email === nextUser.email &&
         currentUser.avatar === nextUser.avatar
       ) {
         return currentUser;


### PR DESCRIPTION
## Summary
- expose a minimal name/email/avatar identity response to the trusted app that owns a valid access grant
- load that identity in Ewe Note when signed in through an app grant
- show the signed-in account name and email in Settings

## Security
- requires a valid, unrevoked access grant
- requires an explicitly trusted browser origin
- requires the grant requester domain to match that origin
- returns no room data or broader account record

## Validation
- 427 package tests passed
- auth and Ewe Note type checks passed
- auth and Ewe Note production builds passed
- repository lint, format, code-index, and secret scan passed