### PR TITLE
Fix Ewe Note sign-out cache clearing

### DIFF
--- a/.changeset/quiet-caches-clear.md
+++ b/.changeset/quiet-caches-clear.md
@@ -1,0 +1,5 @@
+---
+'@eweser/db': patch
+---
+
+Wait for local IndexedDB rooms to clear before logout completes.

--- a/packages/db/INDEX.md
+++ b/packages/db/INDEX.md
@@ -10,6 +10,7 @@ IndexedDB persistence, and optional Hocuspocus sync.
 - The public `Database` and `Room` client APIs.
 - Yjs document helpers and room lifecycle behavior.
 - Local persistence and auth/sync connection helpers.
+- Logout clearing waits for IndexedDB before callers reload the app.
 
 ## Start Here
 

--- a/packages/db/src/methods/connection/logout.test.ts
+++ b/packages/db/src/methods/connection/logout.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Database } from '../..';
+import { logoutAndClear } from './logout';
+
+describe('logoutAndClear', () => {
+  it('waits for IndexedDB clearing before it destroys providers', async () => {
+    const events: string[] = [];
+    let finishClear: (() => void) | undefined;
+    const clearData = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishClear = () => {
+            events.push('cleared');
+            resolve();
+          };
+        })
+    );
+    const destroy = vi.fn(() => events.push('destroyed'));
+    const db = {
+      logout: vi.fn(() => events.push('logged-out')),
+      collectionKeys: ['notes'],
+      getRooms: vi.fn(() => [{ indexedDbProvider: { clearData, destroy } }]),
+      registry: [{ id: 'room-1' }],
+      localStorageService: { removeItem: vi.fn() },
+    } as unknown as Database;
+
+    const clearing = logoutAndClear(db)();
+    await Promise.resolve();
+
+    expect(events).toEqual(['logged-out']);
+    expect(db.registry).toHaveLength(1);
+
+    finishClear?.();
+    await clearing;
+
+    expect(events).toEqual(['logged-out', 'cleared', 'destroyed']);
+    expect(db.registry).toEqual([]);
+  });
+});

--- a/packages/db/src/methods/connection/logout.ts
+++ b/packages/db/src/methods/connection/logout.ts
@@ -26,11 +26,11 @@ export const logoutAndClear =
   /**
    * Logs out and also clears all local data from indexedDB and localStorage.
    */
-  () => {
+  async () => {
     db.logout();
     for (const collectionKey of db.collectionKeys) {
       for (const room of db.getRooms(collectionKey)) {
-        room.indexedDbProvider?.clearData();
+        await room.indexedDbProvider?.clearData();
         room.indexedDbProvider?.destroy();
       }
     }

--- a/packages/ewe-note/INDEX.md
+++ b/packages/ewe-note/INDEX.md
@@ -28,6 +28,7 @@ Tailwind, TipTap, and `@eweser/db`.
 ## Key Contracts
 
 - Note data lives in `@eweser/db` rooms and remains useful offline.
+- Sign-out waits for the requested local-data clear before reloading.
 - TipTap/Obsidian import-export behavior must preserve user content.
 - Shared example UI changes may require changesets when they affect published
   package APIs.

--- a/packages/ewe-note/src/db.tsx
+++ b/packages/ewe-note/src/db.tsx
@@ -130,7 +130,7 @@ export type DbContextType = {
     email: string;
     avatar: string;
   };
-  signOut: () => void;
+  signOut: () => Promise<void>;
   // Secure room properties
   createSecureRoom: () => Promise<void>;
   lockCurrentRoom: () => void;
@@ -163,8 +163,8 @@ export function useDb() {
   return context;
 }
 
-const signOut = () => {
-  db.logoutAndClear();
+const signOut = async () => {
+  await db.logoutAndClear();
   localStorage.removeItem('roomId');
   localStorage.removeItem('noteId');
   window.document.location.reload();


### PR DESCRIPTION
## What changed

- Wait for every local Ewe Note room to clear before reload.
- Wait for sign-out cleanup before removing local identifiers.
- Add a test for the clear-and-reload race.

## Why

Ewe Note reloaded before IndexedDB cleanup finished. A stale offline note could therefore survive sign-out and appear again after sign-in.

## User impact

After deployment, sign-out will finish clearing the stale local cache before Ewe Note reloads. A later sign-in can then load the current server note.

## Data flow

```mermaid
flowchart LR
  A[Sign out] --> B[Clear each local IndexedDB room]
  B --> C[Destroy room providers]
  C --> D[Remove local identity]
  D --> E[Reload Ewe Note]
  E --> F[Sign in and load server note]
```

## Checks

- Database tests: 129 passed, 1 todo.
- Ewe Note tests: 221 passed.
- Database and Ewe Note type checks passed.
- Shared, database, and Ewe Note builds passed.
- Code index check passed.
- Pre-commit and pre-push secret scans passed.
- All required GitHub checks passed on commit 7bec260.

## Verification gap

This behavior has no visual layout change, so a screenshot does not prove the fix. The final proof requires a deployed build and one sign-out/sign-in test on the affected device.