### PR TITLE
Refine mobile account navigation

### DIFF
--- a/docs/ai/plans/2026-08-13-mobile-account-navigation-and-security.md
+++ b/docs/ai/plans/2026-08-13-mobile-account-navigation-and-security.md
@@ -1,0 +1,95 @@
+# Plan: Mobile Account Navigation And Security Simplification
+
+## Goal
+
+Give signed-in mobile users a compact Account menu, while making the Security page calm, state-aware, and safe to operate.
+
+## Scope
+
+- In: Mobile Account sheet navigation, theme control, separated sign-out action, responsive account-shell cleanup, state-aware 2FA controls, plain-language security copy, action-local status feedback, and focused tests.
+- Out: Database migrations, passkey support, active-session management, account deletion, and public package API changes.
+
+## Assumptions / Open Questions
+
+- Assumption: `twoFactorEnabled` on the authenticated auth-server user is the canonical 2FA state and can be returned by the existing bootstrap endpoint.
+- Assumption: The user's “Do these now in one go” approves this plan and its security UX behavior, including confirmation before disabling 2FA or replacing backup codes.
+
+## Domain Language
+
+- Glossary docs: `GLOSSARY.md`, `packages/auth-server-hono/GLOSSARY.md`.
+- New terms: None.
+- Changed terms: Use “two-factor authentication” and “backup codes” in user copy; do not expose implementation dependencies as product copy.
+- ADR candidates: None; this is a bounded UI and existing bootstrap-response change.
+
+## Runs
+
+## Run Order And Manual Test Handoffs
+
+Run order: Sequential. Run 1 defines the bootstrap state consumed by Run 2.
+
+### Run 1: Expose Two-Factor State
+
+- **Id**: `run-1`
+- **Title**: Expose two-factor status through the existing account bootstrap response
+- **UI classification**: `ui: false`
+- **Browser checkpoint**: `none`
+- **Deliverable**: Signed-in clients can distinguish two-factor setup from management without inference.
+- **Files**:
+  - `packages/auth-server-hono/src/routes/account.ts`: include the authenticated user's two-factor state in bootstrap.
+  - `packages/auth-server-hono/src/routes/account.test.ts`: verify the bounded response field.
+  - `packages/app/src/lib/api.ts`: type the response field.
+- **Steps**:
+  - [ ] Add the boolean state without widening other identity data.
+  - [ ] Cover the response contract with a route test.
+- **Tests**: `npm test --workspace @eweser/auth-server-hono`.
+- **Verification**: Confirm only the signed-in account bootstrap response receives the state.
+- **Manual test handoff**: Not needed: the state is exercised through Run 2.
+- **Dependencies**: None.
+- **Model tier**: `strong`
+- **Risk level**: `medium`
+
+### Run 2: Mobile Navigation And Security Flow
+
+- **Id**: `run-2`
+- **Title**: Implement the compact mobile account sheet and simplified Security page
+- **UI classification**: `ui: true`
+- **Browser checkpoint**: `focused`
+- **Deliverable**: Mobile header has one compact Account control; Security shows one context-appropriate 2FA path with confirmations for destructive recovery actions.
+- **Files**:
+  - `packages/app/src/pages.tsx`: account sheet, state-aware 2FA UI, plain-language copy, local status feedback.
+  - `packages/app/src/index.css`: mobile sheet, reduced settings surface hierarchy, and responsive sidebar behavior.
+  - `packages/app/src/App.test.tsx`: navigation and security-state behavior tests.
+- **Steps**:
+  - [ ] Replace the mobile header sign-out button with an accessible Account menu containing navigation, theme choice, and a separated “Sign out of this device” action.
+  - [ ] Remove the duplicated mobile sidebar navigation.
+  - [ ] Replace the card-heavy Security overview with compact status rows and actionable-only copy.
+  - [ ] Render setup, enrollment, and management states separately; require an explicit confirmation before disabling 2FA or regenerating backup codes.
+  - [ ] Announce action-local success and errors.
+- **Tests**: `npm test --workspace @eweser/app`; `npm run type-check --workspace @eweser/app`; `npm run build --workspace @eweser/app`.
+- **Verification**: Focused signed-in mobile browser checkpoint using synthetic local data, including opening the Account sheet and reviewing the Security setup state.
+- **Manual test handoff**:
+  - Start the local app against fixture auth data.
+  - At 390px, open `/security`, then Account; verify navigation, theme action, and separated sign-out row.
+  - Verify that a user without 2FA sees only setup; verify management actions require explicit confirmation when 2FA is enabled.
+- **Dependencies**: `run-1`.
+- **Model tier**: `strong`
+- **Risk level**: `high`
+
+## Stop Conditions
+
+Stop and ask for user approval if implementation requires migrations, changes to the underlying Better Auth 2FA protocol, public package API changes, or a security behavior outside the stated confirmation and status UX.
+
+## Approval Boundary
+
+The user's approval in this conversation authorizes Coder to implement the runs above, write focused tests, perform browser verification with synthetic data, commit, push a feature branch, and open a ready-for-review PR. It does not authorize direct main pushes, production deployment, credential handling, migrations, or unrelated account redesign.
+
+## Execution Summary
+
+| Run     | Status   | Files Changed                                                 | Verification                                                                                        | Notes                                                                                                                   |
+| ------- | -------- | ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `run-1` | Complete | `account.ts`, `account.test.ts`, `api.ts`                     | 10 focused route tests pass                                                                         | Bootstrap reads the canonical account record and returns only the boolean state.                                        |
+| `run-2` | Complete | Account sheet, Security UI, responsive CSS, focused app tests | 28 app tests, app type-check and production build pass; 390px synthetic browser checkpoint complete | Included a portal to keep the sheet above the sticky header, a QR enrollment step, and destructive-action confirmation. |
+
+## Self-Reflection / Instruction Improvements
+
+- The auth-server workspace type-check remains blocked by unrelated existing missing `@eweser/logger` declarations and access-grant request typing. The changed bootstrap field type-checks through the focused route test, while the app type-check passes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -33652,6 +33652,15 @@
         "qrcode-terminal": "bin/qrcode-terminal.js"
       }
     },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/qs": {
       "version": "6.14.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
