### PR TITLE
Fix login with stale local vaults

### DIFF
--- a/.changeset/local-vault-login-reconciliation.md
+++ b/.changeset/local-vault-login-reconciliation.md
@@ -1,0 +1,5 @@
+---
+'@eweser/db': patch
+---
+
+Deduplicate app-initialized rooms and allow access-grant login to continue when an initial offline room must remain local-only.

--- a/packages/db/src/index.test.ts
+++ b/packages/db/src/index.test.ts
@@ -1,6 +1,8 @@
+// @vitest-environment jsdom
+
 import type { DatabaseOptions } from '.';
 import { Database } from '.';
-import { it, expect } from 'vitest';
+import { beforeEach, it, expect } from 'vitest';
 
 const collectionKeys = [
   'notes',
@@ -15,6 +17,10 @@ const collectionKeys = [
   'projectWikiDrafts',
 ];
 const defaultAuthServer = 'https://www.eweser.com';
+
+beforeEach(() => {
+  localStorage.clear();
+});
 
 it('Database initializes with defaults', () => {
   const DB = new Database();
@@ -34,6 +40,21 @@ it('Database initializes with options', () => {
   expect(DB).toBeDefined();
   expect(DB.authServer).toBe(options.authServer);
   expect(DB.logLevel).toBe(options.logLevel);
+});
+it('Database removes duplicate rooms from a persisted local registry', () => {
+  const room = {
+    id: 'local-room',
+    name: 'Local notes',
+    collectionKey: 'notes',
+  };
+  localStorage.setItem('ewe_room_registry', JSON.stringify([room, room, room]));
+
+  const DB = new Database({ providers: ['IndexedDB'] });
+
+  expect(DB.registry).toEqual([room]);
+  expect(JSON.parse(localStorage.getItem('ewe_room_registry') ?? '[]')).toEqual(
+    [room]
+  );
 });
 it.todo(
   'Can use local server',

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -42,6 +42,7 @@ import {
   localStorageGet,
   localStorageRemove,
   localStorageSet,
+  setLocalRegistry,
 } from './utils/localStorageService.js';
 import { generateShareRoomLink } from './methods/connection/generateShareRoomLink.js';
 import { pingServer } from './utils/connection/pingServer.js';
@@ -90,6 +91,12 @@ export interface DatabaseOptions {
    * that need pre-populated data before sync is available.
    */
   initialDocuments?: SeedDocuments<EweDocument>;
+}
+
+function deduplicateRegistry(registry: Registry): Registry {
+  return Array.from(
+    new Map(registry.map((room) => [room.id, room] as const)).values()
+  );
 }
 
 export class Database extends TypedEventEmitter<DatabaseEvents> {
@@ -290,17 +297,17 @@ export class Database extends TypedEventEmitter<DatabaseEvents> {
     setupLogger(this);
     this.debug('Database created with options', options);
 
-    this.registry = this.getRegistry() || [];
+    const storedRegistry = this.getRegistry() || [];
+    this.registry = deduplicateRegistry(storedRegistry);
+    if (this.registry.length !== storedRegistry.length) {
+      setLocalRegistry(this)(this.registry);
+    }
     const initializedRooms: Registry = [];
     if (options.initialRooms) {
-      const registryRoomIds = this.registry.map((r) => r.id);
       for (const room of options.initialRooms) {
         const initializedRoom = this.newRoom<EweDocument>(room);
         this._initialRoomIds.add(initializedRoom.id);
         const registryRoom = roomToServerRoom(initializedRoom);
-        if (room.id && !registryRoomIds.includes(room.id)) {
-          this.registry.push(registryRoom);
-        }
         initializedRooms.push(registryRoom);
       }
       /** try to load remotes for initial rooms */

--- a/packages/db/src/methods/connection/syncRegistry.test.ts
+++ b/packages/db/src/methods/connection/syncRegistry.test.ts
@@ -231,6 +231,7 @@ describe('syncRegistry', () => {
     };
     const db = {
       registry: [newRoom],
+      _initialRoomIds: new Set(),
       _pendingRegistryRoomIds: new Set([newRoom.id]),
       userId: '',
       accessGrantToken: '',
@@ -377,5 +378,48 @@ describe('syncRegistry', () => {
     expect(serverFetch).toHaveBeenCalledOnce();
     expect(db.registry).toEqual([canonicalRoom, pendingRoom]);
     expect(db._pendingRegistryRoomIds).toEqual(new Set([pendingRoom.id]));
+  });
+
+  it('keeps a rejected initial room local-only without blocking login', async () => {
+    const localRoom = {
+      id: 'local-room',
+      name: 'Local notes',
+      collectionKey: 'notes',
+    };
+    const canonicalRoom = {
+      id: 'canonical-room',
+      name: 'Notes',
+      collectionKey: 'notes',
+    };
+    const db = {
+      registry: [localRoom, localRoom, localRoom],
+      collections: { notes: {} },
+      _initialRoomIds: new Set([localRoom.id]),
+      _pendingRegistryRoomIds: new Set([localRoom.id]),
+      userId: '',
+      accessGrantToken: '',
+      getToken: () => 'token',
+      emit: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      serverFetch: vi.fn().mockResolvedValue({
+        data: {
+          rooms: [canonicalRoom],
+          token: 'next-token',
+          userId: 'user-1',
+        },
+        error: null,
+      }),
+    } as unknown as Database;
+
+    await expect(syncRegistry(db)()).resolves.toBe(true);
+
+    expect(db.registry).toEqual([canonicalRoom, localRoom]);
+    expect(db._pendingRegistryRoomIds).toEqual(new Set());
+    expect(db.warn).toHaveBeenCalledWith(
+      'Keeping rejected initial rooms local-only',
+      { roomCount: 1 }
+    );
   });
 });

--- a/packages/db/src/methods/connection/syncRegistry.ts
+++ b/packages/db/src/methods/connection/syncRegistry.ts
@@ -8,6 +8,12 @@ import {
 } from '../../utils/localStorageService.js';
 import type { Database } from '../../index.js';
 
+function uniqueRoomsById(rooms: Database['registry']) {
+  return Array.from(
+    new Map(rooms.map((room) => [room.id, room] as const)).values()
+  );
+}
+
 function unloadRoomsMissingFromRegistry(
   db: Database,
   previousRooms: Database['registry'],
@@ -85,11 +91,14 @@ export const syncRegistry = (db: Database) => {
           (previousRoom) => previousRoom.id === room.id && previousRoom._deleted
         )
       );
-      const roomsCreatedDuringSync = db.registry.filter(
-        (room) =>
-          db._pendingRegistryRoomIds.has(room.id) && !serverRoomIds.has(room.id)
+      const roomsCreatedDuringSync = uniqueRoomsById(
+        db.registry.filter(
+          (room) =>
+            db._pendingRegistryRoomIds.has(room.id) &&
+            !serverRoomIds.has(room.id)
+        )
       );
-      const nextRooms = [...rooms, ...roomsCreatedDuringSync];
+      const nextRooms = uniqueRoomsById([...rooms, ...roomsCreatedDuringSync]);
 
       unloadRoomsMissingFromRegistry(db, previousRooms, nextRooms);
       setLocalRegistry(db)(nextRooms);
@@ -98,6 +107,18 @@ export const syncRegistry = (db: Database) => {
         if (serverRoomIds.has(roomId)) {
           db._pendingRegistryRoomIds.delete(roomId);
         }
+      }
+
+      const rejectedInitialRoomIds = newRoomIds.filter(
+        (roomId) => db._initialRoomIds.has(roomId) && !serverRoomIds.has(roomId)
+      );
+      for (const roomId of rejectedInitialRoomIds) {
+        db._pendingRegistryRoomIds.delete(roomId);
+      }
+      if (rejectedInitialRoomIds.length > 0) {
+        db.warn('Keeping rejected initial rooms local-only', {
+          roomCount: rejectedInitialRoomIds.length,
+        });
       }
 
       if (rejectedTombstoneRooms.length > 0) {

--- a/packages/db/src/methods/newRoom.test.ts
+++ b/packages/db/src/methods/newRoom.test.ts
@@ -59,4 +59,27 @@ describe('newRoom', () => {
 
     expect(db.syncRegistry).toHaveBeenCalled();
   });
+
+  it('does not duplicate an existing room when an app initializes it again', () => {
+    const existingRoom = {
+      id: 'room-existing',
+      collectionKey: 'notes' as const,
+      name: 'Local notes',
+    };
+    const db = {
+      collections: { notes: {}, flashcards: {}, profiles: {} },
+      registry: [existingRoom],
+      _pendingRegistryRoomIds: new Set<string>(),
+      online: false,
+      debug: vi.fn(),
+      loadRoom: vi.fn(),
+      syncRegistry: vi.fn(),
+    } as unknown as Database;
+
+    newRoom(db)(existingRoom);
+
+    expect(db.registry).toEqual([existingRoom]);
+    expect(db._pendingRegistryRoomIds).toEqual(new Set([existingRoom.id]));
+    expect(setLocalRegistryMock).toHaveBeenCalledWith([existingRoom]);
+  });
 });

--- a/packages/db/src/methods/newRoom.ts
+++ b/packages/db/src/methods/newRoom.ts
@@ -22,7 +22,9 @@ export const newRoom =
       room as unknown as Room<EweDocument>;
 
     const registryRoom = roomToServerRoom(room);
-    db.registry.push(registryRoom);
+    if (!db.registry.some((entry) => entry.id === room.id)) {
+      db.registry.push(registryRoom);
+    }
     db._pendingRegistryRoomIds.add(room.id);
     setLocalRegistry(db)(db.registry);
 


### PR DESCRIPTION
## What changed

- deduplicate persisted room registries during database startup
- avoid appending an app-initialized room that is already registered locally
- keep an initial offline room local-only when the server authoritatively omits it, instead of blocking the valid access-grant login
- deduplicate locally preserved pending rooms during registry reconciliation
- add a patch changeset for `@eweser/db`

## Root cause

Ewe Note initializes the same offline-first vault on every startup. The SDK appended that room to the persisted registry each time and marked it as pending registration. When an old server-side room was no longer present in the access grant, the valid grant still refreshed successfully, but registry draining returned `false` forever. `Database.login()` therefore never enabled remote sync or emitted the logged-in state.

## Result

The local vault remains available without being recreated or deleted, duplicate registry entries collapse to one, and the valid account grant can complete login and start remote synchronization.

```mermaid
flowchart LR
  A[Approved access grant] --> B[Sync authoritative registry]
  B --> C[Deduplicate server and local rooms]
  C --> D{Initial local room returned?}
  D -- Yes --> E[Use synced room]
  D -- No --> F[Keep one local-only room]
  E --> G[Complete login and enable sync]
  F --> G
```

## Validation

- `npm test --workspace @eweser/db` — 128 passed, 1 existing todo
- `npm run type-check --workspace @eweser/db`
- focused ESLint and Prettier checks for all changed files
- repository pre-push autofix, verification, and tracked-secret scan

## Review evidence

No screenshot is included because the patch changes SDK login state and registry reconciliation without changing rendered UI. A production-auth preview would require real credentials and data, so live verification remains gated on merge/deploy approval.
