### PR TITLE
fix(ewe-note): wait for note sync before not found

### DIFF
--- a/packages/ewe-note/src/app/pages/EnhancedEditor.tsx
+++ b/packages/ewe-note/src/app/pages/EnhancedEditor.tsx
@@ -44,13 +44,15 @@ export const REMOTE_NOTE_HYDRATION_GRACE_MS = 10_000;
 export function shouldWaitForRemoteNote({
   hasToken,
   noteFound,
+  syncInProgress,
   waitExpired,
 }: {
   hasToken: boolean;
   noteFound: boolean;
+  syncInProgress: boolean;
   waitExpired: boolean;
 }) {
-  return hasToken && !noteFound && !waitExpired;
+  return hasToken && !noteFound && (syncInProgress || !waitExpired);
 }
 
 export function buildEditorWikiLinkPath(
@@ -144,6 +146,7 @@ export function EnhancedEditor() {
     allRooms,
     db,
     hasToken,
+    syncStatus,
     selectedRoom,
     setSelectedRoom,
     setSelectedNoteId,
@@ -157,13 +160,13 @@ export function EnhancedEditor() {
 
   useEffect(() => {
     setMissingNoteWaitExpired(false);
-    if (note || !hasToken) return;
+    if (note || !hasToken || syncStatus === 'connecting') return;
     const timeout = window.setTimeout(
       () => setMissingNoteWaitExpired(true),
       REMOTE_NOTE_HYDRATION_GRACE_MS
     );
     return () => window.clearTimeout(timeout);
-  }, [hasToken, note, noteId]);
+  }, [hasToken, note, noteId, syncStatus]);
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
@@ -199,6 +202,7 @@ export function EnhancedEditor() {
     shouldWaitForRemoteNote({
       hasToken,
       noteFound: Boolean(note),
+      syncInProgress: syncStatus === 'connecting',
       waitExpired: missingNoteWaitExpired,
     })
   ) {

--- a/packages/ewe-note/src/app/pages/EnhancedEditor.wiki-navigation.test.ts
+++ b/packages/ewe-note/src/app/pages/EnhancedEditor.wiki-navigation.test.ts
@@ -35,6 +35,7 @@ describe('EnhancedEditor wiki navigation helpers', () => {
       shouldWaitForRemoteNote({
         hasToken: true,
         noteFound: false,
+        syncInProgress: false,
         waitExpired: false,
       })
     ).toBe(true);
@@ -42,9 +43,21 @@ describe('EnhancedEditor wiki navigation helpers', () => {
       shouldWaitForRemoteNote({
         hasToken: true,
         noteFound: false,
+        syncInProgress: false,
         waitExpired: true,
       })
     ).toBe(false);
+  });
+
+  it('keeps waiting while synced rooms are still connecting', () => {
+    expect(
+      shouldWaitForRemoteNote({
+        hasToken: true,
+        noteFound: false,
+        syncInProgress: true,
+        waitExpired: true,
+      })
+    ).toBe(true);
   });
   it('preserves heading targets as editor URL hashes', () => {
     expect(


### PR DESCRIPTION
## What changed

Ewe Note now keeps a missing deep-linked note in the loading state while note rooms are still connecting. The existing 10-second final grace period starts only after synchronization settles.

## Root cause

The editor started its fixed 10-second "not found" timer as soon as the route mounted, while a cold room connection may legitimately take up to 30 seconds. That let the timeout expire before the target room hydrated.

## Impact

Cold deep links into synced vaults, including read-only agent-memory journals, no longer become a false "Note not found" result merely because room synchronization is still active.

## Flow

```mermaid
flowchart LR
    A[Open deep note link] --> B{Note already local?}
    B -- yes --> C[Open editor]
    B -- no --> D{Rooms still connecting?}
    D -- yes --> E[Keep Opening note state]
    E --> D
    D -- no --> F[Start final 10 second grace]
    F --> G{Note arrived?}
    G -- yes --> C
    G -- no --> H[Show Note not found]
```

## Validation

- Focused Vitest regression: 4 tests passed.
- ESLint on both changed files: passed.
- Prettier on both changed files: passed.
- Secret scan from the repository pre-push hook: passed.
- Full local type-check was not authoritative because the pre-existing shared dependency cache is incomplete; repository CI is the full-check gate.

## Review Evidence Checklist

- UI-visible change: Yes, behavioral timing only.
- Screenshots: N/A: there is no markup or styling change, and a static screenshot cannot demonstrate the corrected transition timing.
- Visual assessment: N/A: spacing, alignment, wrapping, density, responsive fit, and appearance are unchanged.
- Flow/control movement changed: Yes.
- Mermaid diagram: included above.
- Open review comments addressed: N/A.