@@ -42092,6 +42101,7 @@
         "clsx": "^2.1.1",
         "lucide-react": "^0.553.0",
         "next-themes": "^0.4.6",
+        "qrcode.react": "^4.2.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.9.6"

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -34,12 +34,13 @@ npm run dev
 
 ## Environment Variables
 
-| Variable                  | Description                                               |
-| ------------------------- | --------------------------------------------------------- |
-| `VITE_AUTH_SERVER_URL`    | URL of the auth API server                                |
-| `VITE_AUTH_API_URL`       | Auth client base URL. Defaults to same-origin `/api/auth` |
-| `AUTH_API_PROXY_URL`      | Runtime nginx proxy target for same-origin auth paths     |
-| `VITE_TURNSTILE_SITE_KEY` | Optional Cloudflare Turnstile site key for signup captcha |
+| Variable                  | Description                                                 |
+| ------------------------- | ----------------------------------------------------------- |
+| `VITE_AUTH_SERVER_URL`    | URL of the auth API server                                  |
+| `VITE_AUTH_API_URL`       | Auth client base URL. Defaults to same-origin `/api/auth`   |
+| `AUTH_API_PROXY_URL`      | Runtime nginx proxy target for same-origin auth paths       |
+| `AUTH_SERVER_TARGET`      | Vite development proxy target; never exposed to the browser |
+| `VITE_TURNSTILE_SITE_KEY` | Optional Cloudflare Turnstile site key for signup captcha   |
 
 ## Docker
 

--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <link rel="icon" href="/src/assets/eweser-logo.svg" type="image/svg+xml" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Eweser App</title>
   </head>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -18,6 +18,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.553.0",
     "next-themes": "^0.4.6",
+    "qrcode.react": "^4.2.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.9.6"

--- a/packages/app/src/App.test.tsx
+++ b/packages/app/src/App.test.tsx
@@ -1,4 +1,10 @@
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MemoryRouter, useNavigate } from 'react-router-dom';
@@ -219,6 +225,7 @@ describe('auth-pages app', () => {
         id: 'user-1',
         image: null,
         name: 'Test User',
+        twoFactorEnabled: false,
       },
       userCount: 1,
     });
@@ -292,7 +299,7 @@ describe('auth-pages app', () => {
     expect(screen.getAllByText(/ai grants/i).length).toBeGreaterThan(0);
   });
 
