### PR TITLE
Add mobile sign out control

### DIFF
--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -280,6 +280,32 @@ describe('auth-pages app', () => {
     expect(screen.getAllByText(/ai grants/i).length).toBeGreaterThan(0);
   });
 
+  it('keeps sign out available in the mobile header for signed-in users', async () => {
+    sessionState = {
+      data: {
+        session: { id: 'session-1' },
+        user: { email: 'test@example.com', id: 'user-1' },
+      },
+      error: null,
+      isPending: false,
+      isRefetching: false,
+      refetch: vi.fn().mockResolvedValue(undefined),
+    };
+
+    renderApp('/');
+
+    await screen.findByRole('heading', {
+      name: /everything your apps can touch/i,
+    });
+
+    const mobileSignOut = document.querySelector(
+      '[data-cy="mobile-sign-out-link"]'
+    );
+    expect(mobileSignOut).not.toBeNull();
+    expect(mobileSignOut).toHaveAttribute('href', '/sign-out');
+    expect(mobileSignOut?.parentElement).toHaveClass('md:hidden');
+  });
+
   it('uses local redirect query params after normal sign-in', async () => {
     authMocks.signInEmail.mockResolvedValue({
       data: {

--- a/packages/app/src/pages.tsx
+++ b/packages/app/src/pages.tsx
@@ -9,6 +9,7 @@ import {
   FileText,
   Github,
   LockKeyhole,
+  LogOut,
   Moon,
   PlugZap,
   RefreshCw,
@@ -260,6 +261,22 @@ function SiteHeader() {
             EweserDB
           </span>
         </Link>
+
+        {session.data?.user ? (
+          <nav
+            className="flex items-center md:hidden"
+            aria-label="Account actions"
+          >
+            <Link
+              className="inline-flex min-h-11 items-center gap-2 rounded-xl border border-input bg-background/55 px-3 text-sm font-medium text-foreground no-underline transition-colors hover:bg-accent"
+              data-cy="mobile-sign-out-link"
+              to="/sign-out"
+            >
+              <LogOut className="h-4 w-4" />
+              Sign out
+            </Link>
+          </nav>
+        ) : null}
 
         <nav className="hidden items-center gap-6 md:flex">
           {session.data?.user ? (


### PR DESCRIPTION
## What changed

Adds an explicit `Sign out` control to the signed-in mobile header on Eweser account pages.

## Why

The signed-in header previously hid all navigation below the desktop breakpoint. On a phone, the account security page provided no discoverable way to end the session.

## Impact

Mobile users can now reach the existing `/sign-out` route from every account page. The logout behavior itself is unchanged.

## Validation

- `npm test --workspace @eweser/app` (24 passing)
- `npm run type-check --workspace @eweser/app`
- `npx prettier --check packages/app/src/pages.tsx packages/app/src/App.test.tsx`
- Mobile browser checkpoint at 390 × 844 with synthetic account data
