### PR TITLE
Add shared runtime orientation skill

### DIFF
--- a/.agents/skills/eweser-runtime-orientation/SKILL.md
+++ b/.agents/skills/eweser-runtime-orientation/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: eweser-runtime-orientation
+description: >
+  Use this skill for EweserDB runtime orientation before running tests/services.
+  It reduces guesswork for local/prod endpoints, worktree-specific ports, and
+  repeated environment setup checks.
+---
+
+# EweserDB Runtime Orientation
+
+Use this skill whenever you need to run code, start services, run tests, or inspect
+local/prod environment status for EweserDB.
+
+## Why this skill exists
+
+Agents should avoid guessing environment state. This skill creates a deterministic,
+low-latency startup path:
+identify worktree and branch → read project guidance → load local runtime notes →
+probe listeners/services → run only the required command.
+
+## Workflow (required)
+
+1. Confirm repository and worktree
+
+```bash
+pwd
+git rev-parse --show-toplevel
+git branch --show-current
+```
+
+2. Read `LOCAL_DEVELOPMENT.md` and nearest `INDEX.md` files before running tests.
+
+```bash
+sed -n '1,220p' LOCAL_DEVELOPMENT.md
+# plus root package-level INDEX.md files where present
+```
+
+3. Load local machine runtime notes from `$HOME/.local/state/eweser-db/runtime.md`.
+
+```bash
+bash "$(git rev-parse --show-toplevel)/.agents/skills/eweser-runtime-orientation/scripts/eweser-runtime-orientation.sh" status
+```
+
+4. Refresh discovered state before meaningful operations.
+
+```bash
+bash "$(git rev-parse --show-toplevel)/.agents/skills/eweser-runtime-orientation/scripts/eweser-runtime-orientation.sh" refresh
+```
+
+5. Use discovered state to avoid assumptions.
+
+- Never assume fixed ports.
+- Never assume the app always runs on 8000.
+- Do not map local stack values to prod URLs.
+- Use discovered service health results before Cypress or long-running browser flows.
+
+## Canonical local runtime notes format
+
+`$HOME/.local/state/eweser-db/runtime.md` is machine-specific and worktree-aware.
+
+```markdown
+# EweserDB Runtime Notes
+
+Machine: <hostname>
+Updated: 2026-05-02T00:00:00Z
+
+## Worktree Slots
+
+- <repo-root>: main
+- <worktree-root>: pr-1234
+
+## Service Endpoints
+
+- Auth API: http://localhost:3001
+- App UI: http://localhost:5174
+- Sync: ws://localhost:38181
+
+## Dev Notes
+
+- docker compose: docker compose -f docker-compose.dev.yml up
+- caddy: running
+- last_cypress_target: auth-api@3001 + app@5174
+```
+
+If live discovery differs from notes, prefer live discovery and refresh notes.
+
+## Helper script contract
+
+This skill relies on:
+
+- `.agents/skills/eweser-runtime-orientation/scripts/eweser-runtime-orientation.sh status` outputs worktree, branch, and
+  current listening ports for common Eweser services.
+- `.agents/skills/eweser-runtime-orientation/scripts/eweser-runtime-orientation.sh refresh` probes ports and writes the
+  latest observed endpoints into `$HOME/.local/state/eweser-db/runtime.md`.
+
+## Safety rules
+
+- Always verify target endpoints before destructive actions.
+- Never write data to prod endpoints from these local notes.
+- If notes are stale, run `refresh` and continue with the refreshed values.

--- a/.agents/skills/eweser-runtime-orientation/scripts/eweser-runtime-orientation.sh
+++ b/.agents/skills/eweser-runtime-orientation/scripts/eweser-runtime-orientation.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+BRANCH="$(git -C "$ROOT" branch --show-current 2>/dev/null || echo unknown)"
+RUNTIME_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/eweser-db"
+RUNTIME_FILE="$RUNTIME_DIR/runtime.md"
+
+find_port() {
+  for port in "$@"; do
+    if lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1; then
+      printf "%s" "$port"
+      return 0
+    fi
+  done
+  return 1
+}
+
+case "${1:-status}" in
+  status)
+    echo "# Runtime status snapshot"
+    echo "ROOT: $ROOT"
+    echo "BRANCH: $BRANCH"
+    echo "Auth API: $(find_port 3001 3002 3000 8787 8788 || echo unknown)"
+    echo "App UI: $(find_port 5173 5174 5175 3000 3001 || echo unknown)"
+    echo "Sync: $(find_port 38181 38180 38182 || echo unknown)"
+    echo "Postgres: $(find_port 5432 5433 || echo unknown)"
+    echo "Aggregator: $(find_port 38190 38191 || echo unknown)"
+    ;;
+  refresh)
+    mkdir -p "$RUNTIME_DIR"
+    NOW="$(date -Iseconds)"
+    HOST="$(hostname)"
+
+    AUTH_API_PORT="$(find_port 3001 3002 3000 8787 8788 || echo unknown)"
+    APP_UI_PORT="$(find_port 5173 5174 5175 3000 3001 || echo unknown)"
+    SYNC_PORT="$(find_port 38181 38180 38182 || echo unknown)"
+    POSTGRES_PORT="$(find_port 5432 5433 || echo unknown)"
+
+cat > "$RUNTIME_FILE" <<EOF
+# EweserDB Runtime Notes
+
+Machine: $HOST
+Updated: $NOW
+
+## Worktree Slots
+- $ROOT ($BRANCH)
+
+## Service Endpoints
+- Auth API: ${AUTH_API_PORT:-unknown}
+- App UI: ${APP_UI_PORT:-unknown}
+- Sync: ${SYNC_PORT:-unknown}
+- Postgres: ${POSTGRES_PORT:-unknown}
+
+## Dev Notes
+- Observed via lsof listener scan from eweser-runtime-orientation.sh refresh
+EOF
+
+    echo "Updated $RUNTIME_FILE"
+    ;;
+  *)
+    echo "Usage: $0 [status|refresh]"
+    exit 1
+    ;;
+esac

--- a/.claude/skills/eweser-runtime-orientation
+++ b/.claude/skills/eweser-runtime-orientation
@@ -1,0 +1,1 @@
+../../.agents/skills/eweser-runtime-orientation

--- a/INDEX.md
+++ b/INDEX.md
@@ -29,6 +29,8 @@ shared schemas, auth grants, sync, and interoperable apps.
 
 ## Children
 
+- [`.agents/skills/eweser-runtime-orientation/`](./.agents/skills/eweser-runtime-orientation/):
+  shared Claude Code and Codex runtime discovery skill.
 - [`packages/`](./packages/): SDK packages, services, apps, logger, and MCP
   server.
 - [`examples/`](./examples/): Teaching apps and interop demos.


### PR DESCRIPTION
## What changed

- Added the Eweser runtime orientation skill to the repository.
- Added Claude Code discovery for the same skill.
- Moved machine notes to the neutral XDG state directory.

## Why

Eweser owns this runtime knowledge. Claude Code and Codex should use one source.

## Checks

- `bash -n` passed.
- The live status probe passed.
- `npm run code-index:check` passed.
- Skill validation passed.