-  it('keeps sign out available in the mobile header for signed-in users', async () => {
+  it('keeps sign out in the mobile account menu for signed-in users', async () => {
     sessionState = {
       data: {
         session: { id: 'session-1' },
@@ -310,12 +317,22 @@ describe('auth-pages app', () => {
       name: /everything your apps can touch/i,
     });
 
-    const mobileSignOut = document.querySelector(
-      '[data-cy="mobile-sign-out-link"]'
+    await userEvent.click(
+      screen.getByRole('button', { name: /open account menu/i })
     );
-    expect(mobileSignOut).not.toBeNull();
+
+    const mobileSignOut = screen.getByRole('link', {
+      name: /sign out of this device/i,
+    });
     expect(mobileSignOut).toHaveAttribute('href', '/sign-out');
-    expect(mobileSignOut?.parentElement).toHaveClass('md:hidden');
+    expect(
+      screen.getByRole('navigation', { name: /account navigation/i })
+    ).toBeInTheDocument();
+    expect(
+      within(
+        screen.getByRole('complementary', { name: /account menu/i })
+      ).getByRole('button', { name: /use light theme/i })
+    ).toBeInTheDocument();
   });
 
   it('uses local redirect query params after normal sign-in', async () => {
@@ -383,6 +400,7 @@ describe('auth-pages app', () => {
         id: 'user-1',
         image: null,
         name: 'Test User',
+        twoFactorEnabled: false,
       },
       userCount: 1,
     });
@@ -1050,6 +1068,7 @@ describe('auth-pages app', () => {
         id: 'user-1',
         image: null,
         name: 'Test User',
+        twoFactorEnabled: false,
       },
       userCount: 1,
     });
@@ -1169,6 +1188,7 @@ describe('auth-pages app', () => {
         id: 'user-1',
         image: null,
         name: 'Test User',
+        twoFactorEnabled: false,
       },
       userCount: 1,
     });
@@ -1176,7 +1196,63 @@ describe('auth-pages app', () => {
     renderApp('/account/security');
 
     expect(
-      await screen.findByRole('heading', { name: /keep your account tight/i })
+      await screen.findByRole('heading', { name: /^security$/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: /set up two-factor authentication/i,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /turn off 2fa/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('requires confirmation before replacing backup codes', async () => {
+    sessionState = {
+      data: {
+        session: { id: 'session-1' },
+        user: { email: 'test@example.com', id: 'user-1' },
+      },
+      error: null,
+      isPending: false,
+      isRefetching: false,
+      refetch: vi.fn().mockResolvedValue(undefined),
+    };
+    apiMocks.getAccountBootstrap.mockResolvedValue({
+      profileRooms: [],
+      rooms: [],
+      user: {
+        email: 'test@example.com',
+        emailVerified: true,
+        id: 'user-1',
+        image: null,
+        name: 'Test User',
+        twoFactorEnabled: true,
+      },
+      userCount: 1,
+    });
+
+    renderApp('/security');
+
+    await userEvent.click(
+      await screen.findByRole('button', {
+        name: /manage two-factor authentication/i,
+      })
+    );
+    await userEvent.type(
+      screen.getByLabelText(/current password/i),
+      'password'
+    );
+    await userEvent.click(
+      screen.getByRole('button', { name: /replace backup codes/i })
+    );
+
+    expect(
+      screen.getByText(/replace your backup codes\?/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /replace backup codes/i })
     ).toBeInTheDocument();
   });
 });

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -544,6 +544,14 @@ body,
     box-shadow: var(--shadow-small);
   }
 
+  .app-page-hero-plain {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 1rem;
+    align-items: end;
+    margin: 0.5rem 0 1.5rem;
+  }
+
   .app-page-title,
   .mcp-hero-title {
     margin: 0.4rem 0 0;
@@ -637,6 +645,60 @@ body,
     background: var(--surface-raised);
     padding: 1.15rem;
     box-shadow: var(--shadow-small);
+  }
+
+  .app-settings-group {
+    border-top: 1px solid var(--surface-line);
+    border-bottom: 1px solid var(--surface-line);
+    margin-bottom: 1rem;
+  }
+
+  .app-settings-row {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    gap: 0.85rem;
+    align-items: center;
+    padding: 1rem 0;
+  }
+
+  .app-settings-row + .app-settings-row {
+    border-top: 1px solid var(--surface-line);
+  }
+
+  .app-settings-row h2 {
+    margin: 0;
+    color: var(--foreground);
+    font-size: 1rem;
+    font-weight: 760;
+    letter-spacing: -0.02em;
+  }
+
+  .app-settings-row p,
+  .app-confirmation-panel p {
+    margin: 0.3rem 0 0;
+    color: var(--muted-foreground);
+    font-size: 0.86rem;
+    line-height: 1.5;
+  }
+
+  .app-settings-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 0.8rem;
+    background: var(--accent);
+    color: var(--primary);
+  }
+
+  .app-settings-icon-muted {
+    background: var(--surface-soft);
+    color: var(--muted-foreground);
+  }
+
+  .app-security-panel {
+    max-width: 58rem;
   }
 
   .app-panel + .app-panel,
@@ -833,6 +895,130 @@ body,
     display: flex;
     flex-wrap: wrap;
     gap: 0.7rem;
+  }
+
+  .app-security-management {
+    display: grid;
+    gap: 1rem;
+    max-width: 38rem;
+  }
+
+  .app-confirmation-panel {
+    border: 1px solid oklch(from var(--destructive) l c h / 0.5);
+    border-radius: 1rem;
+    background: oklch(from var(--destructive) l c h / 0.1);
+    padding: 1rem;
+  }
+
+  .app-totp-setup-panel {
+    max-width: 30rem;
+  }
+
+  .app-totp-qr {
+    display: grid;
+    width: fit-content;
+    margin: 1rem 0;
+    border-radius: 0.9rem;
+    background: var(--foreground);
+    padding: 0.75rem;
+    color: var(--background);
+  }
+
+  .app-action-notice,
+  .app-action-error {
+    margin: 1rem 0 0;
+    border-radius: 0.85rem;
+    padding: 0.8rem 0.95rem;
+    font-size: 0.86rem;
+    line-height: 1.45;
+  }
+
+  .app-action-notice {
+    background: oklch(from var(--primary) l c h / 0.14);
+    color: var(--foreground);
+  }
+
+  .app-action-error {
+    background: oklch(from var(--destructive) l c h / 0.12);
+    color: var(--destructive);
+  }
+
+  .mobile-account-menu {
+    position: relative;
+  }
+
+  .mobile-account-menu-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 60;
+    border: 0;
+    background: oklch(0.08 0.02 176 / 0.55);
+  }
+
+  .mobile-account-menu-sheet {
+    position: fixed;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 61;
+    display: grid;
+    gap: 0.75rem;
+    border: 1px solid var(--surface-line);
+    border-bottom: 0;
+    border-radius: 1.35rem 1.35rem 0 0;
+    background: var(--surface-raised);
+    box-shadow: 0 -24px 64px oklch(0.06 0.02 176 / 0.42);
+    padding: 1rem;
+  }
+
+  .mobile-account-menu-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .mobile-account-menu-heading h2 {
+    margin: 0.18rem 0 0;
+    color: var(--foreground);
+    font-size: 1.15rem;
+    letter-spacing: -0.02em;
+  }
+
+  .mobile-account-menu-links {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.45rem;
+  }
+
+  .mobile-account-menu-links a,
+  .mobile-account-menu-sign-out {
+    display: flex;
+    min-height: 2.75rem;
+    align-items: center;
+    gap: 0.65rem;
+    border-radius: 0.8rem;
+    padding: 0.7rem 0.8rem;
+    color: var(--foreground);
+    font-size: 0.88rem;
+    font-weight: 700;
+    text-decoration: none;
+  }
+
+  .mobile-account-menu-links a {
+    background: var(--surface-soft);
+  }
+
+  .mobile-account-menu-preferences {
+    border-top: 1px solid var(--surface-line);
+    padding-top: 0.6rem;
+  }
+
+  .mobile-account-menu-sign-out {
+    border-top: 1px solid var(--surface-line);
+    border-radius: 0;
+    padding-top: 1rem;
+    color: var(--muted-foreground);
   }
 
   .app-code-panel,
@@ -1280,6 +1466,7 @@ body,
   @media (max-width: 1100px) {
     .auth-grid,
     .app-page-hero,
+    .app-page-hero-plain,
     .app-two-column,
     .app-form-grid,
     .mcp-hero,
@@ -1330,19 +1517,7 @@ body,
     }
 
     .app-sidebar {
-      position: relative;
-      top: 0;
-      height: auto;
-      border-right: 0;
-      border-bottom: 1px solid var(--surface-line);
-    }
-
-    .app-sidebar-card {
       display: none;
-    }
-
-    .app-nav {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
     .auth-proof-list,
@@ -1354,6 +1529,11 @@ body,
   }
 
   @media (max-width: 620px) {
+    .app-site-header-content {
+      height: 4rem;
+      padding-inline: 1rem;
+    }
+
     .auth-grid,
     .app-page,
     .mcp-page {
@@ -1371,7 +1551,30 @@ body,
       font-size: 2.15rem;
     }
 
-    .app-nav {
+    .app-settings-row {
+      grid-template-columns: auto minmax(0, 1fr);
+      align-items: start;
+    }
+
+    .app-settings-row > :last-child {
+      grid-column: 2;
+      justify-self: start;
+    }
+
+    .app-form-grid {
+      align-items: stretch;
+    }
+
+    .app-form-grid > .inline-flex {
+      width: 100%;
+    }
+
+    .app-button-cluster > button,
+    .app-form-grid > button {
+      min-height: 2.75rem;
+    }
+
+    .mobile-account-menu-links {
       grid-template-columns: 1fr;
     }
   }

--- a/packages/app/src/lib/api.ts
+++ b/packages/app/src/lib/api.ts
@@ -12,6 +12,7 @@ export interface AuthPagesUser {
   emailVerified: boolean;
   image: string | null;
   name: string | null;
+  twoFactorEnabled: boolean;
 }
 
 export interface AccountBootstrapResponse {

--- a/packages/app/src/pages.tsx
+++ b/packages/app/src/pages.tsx
@@ -2933,11 +2933,22 @@ function SecurityPage() {
               });
             }}
           >
+            <input
+              aria-hidden="true"
+              autoComplete="username"
+              className="sr-only"
+              name="username"
+              readOnly
+              tabIndex={-1}
+              type="email"
+              value={bootstrap?.user.email ?? ''}
+            />
             <div className="space-y-2">
               <Label htmlFor="security-password">Current password</Label>
               <Input
                 autoComplete="current-password"
                 id="security-password"
+                name="current-password"
                 onChange={(event) => setPassword(event.target.value)}
                 type="password"
                 value={password}

--- a/packages/app/src/pages.tsx
+++ b/packages/app/src/pages.tsx
@@ -10,15 +10,19 @@ import {
   Github,
   LockKeyhole,
   LogOut,
+  Menu,
   Moon,
   PlugZap,
   RefreshCw,
   ShieldCheck,
   Sun,
   UserRound,
+  X,
 } from 'lucide-react';
 import { ThemeProvider, useTheme } from 'next-themes';
+import { QRCodeSVG } from 'qrcode.react';
 import { useEffect, useMemo, useState, type FormEvent } from 'react';
+import { createPortal } from 'react-dom';
 import EweserLogo from './assets/eweser-logo.svg';
 import heroPastureImage from './assets/hero-orbit-house.png';
 import loginDarkImage from './assets/login-dark.png';
@@ -230,19 +234,135 @@ function getConnectedClientCount(overview: ConnectAiOverviewResponse | null) {
   );
 }
 
