### PR TITLE
fix(ewe-note): add file actions to sidebar

### DIFF
--- a/packages/ewe-note/src/app/components/EnhancedSidebar.test.tsx
+++ b/packages/ewe-note/src/app/components/EnhancedSidebar.test.tsx
@@ -18,6 +18,7 @@ const updateFolder = vi.fn();
 const deleteFolder = vi.fn();
 const addNote = vi.fn(() => ({ id: 'note-created' }));
 const moveNote = vi.fn();
+const deleteNote = vi.fn();
 const deleteVault = vi.fn().mockResolvedValue(undefined);
 const readerRoom = {
   id: 'secure-room',
@@ -25,6 +26,19 @@ const readerRoom = {
   writeAccess: ['writer-user'],
   adminAccess: [],
 };
+const writableRoom = {
+  id: 'room-1',
+  syncUrl: 'wss://sync.example.test',
+  writeAccess: ['reader-user'],
+  adminAccess: [],
+};
+const readOnlyNoteRoom = {
+  id: 'room-1',
+  syncUrl: 'wss://sync.example.test',
+  writeAccess: [],
+  adminAccess: [],
+};
+let noteRoomWritable = true;
 let vaultDeletionEligibility:
   | { canDelete: true; noteCount: 0 }
   | {
@@ -132,6 +146,7 @@ vi.mock('../contexts/NotesContext', () => ({
     getDirectNotesInFolder,
     getNotesInFolder,
     moveNote,
+    deleteNote,
   }),
 }));
 
