### PR TITLE
Refresh Ewe Note after remote updates

### DIFF
--- a/packages/ewe-note/src/components/INDEX.md
+++ b/packages/ewe-note/src/components/INDEX.md
@@ -13,7 +13,7 @@ bridge, layout chrome, sidebar, dialogs, theme controls, and local UI primitives
 
 ## Start Here
 
-- [`editor.tsx`](./editor.tsx): TipTap, Yjs collaboration, and save bridge.
+- [`editor.tsx`](./editor.tsx): TipTap, Yjs collaboration, remote refresh, and save bridge.
 - [`layout.tsx`](./layout.tsx): App chrome, topbar, sidebar, and focus layout.
 - [`app-sidebar.tsx`](./app-sidebar.tsx): Main navigation and room/note sidebar.
 - [`layout-shortcuts.ts`](./layout-shortcuts.ts): Keyboard layout state rules.

--- a/packages/ewe-note/src/components/tiptap-editor-refresh.test.ts
+++ b/packages/ewe-note/src/components/tiptap-editor-refresh.test.ts
@@ -41,7 +41,33 @@ describe('shouldRefreshLocalEditorContent', () => {
     ).toBe(true);
   });
 
-  it('blocks refreshes while focused, source mode, collaboration, or missing editor already own content', () => {
+  it('refreshes collaborative content when no local edit is pending', () => {
+    expect(
+      shouldRefreshLocalEditorContent({
+        collaborationReady: true,
+        focused: false,
+        hasEditor: true,
+        noteText: 'remote markdown',
+        pendingEditorMarkdown: null,
+        sourceMode: false,
+      })
+    ).toBe(true);
+  });
+
+  it('protects pending collaborative edits from remote refreshes', () => {
+    expect(
+      shouldRefreshLocalEditorContent({
+        collaborationReady: true,
+        focused: false,
+        hasEditor: true,
+        noteText: 'remote markdown',
+        pendingEditorMarkdown: 'local markdown',
+        sourceMode: false,
+      })
+    ).toBe(false);
+  });
+
+  it('blocks refreshes while focused, in source mode, or missing the editor', () => {
     const readyToRefresh = {
       collaborationReady: false,
       focused: false,
@@ -56,12 +82,6 @@ describe('shouldRefreshLocalEditorContent', () => {
     ).toBe(false);
     expect(
       shouldRefreshLocalEditorContent({ ...readyToRefresh, sourceMode: true })
-    ).toBe(false);
-    expect(
-      shouldRefreshLocalEditorContent({
-        ...readyToRefresh,
-        collaborationReady: true,
-      })
     ).toBe(false);
     expect(
       shouldRefreshLocalEditorContent({ ...readyToRefresh, hasEditor: false })

--- a/packages/ewe-note/src/components/tiptap-editor.tsx
+++ b/packages/ewe-note/src/components/tiptap-editor.tsx
@@ -261,7 +261,8 @@ export function shouldRefreshLocalEditorContent({
   pendingEditorMarkdown,
   sourceMode,
 }: ShouldRefreshLocalEditorContentOptions): boolean {
-  if (!hasEditor || collaborationReady || sourceMode || focused) return false;
+  if (!hasEditor || sourceMode || focused) return false;
+  if (collaborationReady) return pendingEditorMarkdown === null;
   return pendingEditorMarkdown === null || pendingEditorMarkdown === noteText;
 }
 


### PR DESCRIPTION
## What changed

- Refresh the collaborative editor when remote Markdown changes.
- Keep pending local edits protected.
- Keep focused and source-mode editors protected.

## Root cause

The note list received the remote update, but TipTap ignored the changed note text whenever collaboration was active. The open editor therefore kept rendering the stale body.

## User impact

A remote vault sync now updates the open Ewe Note editor after synchronization. Users no longer need to reopen or clear the note.

## Data flow

```mermaid
flowchart LR
  A[Remote vault update] --> B[Eweser note text changes]
  B --> C[Ewe Note context refreshes]
  C --> D{Local edit pending?}
  D -- No --> E[Refresh TipTap content]
  D -- Yes --> F[Keep local editor content]
```

## Checks

- Ewe Note tests: 223 passed.
- Focused refresh tests: 6 passed.
- Ewe Note type check passed.
- Production build passed.
- Code index and diff checks passed.
- Secret scans passed.

## Review evidence

- UI-visible change: Yes, displayed note content refreshes.
- Screenshots: N/A. The production note contains private operational text and the change has no layout delta.
- Visual assessment: The existing layout is unchanged. No spacing, alignment, wrapping, overflow, density, or responsive behavior changed.
- Flow movement changed: Yes.
- Mermaid diagram: Included.
- Open review comments addressed: N/A.

## Production checkpoint

The production note list showed the current phone-farm priorities. The open editor showed the stale Product Lab version. This exact mismatch reproduced the fixed path.