-function ThemeToggle() {
+function ThemeToggle({ fullWidth = false }: { fullWidth?: boolean }) {
   const { resolvedTheme, setTheme } = useTheme();
   const isDark = resolvedTheme === 'dark';
+  const label = isDark ? 'Use light theme' : 'Use dark theme';
 
   return (
     <Button
-      aria-label="Toggle theme"
+      aria-label={label}
+      className={
+        fullWidth
+          ? '!h-11 w-full justify-start gap-3 rounded-xl px-3 text-left'
+          : undefined
+      }
       tone="ghost"
       type="button"
       onClick={() => setTheme(isDark ? 'light' : 'dark')}
     >
       {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+      {fullWidth ? <span>{isDark ? 'Light theme' : 'Dark theme'}</span> : null}
     </Button>
+  );
+}
+
+function MobileAccountMenu() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    function closeOnEscape(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        setIsOpen(false);
+      }
+    }
+
+    window.addEventListener('keydown', closeOnEscape);
+    return () => window.removeEventListener('keydown', closeOnEscape);
+  }, [isOpen]);
+
+  const close = () => setIsOpen(false);
+  const accountSheet = isOpen ? (
+    <>
+      <button
+        aria-label="Close account menu"
+        className="mobile-account-menu-backdrop"
+        type="button"
+        onClick={close}
+      />
+      <aside
+        aria-label="Account menu"
+        className="mobile-account-menu-sheet"
+        id="mobile-account-menu-sheet"
+      >
+        <div className="mobile-account-menu-heading">
+          <div>
+            <p className="mcp-eyebrow">EweserDB</p>
+            <h2>Account</h2>
+          </div>
+          <Button
+            aria-label="Close account menu"
+            className="!h-11 !w-11 !rounded-xl !px-0"
+            tone="ghost"
+            type="button"
+            onClick={close}
+          >
+            <X className="h-5 w-5" />
+          </Button>
+        </div>
+
+        <nav
+          className="mobile-account-menu-links"
+          aria-label="Account navigation"
+        >
+          <Link to="/" onClick={close}>
+            <Database className="h-4 w-4" />
+            Data Home
+          </Link>
+          <Link to="/apps" onClick={close}>
+            <PlugZap className="h-4 w-4" />
+            Apps
+          </Link>
+          <Link to="/ai" onClick={close}>
+            <Bot className="h-4 w-4" />
+            MCP clients
+          </Link>
+          <Link to="/home" onClick={close}>
+            <UserRound className="h-4 w-4" />
+            Account
+          </Link>
+          <Link to="/security" onClick={close}>
+            <ShieldCheck className="h-4 w-4" />
+            Security
+          </Link>
+        </nav>
+
+        <div className="mobile-account-menu-preferences">
+          <ThemeToggle fullWidth />
+        </div>
+
+        <Link
+          className="mobile-account-menu-sign-out"
+          data-cy="mobile-sign-out-link"
+          to="/sign-out"
+          onClick={close}
+        >
+          <LogOut className="h-4 w-4" />
+          Sign out of this device
+        </Link>
+      </aside>
+    </>
+  ) : null;
+
+  return (
+    <div className="mobile-account-menu md:hidden">
+      <Button
+        aria-controls="mobile-account-menu-sheet"
+        aria-expanded={isOpen}
+        aria-label="Open account menu"
+        className="!h-11 !w-11 !rounded-xl !px-0"
+        tone="ghost"
+        type="button"
+        onClick={() => setIsOpen((open) => !open)}
+      >
+        <Menu className="h-5 w-5" />
+      </Button>
+      {accountSheet ? createPortal(accountSheet, document.body) : null}
+    </div>
   );
 }
 