@@ -152,7 +167,7 @@ vi.mock('../../db', () => ({
     syncStatusDescription: 'Stored on this device',
     user: { firstName: 'Guest' },
     selectedRoom: null,
-    allRooms: [readerRoom],
+    allRooms: [readerRoom, noteRoomWritable ? writableRoom : readOnlyNoteRoom],
     db: { userId: 'reader-user' },
     createSecureRoom: vi.fn(),
     lockCurrentRoom: vi.fn(),
@@ -203,9 +218,11 @@ describe('EnhancedSidebar', () => {
     deleteFolder.mockClear();
     addNote.mockClear();
     moveNote.mockClear();
+    deleteNote.mockClear();
     deleteVault.mockReset();
     deleteVault.mockResolvedValue(undefined);
     vaultDeletionEligibility = { canDelete: true, noteCount: 0 };
+    noteRoomWritable = true;
     useDrag.mockClear();
     useDrop.mockClear();
     mockNavigate.mockClear();
@@ -265,6 +282,50 @@ describe('EnhancedSidebar', () => {
     fireEvent.click(noteButton);
 
     expect(mockNavigate).toHaveBeenCalledWith('/editor/note-1');
+  });
+
+  it('deletes a writable note from its file actions menu', () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    render(<EnhancedSidebar onSearchClick={vi.fn()} activeView="recent" />);
+
+    fireEvent.pointerDown(
+      screen.getByRole('button', { name: 'Note actions for Project Plan' })
+    );
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Delete note' }));
+
+    expect(confirmSpy).toHaveBeenCalledWith('Delete "Project Plan"?');
+    expect(deleteNote).toHaveBeenCalledWith('note-1');
+  });
+
+  it('keeps a read-only note action visible but disables deletion', () => {
+    noteRoomWritable = false;
+    render(<EnhancedSidebar onSearchClick={vi.fn()} activeView="recent" />);
+
+    fireEvent.pointerDown(
+      screen.getByRole('button', { name: 'Note actions for Project Plan' })
+    );
+
+    const item = screen.getByRole('menuitem', {
+      name: 'Delete note. This note is read-only.',
+    });
+    expect(item.getAttribute('data-disabled')).not.toBeNull();
+    expect(deleteNote).not.toHaveBeenCalled();
+  });
+
+  it('keeps note and eligible-folder actions mobile-visible and desktop-hover-revealed', () => {
+    render(<EnhancedSidebar onSearchClick={vi.fn()} activeView="recent" />);
+
+    expect(
+      screen.getByRole('button', { name: 'Note actions for Project Plan' })
+        .className
+    ).toContain('md:opacity-0');
+    expect(
+      screen.getByRole('button', { name: 'Delete folder Projects' }).className
+    ).toContain('md:opacity-0');
+    expect(
+      screen.getByRole('button', { name: 'Folder actions for Projects' })
+        .className
+    ).toContain('md:opacity-0');
   });
 
   it('makes each direct note a drag source with its current folder', () => {

--- a/packages/ewe-note/src/app/components/EnhancedSidebar.tsx
+++ b/packages/ewe-note/src/app/components/EnhancedSidebar.tsx
@@ -68,6 +68,9 @@ const ItemTypes = {
   NOTE: 'note',
 };
 
+const treeActionVisibility =
+  'opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100 focus-visible:opacity-100';
+
 interface DraggedNoteItem {
   noteId: string;
   folderId: string;
@@ -703,6 +706,9 @@ function DraggableNoteItem({
   isActive: boolean;
   onOpen: () => void;
 }) {
+  const navigate = useNavigate();
+  const { deleteNote } = useNotes();
+  const { allRooms, db } = useDb();
   const [{ isDragging }, drag] = useDrag<
     DraggedNoteItem,
     unknown,
@@ -713,24 +719,61 @@ function DraggableNoteItem({
     collect: (monitor) => ({ isDragging: monitor.isDragging() }),
   });
   const title = formatTreeNoteTitle(note.title);
+  const noteRoom = allRooms.find((room) => room.id === note.roomId);
+  const canDeleteNote = Boolean(noteRoom && canWriteRoom(noteRoom, db.userId));
+
+  const handleDelete = () => {
+    if (!canDeleteNote || !window.confirm(`Delete "${title}"?`)) return;
+    deleteNote(note.id);
+    if (isActive) navigate('/');
+  };
 
   return (
-    <button
-      ref={drag}
-      type="button"
-      onClick={onOpen}
-      data-cy={`ewe-note-note-drag-source-${note.id}`}
-      className={`flex w-full min-w-0 items-start gap-2 rounded-md py-1.5 pl-10 pr-3 text-left text-sm transition-colors ${
-        isActive
-          ? 'bg-sidebar-accent text-sidebar-foreground'
-          : 'hover:bg-sidebar-accent/70'
-      } ${isDragging ? 'cursor-grabbing opacity-50' : 'cursor-grab'}`}
-      title={`Drag to move • ${title}`}
-      aria-label={`Open note ${title}`}
-    >
-      <FileText className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
-      <span className="min-w-0 flex-1 truncate leading-5">{title}</span>
-    </button>
+    <div className="group flex w-full min-w-0 items-start gap-1 rounded-md">
+      <button
+        ref={drag}
+        type="button"
+        onClick={onOpen}
+        data-cy={`ewe-note-note-drag-source-${note.id}`}
+        className={`flex min-w-0 flex-1 items-start gap-2 rounded-md py-1.5 pl-10 pr-2 text-left text-sm transition-colors ${
+          isActive
+            ? 'bg-sidebar-accent text-sidebar-foreground'
+            : 'hover:bg-sidebar-accent/70'
+        } ${isDragging ? 'cursor-grabbing opacity-50' : 'cursor-grab'}`}
+        title={`Drag to move • ${title}`}
+        aria-label={`Open note ${title}`}
+      >
+        <FileText className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+        <span className="min-w-0 flex-1 truncate leading-5">{title}</span>
+      </button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            aria-label={`Note actions for ${title}`}
+            className={`mt-1 shrink-0 rounded-full p-1 text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${treeActionVisibility}`}
+            data-cy={`ewe-note-note-actions-${note.id}`}
+          >
+            <MoreHorizontal className="h-4 w-4" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            onClick={handleDelete}
+            disabled={!canDeleteNote}
+            aria-label={
+              canDeleteNote
+                ? 'Delete note'
+                : 'Delete note. This note is read-only.'
+            }
+            variant="destructive"
+          >
+            <Trash2 className="mr-2 h-4 w-4" />
+            Delete note
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   );
 }
 
@@ -800,7 +843,7 @@ function FolderItem({
   return (
     <div
       ref={drop}
-      className={`flex w-full min-w-0 items-center gap-1 rounded-md transition-colors ${
+      className={`group flex w-full min-w-0 items-center gap-1 rounded-md transition-colors ${
         isOver ? 'bg-primary/15 ring-1 ring-primary/40' : ''
       }`}
     >
@@ -836,7 +879,7 @@ function FolderItem({
           aria-label={`${deleteLabel} ${folder.name}`}
           title={`${deleteLabel} ${folder.name}`}
           onClick={handleDelete}
-          className="shrink-0 self-center rounded-full p-1 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className={`shrink-0 self-center rounded-full p-1 text-muted-foreground hover:bg-destructive/10 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${treeActionVisibility}`}
           data-cy={
             folder.kind === 'shared-room'
               ? `ewe-note-delete-vault-${folder.roomId}`
@@ -851,7 +894,7 @@ function FolderItem({
           <button
             type="button"
             aria-label={`${folder.kind === 'shared-room' ? 'Vault' : 'Folder'} actions for ${folder.name}`}
-            className="shrink-0 self-center rounded-full p-1 text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground"
+            className={`shrink-0 self-center rounded-full p-1 text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${treeActionVisibility}`}
             data-cy={`ewe-note-folder-actions-${folder.id}`}
           >
             <MoreHorizontal className="h-4 w-4" />

--- a/packages/ewe-note/src/app/components/EnhancedSidebar.tsx
+++ b/packages/ewe-note/src/app/components/EnhancedSidebar.tsx
@@ -69,7 +69,7 @@ const ItemTypes = {
 };
 
 const treeActionVisibility =
-  'opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100 focus-visible:opacity-100';
+  'opacity-100 transition-all md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100 focus-visible:opacity-100';
 
 interface DraggedNoteItem {
   noteId: string;


### PR DESCRIPTION
## What

Makes note deletion reachable from Ewe Note’s folder tree while keeping destructive tree controls quiet on desktop and available on touch screens.

## Changes

- Adds a per-note overflow menu with a confirmed `Delete note` action.
- Disables deletion for notes in rooms where the current user lacks write access.
- Reveals note, folder, and empty-folder delete controls on desktop hover or keyboard focus; keeps them visible on mobile.
- Adds sidebar coverage for deletion, read-only behavior, and responsive action visibility.

## Review Evidence

- Interactive fixture-only preview: https://combinations-guestbook-ambassador-framework.trycloudflare.com/
  - Synthetic signed-out local data; the remote auth service is intentionally unavailable.
  - Active through 10:00 CST on 2026-08-14.
- Sanitized screenshot gallery: https://union-overseas-receptors-surname.trycloudflare.com/
- Visual assessment: Pass. On desktop, overflow/delete actions stay low-noise until hover or keyboard focus. At 390px mobile width, folder delete, folder overflow, and note overflow controls stay visible, aligned, and unclipped; note titles truncate without crowding controls.
- Diagram: Not applicable; this is a local UI interaction change with no altered backend or data-flow boundary.

## Testing

- [x] Lint passes (`npm run lint --workspace @eweser/ewe-note`)
- [x] Focused sidebar tests pass (17 tests)
- [x] Ewe Note tests pass (`npm test --workspace @eweser/ewe-note`: 38 files, 224 tests)
- [x] Type-check and production build pass (`npm run build --workspace @eweser/ewe-note`)
- [x] Pre-commit and pre-push formatting, verification, and secret scans pass

## Checklist

- [x] No changeset needed: Ewe Note application-only behavior
- [x] No secrets committed
- [x] No direct Yjs mutations introduced
- [x] No database migration required
- [x] UI screenshots inspected for spacing, alignment, balance, wrapping, overflow, density, and responsive fit
