### PR TITLE
fix(ewe-note): prefer healthy sync status

### DIFF
--- a/packages/ewe-note/src/db.tsx
+++ b/packages/ewe-note/src/db.tsx
@@ -20,6 +20,11 @@ import { logger } from './utils';
 import { useGetUserFromDb } from './user';
 import { getDefaultNoteText } from './default-tutorial';
 import { loginWithPrioritizedNoteSync } from './prioritized-room-sync';
+import {
+  deriveSyncStatus,
+  type DbStatusSnapshot,
+  type EweNoteSyncStatus,
+} from './sync-status';
 
 /** to make sure that we only have one default room created, make a new uuid v4 for the default room, but if there is already one in localStorage use that*/
 const randomRoomId = crypto.randomUUID();
@@ -147,22 +152,6 @@ export type DbContextType = {
   secureRoomMessage: string | null;
 };
 
-export type EweNoteSyncStatus =
-  | 'local-only'
-  | 'signed-out'
-  | 'connecting'
-  | 'synced'
-  | 'offline'
-  | 'auth-unreachable'
-  | 'sync-error';
-
-type DbStatusSnapshot = {
-  online: boolean;
-  hasToken: boolean;
-  connectedRoomsCount: number;
-  connectingRoomsCount: number;
-};
-
 export const DbContext = createContext<DbContextType | null>(null);
 
 export function useDb() {
@@ -182,28 +171,6 @@ const signOut = () => {
 };
 // for detailed debugging
 // db.on('status', (status) => console.log(status));
-
-function deriveSyncStatus({
-  loaded,
-  loggedIn,
-  hasToken,
-  browserOnline,
-  dbStatus,
-}: {
-  loaded: boolean;
-  loggedIn: boolean;
-  hasToken: boolean;
-  browserOnline: boolean;
-  dbStatus: DbStatusSnapshot | null;
-}): EweNoteSyncStatus {
-  if (!browserOnline) return 'offline';
-  if (!hasToken && !loggedIn) return loaded ? 'signed-out' : 'local-only';
-  if (dbStatus?.online === false) return 'auth-unreachable';
-  if (dbStatus?.connectingRoomsCount) return 'connecting';
-  if (dbStatus?.connectedRoomsCount) return 'synced';
-  if (hasToken && !loggedIn) return 'auth-unreachable';
-  return 'local-only';
-}
 
 function getSyncStatusText(status: EweNoteSyncStatus) {
   switch (status) {

--- a/packages/ewe-note/src/sync-status.test.ts
+++ b/packages/ewe-note/src/sync-status.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { deriveSyncStatus } from './sync-status';
+
+describe('deriveSyncStatus', () => {
+  it('reports synced when a connected room exists alongside background connections', () => {
+    expect(
+      deriveSyncStatus({
+        loaded: true,
+        loggedIn: true,
+        hasToken: true,
+        browserOnline: true,
+        dbStatus: {
+          online: true,
+          hasToken: true,
+          connectedRoomsCount: 2,
+          connectingRoomsCount: 1,
+        },
+      })
+    ).toBe('synced');
+  });
+
+  it('reports connecting until the first room connects', () => {
+    expect(
+      deriveSyncStatus({
+        loaded: true,
+        loggedIn: true,
+        hasToken: true,
+        browserOnline: true,
+        dbStatus: {
+          online: true,
+          hasToken: true,
+          connectedRoomsCount: 0,
+          connectingRoomsCount: 1,
+        },
+      })
+    ).toBe('connecting');
+  });
+});

--- a/packages/ewe-note/src/sync-status.ts
+++ b/packages/ewe-note/src/sync-status.ts
@@ -1,0 +1,37 @@
+export type EweNoteSyncStatus =
+  | 'local-only'
+  | 'signed-out'
+  | 'connecting'
+  | 'synced'
+  | 'offline'
+  | 'auth-unreachable'
+  | 'sync-error';
+
+export type DbStatusSnapshot = {
+  online: boolean;
+  hasToken: boolean;
+  connectedRoomsCount: number;
+  connectingRoomsCount: number;
+};
+
+export function deriveSyncStatus({
+  loaded,
+  loggedIn,
+  hasToken,
+  browserOnline,
+  dbStatus,
+}: {
+  loaded: boolean;
+  loggedIn: boolean;
+  hasToken: boolean;
+  browserOnline: boolean;
+  dbStatus: DbStatusSnapshot | null;
+}): EweNoteSyncStatus {
+  if (!browserOnline) return 'offline';
+  if (!hasToken && !loggedIn) return loaded ? 'signed-out' : 'local-only';
+  if (dbStatus?.online === false) return 'auth-unreachable';
+  if (dbStatus?.connectedRoomsCount) return 'synced';
+  if (dbStatus?.connectingRoomsCount) return 'connecting';
+  if (hasToken && !loggedIn) return 'auth-unreachable';
+  return 'local-only';
+}


### PR DESCRIPTION
+## What changed

EweNote now reports **Synced** as soon as at least one room is connected, even while other rooms are still connecting in the background. It continues to report **Connecting** before the first room connects.

## Root cause

The global badge prioritized `connectingRoomsCount` over `connectedRoomsCount`. Accounts with several vaults therefore flickered or stayed on Connecting whenever any background room was reconnecting, even though usable rooms were already synced.

## Impact

The badge now reflects the healthy, usable state and no longer implies that all synchronization has failed because one background room is still connecting.

## Validation

- `npm --prefix packages/ewe-note test -- --run src/sync-status.test.ts` — 2 tests passed
- `npm run build:typecheck-deps && npm --prefix packages/ewe-note run type-check` — passed in a clean disposable clone
- Pre-commit lint, formatting, and secret scan passed
- Pre-push verification and tracked secret scan passed
- [Interactive fixture build](https://wildlife-falling-screenshot-agenda.trycloudflare.com/?review-sync-status=1) — synthetic/local data, review route verified externally
- [Screenshot and test summary](https://wildlife-falling-screenshot-agenda.trycloudflare.com/sync-status-review.html)
- Review runtime expires at approximately 15:49 CST on 2026-08-12
- Cleanup: `kill -- -767403 -770521`

## Visual assessment

The status remains in the existing Sync card without changing layout. Spacing, alignment, wrapping, density, overflow, and dark-theme contrast remain acceptable at the reviewed desktop viewport.

## Sync status flow

```mermaid
flowchart TD
  A[Browser online and authenticated] --> B{Any room connected?}
  B -->|Yes| C[Synced]
  B -->|No| D{Any room connecting?}
  D -->|Yes| E[Connecting]
  D -->|No| F[Local only or auth status]
```

## Review Evidence Checklist

- UI-visible change: Yes
- Screenshots: [attached in review summary](https://wildlife-falling-screenshot-agenda.trycloudflare.com/sync-status-review.html)
- Visual assessment: completed
- Flow/control movement changed: Yes
- Mermaid diagram: included
- Open review comments addressed: N/A