@@ -251,7 +371,7 @@ function SiteHeader() {
 
   return (
     <header className="sticky top-0 z-50 border-b border-border/70 bg-background/80 backdrop-blur-xl">
-      <div className="mx-auto flex h-20 max-w-7xl items-center justify-between px-6">
+      <div className="app-site-header-content mx-auto flex h-20 max-w-7xl items-center justify-between px-6">
         <Link className="flex items-center gap-3 no-underline" to="/">
           <img
             alt="EweserDB"
@@ -264,21 +384,7 @@ function SiteHeader() {
           </span>
         </Link>
 
-        {session.data?.user ? (
-          <nav
-            className="flex items-center md:hidden"
-            aria-label="Account actions"
-          >
-            <Link
-              className="inline-flex min-h-11 items-center gap-2 rounded-xl border border-input bg-background/55 px-3 text-sm font-medium text-foreground no-underline transition-colors hover:bg-accent"
-              data-cy="mobile-sign-out-link"
-              to="/sign-out"
-            >
-              <LogOut className="h-4 w-4" />
-              Sign out
-            </Link>
-          </nav>
-        ) : null}
+        {session.data?.user ? <MobileAccountMenu /> : null}
 
         <nav className="hidden items-center gap-6 md:flex">
           {session.data?.user ? (
@@ -303,15 +409,15 @@ function SiteHeader() {
               </Link>
               <Link
                 className="text-sm text-muted-foreground no-underline transition-colors hover:text-foreground"
-                to="/sign-out"
-              >
-                Sign out
-              </Link>
-              <Link
-                className="text-sm text-muted-foreground no-underline transition-colors hover:text-foreground"
                 to="/security"
               >
                 Security
+              </Link>
+              <Link
+                className="text-sm text-muted-foreground no-underline transition-colors hover:text-foreground"
+                to="/sign-out"
+              >
+                Sign out
               </Link>
             </>
           ) : (
@@ -433,15 +539,19 @@ function AppPageHero({
   actions,
   body,
   eyebrow,
+  surface = 'card',
   title,
 }: {
   actions?: React.ReactNode;
   body: string;
   eyebrow: string;
+  surface?: 'card' | 'plain';
   title: string;
 }) {
   return (
-    <section className="app-page-hero">
+    <section
+      className={surface === 'plain' ? 'app-page-hero-plain' : 'app-page-hero'}
+    >
       <div>
         <p className="mcp-eyebrow">{eyebrow}</p>
         <h1 className="app-page-title">{title}</h1>
@@ -2678,10 +2788,15 @@ function SecurityPage() {
     null
   );
   const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
   const [password, setPassword] = useState('');
   const [totpUri, setTotpUri] = useState<string | null>(null);
   const [totpCode, setTotpCode] = useState('');
   const [backupCodes, setBackupCodes] = useState<string[]>([]);
+  const [showManagement, setShowManagement] = useState(false);
+  const [pendingAction, setPendingAction] = useState<
+    'disable' | 'regenerate' | null
+  >(null);
   const [working, setWorking] = useState(false);
 
   useEffect(() => {
@@ -2692,6 +2807,7 @@ function SecurityPage() {
 
   async function runAction(action: () => Promise<void>) {
     setError(null);
+    setNotice(null);
     setWorking(true);
     try {
       await action();
@@ -2706,6 +2822,16 @@ function SecurityPage() {
     }
   }
 
+  async function refreshBootstrap() {
+    const result = await getAccountBootstrap();
+    setBootstrap(result);
+    return result;
+  }
+
+  const twoFactorEnabled = bootstrap?.user.twoFactorEnabled;
+  const isEnrolling = totpUri !== null;
+  const isManaging = twoFactorEnabled === true && showManagement;
+
   return (
     <AppConsoleLayout
       active="security"
@@ -2715,23 +2841,28 @@ function SecurityPage() {
       }}
     >
       <AppPageHero
-        body="Email verification, password, two-factor controls, and active session management live here."
+        body="Manage sign-in verification and recovery for this device."
         eyebrow="Security"
-        title="Keep your account tight."
+        surface="plain"
+        title="Security"
       />
 
-      <div className="app-two-column">
-        <section className="app-panel">
-          <div className="app-panel-header">
-            <div>
-              <h2>Email verification</h2>
-              <p>Verification is required for sensitive account actions.</p>
-            </div>
-            <span className="app-status-pill">
-              {bootstrap?.user.emailVerified ? 'Verified' : 'Unverified'}
-            </span>
+      <section className="app-settings-group" aria-label="Security status">
+        <div className="app-settings-row">
+          <span className="app-settings-icon" aria-hidden="true">
+            <CheckCircle2 className="h-5 w-5" />
+          </span>
+          <div>
+            <h2>Email verification</h2>
+            <p>
+              {bootstrap?.user.emailVerified
+                ? 'Your email can be used for account recovery and alerts.'
+                : 'Verify your email before making sensitive account changes.'}
+            </p>
           </div>
-          {!bootstrap?.user.emailVerified ? (
+          {bootstrap?.user.emailVerified ? (
+            <span className="app-status-pill">Verified</span>
+          ) : (
             <Button
               disabled={working}
               tone="outline"
@@ -2741,117 +2872,215 @@ function SecurityPage() {
                   await postAuthJson('/send-verification-email', {
                     callbackURL: appAbsoluteUrl('/verify-email'),
                   });
+                  setNotice('A verification email has been sent.');
                 })
               }
             >
-              {working ? <InlineSpinner /> : 'Resend verification email'}
+              {working ? <InlineSpinner /> : 'Send email'}
             </Button>
-          ) : (
-            <div className="app-request-preview">
-              <span className="app-empty-icon" aria-hidden="true">
-                <CheckCircle2 className="h-5 w-5" />
-              </span>
-              <div>
-                <strong>Email verified</strong>
-                <p>Your email can be used for account recovery and alerts.</p>
-              </div>
-            </div>
           )}
-        </section>
+        </div>
 
-        <section className="app-panel">
-          <div className="app-panel-header">
-            <div>
-              <h2>Passkeys</h2>
-              <p>
-                WebAuthn is deferred until this better-auth version exposes a
-                stable passkey plugin.
-              </p>
-            </div>
-            <span className="mcp-chip">Planned</span>
+        <div className="app-settings-row">
+          <span
+            className="app-settings-icon app-settings-icon-muted"
+            aria-hidden="true"
+          >
+            <LockKeyhole className="h-5 w-5" />
+          </span>
+          <div>
+            <h2>Passkeys</h2>
+            <p>Passkeys are not available yet.</p>
           </div>
-        </section>
-      </div>
+          <span className="app-status-pill app-status-muted">Unavailable</span>
+        </div>
+      </section>
 
-      <section className="app-panel">
+      <section className="app-panel app-security-panel">
         <div className="app-panel-header">
           <div>
             <h2>Two-factor authentication</h2>
             <p>
-              Use your current password to enable, disable, or refresh TOTP.
+              {twoFactorEnabled === undefined
+                ? 'Checking your two-factor status.'
+                : twoFactorEnabled
+                  ? 'Two-factor authentication is on for your account.'
+                  : 'Add an authenticator app to protect your account.'}
             </p>
           </div>
-          <span className="mcp-chip">TOTP</span>
+          {twoFactorEnabled !== undefined ? (
+            <span className="mcp-chip">{twoFactorEnabled ? 'On' : 'Off'}</span>
+          ) : null}
         </div>
 
-        <div className="app-form-grid">
-          <div className="space-y-2">
-            <Label htmlFor="security-password">Current password</Label>
-            <Input
-              id="security-password"
-              onChange={(event) => setPassword(event.target.value)}
-              type="password"
-              value={password}
-            />
-          </div>
+        {twoFactorEnabled === false && !isEnrolling ? (
+          <form
+            className="app-form-grid"
+            onSubmit={(event) => {
+              event.preventDefault();
+              void runAction(async () => {
+                const result = await postAuthJson<{
+                  backupCodes: string[];
+                  totpURI: string;
+                }>('/two-factor/enable', {
+                  password,
+                });
+                setTotpUri(result.totpURI);
+                setBackupCodes(result.backupCodes);
+                setNotice(
+                  'Add this account to your authenticator, then enter its six-digit code.'
+                );
+              });
+            }}
+          >
+            <div className="space-y-2">
+              <Label htmlFor="security-password">Current password</Label>
+              <Input
+                autoComplete="current-password"
+                id="security-password"
+                onChange={(event) => setPassword(event.target.value)}
+                type="password"
+                value={password}
+              />
+            </div>
+            <Button disabled={working || password.length < 1} type="submit">
+              {working ? <InlineSpinner /> : 'Set up two-factor authentication'}
+            </Button>
+          </form>
+        ) : null}
 
-          <div className="app-button-cluster">
-            <Button
-              disabled={working || password.length < 1}
-              type="button"
-              onClick={() =>
-                void runAction(async () => {
-                  const result = await postAuthJson<{
-                    backupCodes: string[];
-                    totpURI: string;
-                  }>('/two-factor/enable', {
-                    password,
-                  });
-                  setTotpUri(result.totpURI);
-                  setBackupCodes(result.backupCodes);
-                })
-              }
-            >
-              Enable 2FA
-            </Button>
-            <Button
-              disabled={working || password.length < 1}
-              tone="outline"
-              type="button"
-              onClick={() =>
-                void runAction(async () => {
-                  await postAuthJson('/two-factor/disable', { password });
-                  setTotpUri(null);
-                })
-              }
-            >
-              Disable 2FA
-            </Button>
-            <Button
-              disabled={working || password.length < 1}
-              tone="outline"
-              type="button"
-              onClick={() =>
-                void runAction(async () => {
-                  const result = await postAuthJson<{ backupCodes: string[] }>(
-                    '/two-factor/generate-backup-codes',
-                    { password }
-                  );
-                  setBackupCodes(result.backupCodes);
-                })
-              }
-            >
-              Regenerate backup codes
-            </Button>
+        {twoFactorEnabled === true && !isManaging ? (
+          <Button type="button" onClick={() => setShowManagement(true)}>
+            Manage two-factor authentication
+          </Button>
+        ) : null}
+
+        {isManaging ? (
+          <div className="app-security-management">
+            <div className="space-y-2">
+              <Label htmlFor="security-password">Current password</Label>
+              <Input
+                autoComplete="current-password"
+                id="security-password"
+                onChange={(event) => setPassword(event.target.value)}
+                type="password"
+                value={password}
+              />
+            </div>
+
+            {pendingAction ? (
+              <div className="app-confirmation-panel">
+                <p className="font-medium text-foreground">
+                  {pendingAction === 'disable'
+                    ? 'Turn off two-factor authentication?'
+                    : 'Replace your backup codes?'}
+                </p>
+                <p>
+                  {pendingAction === 'disable'
+                    ? 'You will no longer need an authenticator app to sign in.'
+                    : 'Your previous backup codes will stop working.'}
+                </p>
+                <div className="app-button-cluster">
+                  <Button
+                    disabled={working || password.length < 1}
+                    tone="danger"
+                    type="button"
+                    onClick={() =>
+                      void runAction(async () => {
+                        if (pendingAction === 'disable') {
+                          await postAuthJson('/two-factor/disable', {
+                            password,
+                          });
+                          setBootstrap((current) =>
+                            current
+                              ? {
+                                  ...current,
+                                  user: {
+                                    ...current.user,
+                                    twoFactorEnabled: false,
+                                  },
+                                }
+                              : current
+                          );
+                          setShowManagement(false);
+                          setNotice('Two-factor authentication is off.');
+                        } else {
+                          const result = await postAuthJson<{
+                            backupCodes: string[];
+                          }>('/two-factor/generate-backup-codes', { password });
+                          setBackupCodes(result.backupCodes);
+                          setNotice(
+                            'New backup codes are ready. Store them somewhere safe.'
+                          );
+                        }
+                        setPendingAction(null);
+                      })
+                    }
+                  >
+                    {working ? (
+                      <InlineSpinner />
+                    ) : pendingAction === 'disable' ? (
+                      'Turn off 2FA'
+                    ) : (
+                      'Replace backup codes'
+                    )}
+                  </Button>
+                  <Button
+                    disabled={working}
+                    tone="ghost"
+                    type="button"
+                    onClick={() => setPendingAction(null)}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <div className="app-button-cluster">
+                <Button
+                  disabled={working || password.length < 1}
+                  tone="outline"
+                  type="button"
+                  onClick={() => setPendingAction('regenerate')}
+                >
+                  Replace backup codes
+                </Button>
+                <Button
+                  disabled={working || password.length < 1}
+                  tone="danger"
+                  type="button"
+                  onClick={() => setPendingAction('disable')}
+                >
+                  Turn off 2FA
+                </Button>
+              </div>
+            )}
           </div>
-        </div>
+        ) : null}
 
         {totpUri ? (
-          <div className="app-code-panel">
-            <p className="text-sm font-medium">TOTP URI</p>
-            <p className="break-all text-xs text-muted-foreground">{totpUri}</p>
+          <div className="app-code-panel app-totp-setup-panel">
+            <p className="text-sm font-medium">Set up your authenticator</p>
+            <p className="text-sm text-muted-foreground">
+              Scan the code with your authenticator app, then enter its code
+              below.
+            </p>
+            <div
+              className="app-totp-qr"
+              aria-label="Authenticator setup QR code"
+            >
+              <QRCodeSVG
+                bgColor="transparent"
+                fgColor="currentColor"
+                includeMargin
+                level="M"
+                size={168}
+                value={totpUri}
+              />
+            </div>
             <div className="mt-3 flex gap-2">
               <Input
+                aria-label="Authenticator code"
                 placeholder="Enter TOTP code"
                 onChange={(event) => setTotpCode(event.target.value)}
                 value={totpCode}
@@ -2865,6 +3094,10 @@ function SecurityPage() {
                       code: totpCode,
                       trustDevice: true,
                     });
+                    await refreshBootstrap();
+                    setTotpUri(null);
+                    setShowManagement(false);
+                    setNotice('Two-factor authentication is now on.');
                   })
                 }
               >
@@ -2877,6 +3110,9 @@ function SecurityPage() {
         {backupCodes.length > 0 ? (
           <div className="app-code-panel">
             <p className="text-sm font-medium">Backup codes</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Store these somewhere safe. Each code can be used once.
+            </p>
             <ul className="mt-3 grid grid-cols-2 gap-2 text-xs">
               {backupCodes.map((code) => (
                 <li key={code} className="rounded bg-muted px-2 py-1 font-mono">
@@ -2887,8 +3123,15 @@ function SecurityPage() {
           </div>
         ) : null}
 
+        {notice ? (
+          <p className="app-action-notice" role="status">
+            {notice}
+          </p>
+        ) : null}
         {error ? (
-          <p className="mt-4 text-sm text-destructive">{error}</p>
+          <p className="app-action-error" role="alert">
+            {error}
+          </p>
         ) : null}
       </section>
     </AppConsoleLayout>

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -3,7 +3,9 @@ import react from '@vitejs/plugin-react';
 import { resolve } from 'path';
 
 const authServerTarget =
-  process.env.VITE_AUTH_SERVER_URL ?? 'http://127.0.0.1:38101';
+  process.env.AUTH_SERVER_TARGET ??
+  process.env.VITE_AUTH_SERVER_URL ??
+  'http://127.0.0.1:38101';
 const authPagesPort = Number(
   process.env.AUTH_PAGES_PORT ?? process.env.VITE_AUTH_PAGES_PORT ?? '3001'
 );

--- a/packages/auth-server-hono/src/routes/account.test.ts
+++ b/packages/auth-server-hono/src/routes/account.test.ts
@@ -82,6 +82,9 @@ describe('accountRouter', () => {
     vi.clearAllMocks();
     mockCreateAccessGrantId.mockReturnValue('user-1|auth.local');
     mockEnsureUserRooms.mockResolvedValue({ grantId: 'user-1|auth.local' });
+    mockGetUserById.mockResolvedValue({
+      twoFactorEnabled: false,
+    });
     mockGetStorageProviderProfile.mockReturnValue({
       configured: true,
       id: 'railway-buckets',
@@ -122,6 +125,7 @@ describe('accountRouter', () => {
         name: 'Test User',
       },
     });
+    mockGetUserById.mockResolvedValueOnce({ twoFactorEnabled: true });
     mockGetAccessGrantById.mockResolvedValue(accessGrant);
     mockGetRoomsFromAccessGrant.mockResolvedValue(rooms);
     mockGetUserCount.mockResolvedValue(7);
@@ -133,6 +137,7 @@ describe('accountRouter', () => {
 
     expect(response.status).toBe(200);
     expect(body.user.id).toBe('user-1');
+    expect(body.user.twoFactorEnabled).toBe(true);
     expect(body.profileRooms).toHaveLength(2);
     expect(body.rooms).toHaveLength(3);
     expect(body.storageProviderProfile).toEqual(

--- a/packages/auth-server-hono/src/routes/account.ts
+++ b/packages/auth-server-hono/src/routes/account.ts
@@ -32,6 +32,10 @@ accountRouter.get('/bootstrap', requireAuth, async (c) => {
   const grantId = createAccessGrantId(user.id, env.AUTH_SERVER_DOMAIN);
 
   await ensureUserRoomsAndAuthServerAccess(user.id);
+  const accountUser = await getUserById(user.id);
+  if (!accountUser) {
+    return c.json({ error: 'Account not found' }, 404);
+  }
 
   const accessGrant = await getAccessGrantById(grantId);
   if (!accessGrant) {
@@ -50,6 +54,7 @@ accountRouter.get('/bootstrap', requireAuth, async (c) => {
       emailVerified: Boolean(user.emailVerified),
       image: user.image ?? null,
       name: user.name ?? null,
+      twoFactorEnabled: accountUser.twoFactorEnabled,
     },
     rooms,
     profileRooms,


### PR DESCRIPTION
## Summary
- replace the mobile header sign-out control with an Account bottom sheet containing navigation, theme choice, and a separated device sign-out action
- simplify Security into compact status rows and state-aware two-factor setup or management flows
- expose the canonical two-factor state through the signed-in account bootstrap response

## Verification
- `npm test --workspace @eweser/auth-server-hono -- --run src/routes/account.test.ts`
- `npm test --workspace @eweser/app -- --run`
- `npm run type-check --workspace @eweser/app`
- `npm run build --workspace @eweser/app`
- focused 390px signed-in synthetic browser checkpoint

## Notes
- Auth-server workspace-wide type-check remains blocked by pre-existing missing `@eweser/logger` declarations and unrelated access-grant request typing.